### PR TITLE
feat: 文字サイズ変更機能のUI実装 (Issue #5)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml
+++ b/ICCardManager/src/ICCardManager/App.xaml
@@ -1,6 +1,20 @@
 <Application x:Class="ICCardManager.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <Application.Resources>
+        <!-- フォントサイズリソース -->
+        <!-- BaseFontSize: 通常のテキスト用（設定で変更可能） -->
+        <sys:Double x:Key="BaseFontSize">14</sys:Double>
+        <!-- LargeFontSize: 見出し用（BaseFontSizeの約1.3倍） -->
+        <sys:Double x:Key="LargeFontSize">18</sys:Double>
+        <!-- SmallFontSize: 補足テキスト用（BaseFontSizeの約0.85倍） -->
+        <sys:Double x:Key="SmallFontSize">12</sys:Double>
+        <!-- TitleFontSize: タイトル用（固定） -->
+        <sys:Double x:Key="TitleFontSize">22</sys:Double>
+        <!-- IconFontSize: アイコン用（固定） -->
+        <sys:Double x:Key="IconFontSize">72</sys:Double>
+        <!-- StatusFontSize: ステータスメッセージ用（固定） -->
+        <sys:Double x:Key="StatusFontSize">28</sys:Double>
     </Application.Resources>
 </Application>

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Models;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Infrastructure.CardReader;
@@ -141,8 +142,59 @@ public partial class App : Application
         RegisterTestDataAsync().Wait();
 #endif
 
+        // 保存済み設定を適用
+        ApplySavedSettings();
+
         // 起動時処理
         PerformStartupTasks(dbContext);
+    }
+
+    /// <summary>
+    /// 保存済み設定を適用
+    /// </summary>
+    private void ApplySavedSettings()
+    {
+        try
+        {
+            var settingsRepository = ServiceProvider.GetRequiredService<ISettingsRepository>();
+            var settings = settingsRepository.GetAppSettingsAsync().Result;
+
+            // 文字サイズを適用
+            ApplyFontSize(settings.FontSize);
+
+            System.Diagnostics.Debug.WriteLine($"設定を適用: フォントサイズ={settings.FontSize}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"設定の適用でエラー: {ex.Message}");
+            // デフォルト値を適用
+            ApplyFontSize(FontSizeOption.Medium);
+        }
+    }
+
+    /// <summary>
+    /// 文字サイズをアプリケーション全体に適用
+    /// </summary>
+    public static void ApplyFontSize(FontSizeOption fontSize)
+    {
+        var baseFontSize = fontSize switch
+        {
+            FontSizeOption.Small => 12.0,
+            FontSizeOption.Medium => 14.0,
+            FontSizeOption.Large => 16.0,
+            FontSizeOption.ExtraLarge => 20.0,
+            _ => 14.0
+        };
+
+        // 比率に基づいて他のフォントサイズも計算
+        var largeFontSize = Math.Round(baseFontSize * 1.3);
+        var smallFontSize = Math.Round(baseFontSize * 0.85);
+
+        // アプリケーションリソースを更新
+        var resources = Application.Current.Resources;
+        resources["BaseFontSize"] = baseFontSize;
+        resources["LargeFontSize"] = largeFontSize;
+        resources["SmallFontSize"] = smallFontSize;
     }
 
 #if DEBUG

--- a/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
@@ -150,24 +150,8 @@ public partial class SettingsViewModel : ViewModelBase
     /// </summary>
     private void ApplyFontSize(FontSizeOption fontSize)
     {
-        var baseFontSize = fontSize switch
-        {
-            FontSizeOption.Small => 12.0,
-            FontSizeOption.Medium => 14.0,
-            FontSizeOption.Large => 16.0,
-            FontSizeOption.ExtraLarge => 20.0,
-            _ => 14.0
-        };
-
-        // アプリケーション全体のフォントサイズを変更
-        if (System.Windows.Application.Current.Resources.Contains("BaseFontSize"))
-        {
-            System.Windows.Application.Current.Resources["BaseFontSize"] = baseFontSize;
-        }
-        else
-        {
-            System.Windows.Application.Current.Resources.Add("BaseFontSize", baseFontSize);
-        }
+        // App.ApplyFontSizeを呼び出して、関連するすべてのフォントサイズを更新
+        App.ApplyFontSize(fontSize);
     }
 
     partial void OnWarningBalanceChanged(int value)

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
@@ -28,11 +28,11 @@
         <Border Grid.Row="0" Background="#FFF3E0" CornerRadius="4" Padding="15" Margin="0,0,0,15">
             <StackPanel>
                 <TextBlock Text="バス利用のバス停名を入力してください"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            FontWeight="Bold"
                            Foreground="#E65100"/>
                 <TextBlock Text="バス停名は「乗車バス停～降車バス停」の形式で入力してください。例: 天神バスセンター～博多駅"
-                           FontSize="12"
+                           FontSize="{DynamicResource SmallFontSize}"
                            Foreground="#795548"
                            Margin="0,5,0,0"
                            TextWrapping="Wrap"/>
@@ -114,7 +114,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -33,11 +33,11 @@
             <!-- ヘッダー -->
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
                 <TextBlock Text="登録済みカード一覧"
-                           FontSize="18"
+                           FontSize="{DynamicResource LargeFontSize}"
                            FontWeight="Bold"
                            VerticalAlignment="Center"/>
                 <TextBlock Text="{Binding Cards.Count, StringFormat=' ({0}件)'}"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Foreground="Gray"
                            VerticalAlignment="Center"
                            Margin="5,0,0,0"/>
@@ -145,7 +145,7 @@
 
                 <!-- フォームヘッダー -->
                 <TextBlock Grid.Row="0"
-                           FontSize="16"
+                           FontSize="{DynamicResource LargeFontSize}"
                            FontWeight="Bold"
                            Margin="0,0,0,20">
                     <TextBlock.Style>
@@ -207,7 +207,7 @@
                              Padding="8"
                              Margin="0,0,0,5"/>
                     <TextBlock Text="空欄の場合は自動採番されます"
-                               FontSize="11"
+                               FontSize="{DynamicResource SmallFontSize}"
                                Foreground="Gray"
                                Margin="0,0,0,15"/>
 
@@ -248,11 +248,11 @@
                         </Style>
                     </StackPanel.Style>
                     <TextBlock Text="カードを選択するか"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                Foreground="Gray"
                                HorizontalAlignment="Center"/>
                     <TextBlock Text="[新規登録]をクリックしてください"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                Foreground="Gray"
                                HorizontalAlignment="Center"
                                Margin="0,5,0,0"/>
@@ -284,7 +284,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -34,15 +34,15 @@
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
                     <TextBlock Text="{Binding Card.CardType}"
-                               FontSize="20"
+                               FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                VerticalAlignment="Center"/>
                     <TextBlock Text="{Binding Card.CardNumber}"
-                               FontSize="20"
+                               FontSize="{DynamicResource LargeFontSize}"
                                Margin="15,0,0,0"
                                VerticalAlignment="Center"/>
                     <TextBlock Text="{Binding Card.Note}"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                Foreground="Gray"
                                Margin="20,0,0,0"
                                VerticalAlignment="Center"/>
@@ -50,10 +50,10 @@
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <TextBlock Text="現在残高:"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                VerticalAlignment="Center"/>
                     <TextBlock Text="{Binding CurrentBalance, StringFormat={}{0:N0}円}"
-                               FontSize="24"
+                               FontSize="{DynamicResource TitleFontSize}"
                                FontWeight="Bold"
                                Foreground="#1565C0"
                                Margin="10,0,0,0"
@@ -78,7 +78,7 @@
                         CornerRadius="4"
                         Padding="15,8">
                     <TextBlock Text="{Binding SelectedPeriodDisplay}"
-                               FontSize="16"
+                               FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                Foreground="#1565C0"/>
                 </Border>
@@ -237,7 +237,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -189,7 +189,7 @@
                 <ProgressBar IsIndeterminate="True" Width="250" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -41,7 +41,7 @@
                                        Margin="10,0,0,0"/>
                         </StackPanel>
                         <TextBlock Text="※ 0～50,000円の範囲で設定できます"
-                                   FontSize="11"
+                                   FontSize="{DynamicResource SmallFontSize}"
                                    Foreground="Gray"
                                    Margin="0,5,0,0"/>
                     </StackPanel>
@@ -70,7 +70,7 @@
                                     Margin="10,0,0,0"/>
                         </Grid>
                         <TextBlock Text="※ 空欄の場合、アプリケーションフォルダにバックアップされます"
-                                   FontSize="11"
+                                   FontSize="{DynamicResource SmallFontSize}"
                                    Foreground="Gray"
                                    Margin="0,5,0,0"/>
                     </StackPanel>
@@ -89,7 +89,7 @@
                                   Width="200"
                                   HorizontalAlignment="Left"/>
                         <TextBlock Text="※ 文字サイズの変更は保存後に反映されます"
-                                   FontSize="11"
+                                   FontSize="{DynamicResource SmallFontSize}"
                                    Foreground="Gray"
                                    Margin="0,5,0,0"/>
                     </StackPanel>
@@ -131,7 +131,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -33,11 +33,11 @@
             <!-- ヘッダー -->
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
                 <TextBlock Text="登録済み職員一覧"
-                           FontSize="18"
+                           FontSize="{DynamicResource LargeFontSize}"
                            FontWeight="Bold"
                            VerticalAlignment="Center"/>
                 <TextBlock Text="{Binding StaffList.Count, StringFormat=' ({0}名)'}"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Foreground="Gray"
                            VerticalAlignment="Center"
                            Margin="5,0,0,0"/>
@@ -106,7 +106,7 @@
 
                 <!-- フォームヘッダー -->
                 <TextBlock Grid.Row="0"
-                           FontSize="16"
+                           FontSize="{DynamicResource LargeFontSize}"
                            FontWeight="Bold"
                            Margin="0,0,0,20">
                     <TextBlock.Style>
@@ -204,11 +204,11 @@
                         </Style>
                     </StackPanel.Style>
                     <TextBlock Text="職員を選択するか"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                Foreground="Gray"
                                HorizontalAlignment="Center"/>
                     <TextBlock Text="[新規登録]をクリックしてください"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                Foreground="Gray"
                                HorizontalAlignment="Center"
                                Margin="0,5,0,0"/>
@@ -240,7 +240,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,10,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -39,14 +39,14 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBlock Text="交通系ICカード管理システム"
-                           FontSize="22"
+                           FontSize="{DynamicResource TitleFontSize}"
                            FontWeight="Bold"
                            Foreground="White"
                            VerticalAlignment="Center"/>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <TextBlock Text="{Binding CurrentDateTime}"
-                               FontSize="16"
+                               FontSize="{DynamicResource LargeFontSize}"
                                Foreground="White"
                                VerticalAlignment="Center"
                                Margin="0,0,20,0"/>
@@ -76,20 +76,20 @@
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                     <!-- 状態アイコン -->
                     <TextBlock Text="{Binding StatusIcon}"
-                               FontSize="72"
+                               FontSize="{DynamicResource IconFontSize}"
                                HorizontalAlignment="Center"
                                Margin="0,0,0,20"/>
 
                     <!-- ステータスメッセージ -->
                     <TextBlock Text="{Binding StatusMessage}"
-                               FontSize="28"
+                               FontSize="{DynamicResource StatusFontSize}"
                                FontWeight="Bold"
                                TextAlignment="Center"
                                TextWrapping="Wrap"
                                HorizontalAlignment="Center"/>
 
                     <!-- タイムアウト表示 -->
-                    <TextBlock FontSize="16"
+                    <TextBlock FontSize="{DynamicResource LargeFontSize}"
                                Foreground="Gray"
                                Margin="0,20,0,0"
                                HorizontalAlignment="Center"
@@ -114,7 +114,7 @@
                     <!-- 貸出中カード -->
                     <TextBlock Grid.Row="0"
                                Text="貸出中のカード"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                FontWeight="Bold"
                                Margin="0,0,0,10"/>
 
@@ -132,7 +132,7 @@
                                             <Run Text=" "/>
                                             <Run Text="{Binding CardNumber}"/>
                                         </TextBlock>
-                                        <TextBlock FontSize="11" Foreground="Gray"
+                                        <TextBlock FontSize="{DynamicResource SmallFontSize}" Foreground="Gray"
                                                    Text="{Binding LastLentAt, StringFormat='{}{0:M/d H:mm}～'}"/>
                                     </StackPanel>
                                 </Border>
@@ -143,7 +143,7 @@
                     <!-- 警告エリア -->
                     <TextBlock Grid.Row="2"
                                Text="警告"
-                               FontSize="14"
+                               FontSize="{DynamicResource BaseFontSize}"
                                FontWeight="Bold"
                                Margin="0,15,0,10"
                                Visibility="{Binding WarningMessages.Count, Converter={StaticResource IntToVisibilityConverter}, Mode=OneWay}"/>
@@ -156,7 +156,7 @@
                                         Margin="0,2" Padding="10,8">
                                     <TextBlock Text="{Binding}"
                                                TextWrapping="Wrap"
-                                               FontSize="12"/>
+                                               FontSize="{DynamicResource SmallFontSize}"/>
                                 </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -172,7 +172,7 @@
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
                 <TextBlock Text="{Binding BusyMessage}"
                            Foreground="White"
-                           FontSize="16"
+                           FontSize="{DynamicResource LargeFontSize}"
                            Margin="0,15,0,0"
                            HorizontalAlignment="Center"/>
             </StackPanel>
@@ -186,7 +186,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0" FontSize="12" Foreground="#1565C0" VerticalAlignment="Center">
+                <TextBlock Grid.Column="0" FontSize="{DynamicResource SmallFontSize}" Foreground="#1565C0" VerticalAlignment="Center">
                     <Run Text="操作: "/>
                     <Run Text="職員証タッチ → ICカードタッチ で貸出/返却"/>
                     <Run Text=" | "/>


### PR DESCRIPTION
## Summary
- App.xamlにフォントサイズリソース（Base/Large/Small/Title/Icon/Status）を追加
- 起動時に保存済みのフォントサイズ設定を適用する処理をApp.xaml.csに実装
- 全画面（MainWindow + 6ダイアログ）のXAMLでハードコードされたフォントサイズを`DynamicResource`に置換

## 変更内容

### 1. App.xaml
フォントサイズリソースを定義（デフォルト値は「中」設定）:
- `BaseFontSize`: 14px - 通常テキスト用
- `LargeFontSize`: 18px - 見出し用（Base×1.3）
- `SmallFontSize`: 12px - 補足テキスト用（Base×0.85）
- `TitleFontSize`: 22px - タイトル用（固定）
- `IconFontSize`: 72px - アイコン用（固定）
- `StatusFontSize`: 28px - ステータスメッセージ用（固定）

### 2. App.xaml.cs
- `ApplySavedSettings()`: 起動時に保存済み設定を読み込み適用
- `ApplyFontSize(FontSizeOption)`: フォントサイズをアプリケーション全体に適用
  - Base/Large/Smallを比率計算で更新

### 3. 各XAMLファイル
ハードコードされたフォントサイズを`{DynamicResource}`に置換:
- `MainWindow.xaml`
- `SettingsDialog.xaml`
- `CardManageDialog.xaml`
- `StaffManageDialog.xaml`
- `ReportDialog.xaml`
- `HistoryDialog.xaml`
- `BusStopInputDialog.xaml`

### 4. SettingsViewModel.cs
- 既存の`ApplyFontSize`メソッドを`App.ApplyFontSize`を呼び出すように変更

## フォントサイズ対応表

| 設定 | BaseFontSize | LargeFontSize | SmallFontSize |
|------|-------------|---------------|---------------|
| 小 | 12px | 16px | 10px |
| 中（標準） | 14px | 18px | 12px |
| 大 | 16px | 21px | 14px |
| 特大 | 20px | 26px | 17px |

## Test plan
- [ ] アプリケーションを起動し、保存済みのフォントサイズが反映されることを確認
- [ ] 設定画面で文字サイズを変更し、保存後に全画面に反映されることを確認
- [ ] 各フォントサイズオプション（小/中/大/特大）で表示が適切であることを確認
- [ ] 再起動後も設定が保持されていることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)