### PR TITLE
feat: DTOパターンの導入 (Issue #9)

### DIFF
--- a/ICCardManager/src/ICCardManager/Dtos/CardDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/CardDto.cs
@@ -1,0 +1,63 @@
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// カード情報DTO
+/// ViewModelで使用するカード情報の表示用オブジェクト
+/// </summary>
+public class CardDto
+{
+    /// <summary>
+    /// カードIDm（16進数16文字）
+    /// </summary>
+    public string CardIdm { get; init; } = string.Empty;
+
+    /// <summary>
+    /// カード種別（はやかけん/nimoca/SUGOCA等）
+    /// </summary>
+    public string CardType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 管理番号
+    /// </summary>
+    public string CardNumber { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 備考
+    /// </summary>
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// 貸出状態
+    /// </summary>
+    public bool IsLent { get; init; }
+
+    /// <summary>
+    /// 最終貸出者IDm（更新用）
+    /// </summary>
+    public string? LastLentStaff { get; init; }
+
+    /// <summary>
+    /// 最終貸出者名（表示用）
+    /// </summary>
+    public string? LentStaffName { get; init; }
+
+    /// <summary>
+    /// 最終貸出日時
+    /// </summary>
+    public DateTime? LentAt { get; init; }
+
+    /// <summary>
+    /// 表示用: カード名（種別 + 番号）
+    /// </summary>
+    public string DisplayName => $"{CardType} {CardNumber}";
+
+    /// <summary>
+    /// 表示用: 貸出状態テキスト
+    /// </summary>
+    public string LentStatusDisplay => IsLent ? "貸出中" : "在庫";
+
+    /// <summary>
+    /// 表示用: 貸出日時
+    /// </summary>
+    public string? LentAtDisplay => LentAt?.ToString("yyyy/MM/dd HH:mm");
+}

--- a/ICCardManager/src/ICCardManager/Dtos/DtoMapper.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/DtoMapper.cs
@@ -1,0 +1,200 @@
+using ICCardManager.Common;
+using ICCardManager.Models;
+
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// Entity ⇔ DTO マッピング用拡張メソッド
+/// </summary>
+public static class DtoMapper
+{
+    #region IcCard → CardDto
+
+    /// <summary>
+    /// IcCardエンティティをCardDtoに変換
+    /// </summary>
+    /// <param name="card">変換元のカードエンティティ</param>
+    /// <param name="staffName">貸出中の場合の職員名（オプション）</param>
+    /// <returns>変換後のDTO</returns>
+    public static CardDto ToDto(this IcCard card, string? staffName = null)
+    {
+        return new CardDto
+        {
+            CardIdm = card.CardIdm,
+            CardType = card.CardType,
+            CardNumber = card.CardNumber,
+            Note = card.Note,
+            IsLent = card.IsLent,
+            LastLentStaff = card.LastLentStaff,
+            LentStaffName = staffName,
+            LentAt = card.LastLentAt
+        };
+    }
+
+    /// <summary>
+    /// IcCardエンティティのコレクションをCardDtoのリストに変換
+    /// </summary>
+    public static List<CardDto> ToDtoList(this IEnumerable<IcCard> cards)
+    {
+        return cards.Select(c => c.ToDto()).ToList();
+    }
+
+    #endregion
+
+    #region Staff → StaffDto
+
+    /// <summary>
+    /// StaffエンティティをStaffDtoに変換
+    /// </summary>
+    public static StaffDto ToDto(this Staff staff)
+    {
+        return new StaffDto
+        {
+            StaffIdm = staff.StaffIdm,
+            Name = staff.Name,
+            Number = staff.Number,
+            Note = staff.Note
+        };
+    }
+
+    /// <summary>
+    /// Staffエンティティのコレクションをリストに変換
+    /// </summary>
+    public static List<StaffDto> ToDtoList(this IEnumerable<Staff> staffList)
+    {
+        return staffList.Select(s => s.ToDto()).ToList();
+    }
+
+    #endregion
+
+    #region Ledger → LedgerDto
+
+    /// <summary>
+    /// LedgerエンティティをLedgerDtoに変換
+    /// </summary>
+    public static LedgerDto ToDto(this Ledger ledger)
+    {
+        return new LedgerDto
+        {
+            Id = ledger.Id,
+            CardIdm = ledger.CardIdm,
+            Date = ledger.Date,
+            DateDisplay = WarekiConverter.ToWareki(ledger.Date),
+            Summary = ledger.Summary,
+            Income = ledger.Income,
+            Expense = ledger.Expense,
+            Balance = ledger.Balance,
+            StaffName = ledger.StaffName,
+            Note = ledger.Note,
+            IsLentRecord = ledger.IsLentRecord,
+            Details = ledger.Details.Select(d => d.ToDto()).ToList()
+        };
+    }
+
+    /// <summary>
+    /// Ledgerエンティティのコレクションをリストに変換
+    /// </summary>
+    public static List<LedgerDto> ToDtoList(this IEnumerable<Ledger> ledgers)
+    {
+        return ledgers.Select(l => l.ToDto()).ToList();
+    }
+
+    #endregion
+
+    #region LedgerDetail → LedgerDetailDto
+
+    /// <summary>
+    /// LedgerDetailエンティティをLedgerDetailDtoに変換
+    /// </summary>
+    public static LedgerDetailDto ToDto(this LedgerDetail detail)
+    {
+        return new LedgerDetailDto
+        {
+            LedgerId = detail.LedgerId,
+            UseDate = detail.UseDate,
+            UseDateDisplay = detail.UseDate?.ToString("yyyy/MM/dd HH:mm"),
+            EntryStation = detail.EntryStation,
+            ExitStation = detail.ExitStation,
+            BusStops = detail.BusStops,
+            Amount = detail.Amount,
+            Balance = detail.Balance,
+            IsCharge = detail.IsCharge,
+            IsBus = detail.IsBus
+        };
+    }
+
+    /// <summary>
+    /// LedgerDetailエンティティのコレクションをリストに変換
+    /// </summary>
+    public static List<LedgerDetailDto> ToDtoList(this IEnumerable<LedgerDetail> details)
+    {
+        return details.Select(d => d.ToDto()).ToList();
+    }
+
+    #endregion
+
+    #region AppSettings → SettingsDto
+
+    /// <summary>
+    /// AppSettingsをSettingsDtoに変換
+    /// </summary>
+    public static SettingsDto ToDto(this AppSettings settings)
+    {
+        return new SettingsDto
+        {
+            WarningBalance = settings.WarningBalance,
+            BackupPath = settings.BackupPath,
+            FontSize = settings.FontSize
+        };
+    }
+
+    #endregion
+
+    #region DTO → Entity（逆変換：更新用）
+
+    /// <summary>
+    /// CardDtoからIcCardエンティティを生成（新規登録・更新用）
+    /// </summary>
+    public static IcCard ToEntity(this CardDto dto)
+    {
+        return new IcCard
+        {
+            CardIdm = dto.CardIdm,
+            CardType = dto.CardType,
+            CardNumber = dto.CardNumber,
+            Note = dto.Note,
+            IsLent = dto.IsLent,
+            LastLentStaff = dto.LastLentStaff,
+            LastLentAt = dto.LentAt
+        };
+    }
+
+    /// <summary>
+    /// StaffDtoからStaffエンティティを生成（新規登録用）
+    /// </summary>
+    public static Staff ToEntity(this StaffDto dto)
+    {
+        return new Staff
+        {
+            StaffIdm = dto.StaffIdm,
+            Name = dto.Name,
+            Number = dto.Number,
+            Note = dto.Note
+        };
+    }
+
+    /// <summary>
+    /// SettingsDtoからAppSettingsを生成
+    /// </summary>
+    public static AppSettings ToEntity(this SettingsDto dto)
+    {
+        return new AppSettings
+        {
+            WarningBalance = dto.WarningBalance,
+            BackupPath = dto.BackupPath,
+            FontSize = dto.FontSize
+        };
+    }
+
+    #endregion
+}

--- a/ICCardManager/src/ICCardManager/Dtos/LedgerDetailDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/LedgerDetailDto.cs
@@ -1,0 +1,108 @@
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// 利用履歴詳細DTO
+/// ViewModelで使用する履歴詳細表示用オブジェクト
+/// </summary>
+public class LedgerDetailDto
+{
+    /// <summary>
+    /// 親レコードID
+    /// </summary>
+    public int LedgerId { get; init; }
+
+    /// <summary>
+    /// 利用日時
+    /// </summary>
+    public DateTime? UseDate { get; init; }
+
+    /// <summary>
+    /// 表示用: 利用日時
+    /// </summary>
+    public string? UseDateDisplay { get; init; }
+
+    /// <summary>
+    /// 乗車駅
+    /// </summary>
+    public string? EntryStation { get; init; }
+
+    /// <summary>
+    /// 降車駅
+    /// </summary>
+    public string? ExitStation { get; init; }
+
+    /// <summary>
+    /// バス停名
+    /// </summary>
+    public string? BusStops { get; init; }
+
+    /// <summary>
+    /// 利用額／チャージ額
+    /// </summary>
+    public int? Amount { get; init; }
+
+    /// <summary>
+    /// 残額
+    /// </summary>
+    public int? Balance { get; init; }
+
+    /// <summary>
+    /// チャージフラグ
+    /// </summary>
+    public bool IsCharge { get; init; }
+
+    /// <summary>
+    /// バス利用フラグ
+    /// </summary>
+    public bool IsBus { get; init; }
+
+    #region 表示用プロパティ
+
+    /// <summary>
+    /// 表示用: 利用区間（駅名またはバス停）
+    /// </summary>
+    public string RouteDisplay
+    {
+        get
+        {
+            if (IsCharge)
+            {
+                return "チャージ";
+            }
+
+            if (IsBus)
+            {
+                return string.IsNullOrEmpty(BusStops) ? "バス（★）" : $"バス（{BusStops}）";
+            }
+
+            if (!string.IsNullOrEmpty(EntryStation) && !string.IsNullOrEmpty(ExitStation))
+            {
+                return $"{EntryStation}～{ExitStation}";
+            }
+
+            if (!string.IsNullOrEmpty(EntryStation))
+            {
+                return $"{EntryStation}～";
+            }
+
+            if (!string.IsNullOrEmpty(ExitStation))
+            {
+                return $"～{ExitStation}";
+            }
+
+            return "不明";
+        }
+    }
+
+    /// <summary>
+    /// 表示用: 金額
+    /// </summary>
+    public string AmountDisplay => Amount.HasValue ? $"{Amount:N0}円" : "";
+
+    /// <summary>
+    /// 表示用: 残額
+    /// </summary>
+    public string BalanceDisplay => Balance.HasValue ? $"{Balance:N0}円" : "";
+
+    #endregion
+}

--- a/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
@@ -1,0 +1,97 @@
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// 利用履歴DTO
+/// ViewModelで使用する履歴表示用オブジェクト
+/// </summary>
+public class LedgerDto
+{
+    /// <summary>
+    /// レコードID
+    /// </summary>
+    public int Id { get; init; }
+
+    /// <summary>
+    /// カードIDm
+    /// </summary>
+    public string CardIdm { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 出納日付
+    /// </summary>
+    public DateTime Date { get; init; }
+
+    /// <summary>
+    /// 表示用: 日付（和暦変換済み）
+    /// </summary>
+    public string DateDisplay { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 摘要
+    /// </summary>
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 受入金額（チャージ額）
+    /// </summary>
+    public int Income { get; init; }
+
+    /// <summary>
+    /// 払出金額（利用額）
+    /// </summary>
+    public int Expense { get; init; }
+
+    /// <summary>
+    /// 残額
+    /// </summary>
+    public int Balance { get; init; }
+
+    /// <summary>
+    /// 利用者氏名
+    /// </summary>
+    public string? StaffName { get; init; }
+
+    /// <summary>
+    /// 備考
+    /// </summary>
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// 貸出中レコードフラグ
+    /// </summary>
+    public bool IsLentRecord { get; init; }
+
+    /// <summary>
+    /// 利用履歴詳細
+    /// </summary>
+    public List<LedgerDetailDto> Details { get; init; } = new();
+
+    #region 表示用プロパティ
+
+    /// <summary>
+    /// 表示用: 受入金額（金額がある場合のみ表示）
+    /// </summary>
+    public string IncomeDisplay => Income > 0 ? $"+{Income:N0}" : "";
+
+    /// <summary>
+    /// 表示用: 払出金額（金額がある場合のみ表示）
+    /// </summary>
+    public string ExpenseDisplay => Expense > 0 ? $"-{Expense:N0}" : "";
+
+    /// <summary>
+    /// 表示用: 残額
+    /// </summary>
+    public string BalanceDisplay => $"{Balance:N0}";
+
+    /// <summary>
+    /// 受入金額があるかどうか
+    /// </summary>
+    public bool HasIncome => Income > 0;
+
+    /// <summary>
+    /// 払出金額があるかどうか
+    /// </summary>
+    public bool HasExpense => Expense > 0;
+
+    #endregion
+}

--- a/ICCardManager/src/ICCardManager/Dtos/SettingsDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/SettingsDto.cs
@@ -1,0 +1,46 @@
+using ICCardManager.Models;
+
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// 設定情報DTO
+/// ViewModelで使用する設定表示用オブジェクト
+/// </summary>
+public class SettingsDto
+{
+    /// <summary>
+    /// 残額警告閾値（円）
+    /// </summary>
+    public int WarningBalance { get; init; }
+
+    /// <summary>
+    /// バックアップ先フォルダパス
+    /// </summary>
+    public string BackupPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 文字サイズ
+    /// </summary>
+    public FontSizeOption FontSize { get; init; }
+
+    #region 表示用プロパティ
+
+    /// <summary>
+    /// 表示用: 残額警告閾値
+    /// </summary>
+    public string WarningBalanceDisplay => $"{WarningBalance:N0}円";
+
+    /// <summary>
+    /// 表示用: 文字サイズ
+    /// </summary>
+    public string FontSizeDisplay => FontSize switch
+    {
+        FontSizeOption.Small => "小",
+        FontSizeOption.Medium => "中（標準）",
+        FontSizeOption.Large => "大",
+        FontSizeOption.ExtraLarge => "特大",
+        _ => "中（標準）"
+    };
+
+    #endregion
+}

--- a/ICCardManager/src/ICCardManager/Dtos/StaffDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/StaffDto.cs
@@ -1,0 +1,35 @@
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// 職員情報DTO
+/// ViewModelで使用する職員情報の表示用オブジェクト
+/// </summary>
+public class StaffDto
+{
+    /// <summary>
+    /// 職員証IDm（16進数16文字）
+    /// </summary>
+    public string StaffIdm { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 職員氏名
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 職員番号
+    /// </summary>
+    public string? Number { get; init; }
+
+    /// <summary>
+    /// 備考
+    /// </summary>
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// 表示用: 職員名（番号付き）
+    /// </summary>
+    public string DisplayName => string.IsNullOrEmpty(Number)
+        ? Name
+        : $"{Number} {Name}";
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Infrastructure.CardReader;
 using ICCardManager.Models;
 using ICCardManager.Services;
@@ -18,10 +19,10 @@ public partial class CardManageViewModel : ViewModelBase
     private readonly CardTypeDetector _cardTypeDetector;
 
     [ObservableProperty]
-    private ObservableCollection<IcCard> _cards = new();
+    private ObservableCollection<CardDto> _cards = new();
 
     [ObservableProperty]
-    private IcCard? _selectedCard;
+    private CardDto? _selectedCard;
 
     [ObservableProperty]
     private bool _isEditing;
@@ -98,7 +99,7 @@ public partial class CardManageViewModel : ViewModelBase
             Cards.Clear();
             foreach (var card in cards.OrderBy(c => c.CardType).ThenBy(c => c.CardNumber))
             {
-                Cards.Add(card);
+                Cards.Add(card.ToDto());
             }
         }
     }
@@ -225,7 +226,7 @@ public partial class CardManageViewModel : ViewModelBase
                     CardNumber = EditCardNumber,
                     Note = string.IsNullOrWhiteSpace(EditNote) ? null : EditNote,
                     IsLent = SelectedCard!.IsLent,
-                    LastLentAt = SelectedCard.LastLentAt,
+                    LastLentAt = SelectedCard.LentAt,
                     LastLentStaff = SelectedCard.LastLentStaff
                 };
 

--- a/ICCardManager/src/ICCardManager/ViewModels/HistoryViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/HistoryViewModel.cs
@@ -1,8 +1,8 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using ICCardManager.Common;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Models;
 
 namespace ICCardManager.ViewModels;
@@ -16,13 +16,13 @@ public partial class HistoryViewModel : ViewModelBase
     private readonly ICardRepository _cardRepository;
 
     [ObservableProperty]
-    private IcCard? _card;
+    private CardDto? _card;
 
     [ObservableProperty]
-    private ObservableCollection<LedgerDisplayItem> _ledgers = new();
+    private ObservableCollection<LedgerDto> _ledgers = new();
 
     [ObservableProperty]
-    private LedgerDisplayItem? _selectedLedger;
+    private LedgerDto? _selectedLedger;
 
     [ObservableProperty]
     private int _currentBalance;
@@ -85,9 +85,18 @@ public partial class HistoryViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// カードを設定して初期化
+    /// カードを設定して初期化（エンティティから）
     /// </summary>
     public async Task InitializeAsync(IcCard card)
+    {
+        Card = card.ToDto();
+        await LoadHistoryAsync();
+    }
+
+    /// <summary>
+    /// カードを設定して初期化（DTOから）
+    /// </summary>
+    public async Task InitializeAsync(CardDto card)
     {
         Card = card;
         await LoadHistoryAsync();
@@ -111,7 +120,7 @@ public partial class HistoryViewModel : ViewModelBase
 
             foreach (var ledger in ledgers.OrderByDescending(l => l.Date).ThenByDescending(l => l.Id))
             {
-                Ledgers.Add(new LedgerDisplayItem(ledger));
+                Ledgers.Add(ledger.ToDto());
             }
 
             // 最新の残高を取得
@@ -191,34 +200,5 @@ public partial class HistoryViewModel : ViewModelBase
     private void UpdateSelectedPeriodDisplay()
     {
         SelectedPeriodDisplay = $"{FromDate:yyyy年M月}";
-    }
-}
-
-/// <summary>
-/// 履歴表示用アイテム
-/// </summary>
-public class LedgerDisplayItem
-{
-    public Ledger Ledger { get; }
-
-    public int Id => Ledger.Id;
-    public DateTime Date => Ledger.Date;
-    public string DateDisplay => WarekiConverter.ToWareki(Ledger.Date);
-    public string Summary => Ledger.Summary;
-    public int? Income => Ledger.Income > 0 ? Ledger.Income : null;
-    public int? Expense => Ledger.Expense > 0 ? Ledger.Expense : null;
-    public int Balance => Ledger.Balance;
-    public string? StaffName => Ledger.StaffName;
-    public string? Note => Ledger.Note;
-
-    public string IncomeDisplay => Income.HasValue ? $"+{Income:N0}" : "";
-    public string ExpenseDisplay => Expense.HasValue ? $"-{Expense:N0}" : "";
-    public string BalanceDisplay => $"{Balance:N0}";
-
-    public bool IsLentRecord => Ledger.IsLentRecord;
-
-    public LedgerDisplayItem(Ledger ledger)
-    {
-        Ledger = ledger;
     }
 }

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ICCardManager.Common;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Infrastructure.CardReader;
 using ICCardManager.Infrastructure.Sound;
 using ICCardManager.Models;
@@ -78,7 +79,7 @@ public partial class MainViewModel : ViewModelBase
     private ObservableCollection<string> _warningMessages = new();
 
     [ObservableProperty]
-    private ObservableCollection<IcCard> _lentCards = new();
+    private ObservableCollection<CardDto> _lentCards = new();
 
     public MainViewModel(
         ICardReader cardReader,
@@ -172,7 +173,7 @@ public partial class MainViewModel : ViewModelBase
         LentCards.Clear();
         foreach (var card in lentCards)
         {
-            LentCards.Add(card);
+            LentCards.Add(card.ToDto());
         }
     }
 

--- a/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
@@ -4,7 +4,7 @@ using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ICCardManager.Data.Repositories;
-using ICCardManager.Models;
+using ICCardManager.Dtos;
 using ICCardManager.Services;
 using Microsoft.Win32;
 
@@ -19,10 +19,10 @@ public partial class ReportViewModel : ViewModelBase
     private readonly ICardRepository _cardRepository;
 
     [ObservableProperty]
-    private ObservableCollection<IcCard> _cards = new();
+    private ObservableCollection<CardDto> _cards = new();
 
     [ObservableProperty]
-    private ObservableCollection<IcCard> _selectedCards = new();
+    private ObservableCollection<CardDto> _selectedCards = new();
 
     [ObservableProperty]
     private int _selectedYear;
@@ -94,7 +94,7 @@ public partial class ReportViewModel : ViewModelBase
 
             foreach (var card in cards.OrderBy(c => c.CardType).ThenBy(c => c.CardNumber))
             {
-                Cards.Add(card);
+                Cards.Add(card.ToDto());
             }
 
             // デフォルトで全選択
@@ -134,7 +134,7 @@ public partial class ReportViewModel : ViewModelBase
     /// カードの選択状態を切り替え
     /// </summary>
     [RelayCommand]
-    public void ToggleCardSelection(IcCard card)
+    public void ToggleCardSelection(CardDto card)
     {
         if (SelectedCards.Contains(card))
         {

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Infrastructure.CardReader;
 using ICCardManager.Models;
 
@@ -16,10 +17,10 @@ public partial class StaffManageViewModel : ViewModelBase
     private readonly ICardReader _cardReader;
 
     [ObservableProperty]
-    private ObservableCollection<Staff> _staffList = new();
+    private ObservableCollection<StaffDto> _staffList = new();
 
     [ObservableProperty]
-    private Staff? _selectedStaff;
+    private StaffDto? _selectedStaff;
 
     [ObservableProperty]
     private bool _isEditing;
@@ -76,7 +77,7 @@ public partial class StaffManageViewModel : ViewModelBase
             StaffList.Clear();
             foreach (var staff in staffList.OrderBy(s => s.Number).ThenBy(s => s.Name))
             {
-                StaffList.Add(staff);
+                StaffList.Add(staff.ToDto());
             }
         }
     }

--- a/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
@@ -1,0 +1,540 @@
+using FluentAssertions;
+using ICCardManager.Dtos;
+using ICCardManager.Models;
+using Xunit;
+
+namespace ICCardManager.Tests.Dtos;
+
+/// <summary>
+/// DtoMapperの単体テスト
+/// </summary>
+public class DtoMapperTests
+{
+    #region IcCard → CardDto
+
+    /// <summary>
+    /// IcCardからCardDtoへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromIcCard_ShouldMapAllProperties()
+    {
+        // Arrange
+        var card = new IcCard
+        {
+            CardIdm = "07FE112233445566",
+            CardType = "はやかけん",
+            CardNumber = "H-001",
+            Note = "テストカード",
+            IsLent = true,
+            LastLentStaff = "FFFF000000000001",
+            LastLentAt = new DateTime(2025, 1, 15, 10, 30, 0)
+        };
+
+        // Act
+        var dto = card.ToDto(staffName: "山田太郎");
+
+        // Assert
+        dto.CardIdm.Should().Be("07FE112233445566");
+        dto.CardType.Should().Be("はやかけん");
+        dto.CardNumber.Should().Be("H-001");
+        dto.Note.Should().Be("テストカード");
+        dto.IsLent.Should().BeTrue();
+        dto.LastLentStaff.Should().Be("FFFF000000000001");
+        dto.LentStaffName.Should().Be("山田太郎");
+        dto.LentAt.Should().Be(new DateTime(2025, 1, 15, 10, 30, 0));
+    }
+
+    /// <summary>
+    /// 貸出中でないカードの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromIcCard_WhenNotLent_ShouldMapCorrectly()
+    {
+        // Arrange
+        var card = new IcCard
+        {
+            CardIdm = "07FE112233445566",
+            CardType = "nimoca",
+            CardNumber = "N-001",
+            IsLent = false
+        };
+
+        // Act
+        var dto = card.ToDto();
+
+        // Assert
+        dto.IsLent.Should().BeFalse();
+        dto.LentStaffName.Should().BeNull();
+        dto.LentAt.Should().BeNull();
+        dto.LastLentStaff.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 表示用プロパティが正しく生成されること
+    /// </summary>
+    [Fact]
+    public void CardDto_DisplayProperties_ShouldBeCorrect()
+    {
+        // Arrange
+        var dto = new CardDto
+        {
+            CardType = "はやかけん",
+            CardNumber = "H-001",
+            IsLent = true,
+            LentAt = new DateTime(2025, 1, 15, 10, 30, 0)
+        };
+
+        // Assert
+        dto.DisplayName.Should().Be("はやかけん H-001");
+        dto.LentStatusDisplay.Should().Be("貸出中");
+        dto.LentAtDisplay.Should().Be("2025/01/15 10:30");
+    }
+
+    /// <summary>
+    /// 在庫状態の表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void CardDto_LentStatusDisplay_WhenNotLent_ShouldShowInStock()
+    {
+        // Arrange
+        var dto = new CardDto { IsLent = false };
+
+        // Assert
+        dto.LentStatusDisplay.Should().Be("在庫");
+    }
+
+    /// <summary>
+    /// カードリストの一括変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDtoList_FromIcCards_ShouldMapAllItems()
+    {
+        // Arrange
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "07FE112233445566", CardType = "はやかけん", CardNumber = "H-001" },
+            new IcCard { CardIdm = "05FE112233445567", CardType = "nimoca", CardNumber = "N-001" }
+        };
+
+        // Act
+        var dtos = cards.ToDtoList();
+
+        // Assert
+        dtos.Should().HaveCount(2);
+        dtos[0].CardType.Should().Be("はやかけん");
+        dtos[1].CardType.Should().Be("nimoca");
+    }
+
+    #endregion
+
+    #region Staff → StaffDto
+
+    /// <summary>
+    /// StaffからStaffDtoへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromStaff_ShouldMapAllProperties()
+    {
+        // Arrange
+        var staff = new Staff
+        {
+            StaffIdm = "FFFF000000000001",
+            Name = "山田太郎",
+            Number = "001",
+            Note = "テスト職員"
+        };
+
+        // Act
+        var dto = staff.ToDto();
+
+        // Assert
+        dto.StaffIdm.Should().Be("FFFF000000000001");
+        dto.Name.Should().Be("山田太郎");
+        dto.Number.Should().Be("001");
+        dto.Note.Should().Be("テスト職員");
+    }
+
+    /// <summary>
+    /// 職員番号がある場合の表示名が正しいこと
+    /// </summary>
+    [Fact]
+    public void StaffDto_DisplayName_WithNumber_ShouldIncludeNumber()
+    {
+        // Arrange
+        var dto = new StaffDto { Name = "山田太郎", Number = "001" };
+
+        // Assert
+        dto.DisplayName.Should().Be("001 山田太郎");
+    }
+
+    /// <summary>
+    /// 職員番号がない場合の表示名が正しいこと
+    /// </summary>
+    [Fact]
+    public void StaffDto_DisplayName_WithoutNumber_ShouldShowNameOnly()
+    {
+        // Arrange
+        var dto = new StaffDto { Name = "山田太郎", Number = null };
+
+        // Assert
+        dto.DisplayName.Should().Be("山田太郎");
+    }
+
+    /// <summary>
+    /// 職員リストの一括変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDtoList_FromStaffs_ShouldMapAllItems()
+    {
+        // Arrange
+        var staffList = new List<Staff>
+        {
+            new Staff { StaffIdm = "FFFF000000000001", Name = "山田太郎" },
+            new Staff { StaffIdm = "FFFF000000000002", Name = "鈴木花子" }
+        };
+
+        // Act
+        var dtos = staffList.ToDtoList();
+
+        // Assert
+        dtos.Should().HaveCount(2);
+        dtos[0].Name.Should().Be("山田太郎");
+        dtos[1].Name.Should().Be("鈴木花子");
+    }
+
+    #endregion
+
+    #region Ledger → LedgerDto
+
+    /// <summary>
+    /// LedgerからLedgerDtoへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromLedger_ShouldMapAllProperties()
+    {
+        // Arrange
+        var ledger = new Ledger
+        {
+            Id = 1,
+            CardIdm = "07FE112233445566",
+            Date = new DateTime(2025, 1, 15),
+            Summary = "鉄道（博多駅～天神駅）",
+            Income = 0,
+            Expense = 210,
+            Balance = 4790,
+            StaffName = "山田太郎",
+            Note = "通勤利用",
+            IsLentRecord = false,
+            Details = new List<LedgerDetail>
+            {
+                new LedgerDetail { LedgerId = 1, EntryStation = "博多駅", ExitStation = "天神駅", Amount = 210 }
+            }
+        };
+
+        // Act
+        var dto = ledger.ToDto();
+
+        // Assert
+        dto.Id.Should().Be(1);
+        dto.CardIdm.Should().Be("07FE112233445566");
+        dto.Date.Should().Be(new DateTime(2025, 1, 15));
+        dto.DateDisplay.Should().Contain("R7"); // 和暦変換される（短縮形式: R7.01.15）
+        dto.Summary.Should().Be("鉄道（博多駅～天神駅）");
+        dto.Income.Should().Be(0);
+        dto.Expense.Should().Be(210);
+        dto.Balance.Should().Be(4790);
+        dto.StaffName.Should().Be("山田太郎");
+        dto.Note.Should().Be("通勤利用");
+        dto.IsLentRecord.Should().BeFalse();
+        dto.Details.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// 受入金額の表示プロパティが正しいこと
+    /// </summary>
+    [Theory]
+    [InlineData(1000, "+1,000")]
+    [InlineData(0, "")]
+    public void LedgerDto_IncomeDisplay_ShouldFormatCorrectly(int income, string expected)
+    {
+        // Arrange
+        var dto = new LedgerDto { Income = income };
+
+        // Assert
+        dto.IncomeDisplay.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// 払出金額の表示プロパティが正しいこと
+    /// </summary>
+    [Theory]
+    [InlineData(210, "-210")]
+    [InlineData(0, "")]
+    public void LedgerDto_ExpenseDisplay_ShouldFormatCorrectly(int expense, string expected)
+    {
+        // Arrange
+        var dto = new LedgerDto { Expense = expense };
+
+        // Assert
+        dto.ExpenseDisplay.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// 残額の表示プロパティが正しいこと
+    /// </summary>
+    [Fact]
+    public void LedgerDto_BalanceDisplay_ShouldFormatWithCommas()
+    {
+        // Arrange
+        var dto = new LedgerDto { Balance = 12345 };
+
+        // Assert
+        dto.BalanceDisplay.Should().Be("12,345");
+    }
+
+    #endregion
+
+    #region LedgerDetail → LedgerDetailDto
+
+    /// <summary>
+    /// LedgerDetailからLedgerDetailDtoへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromLedgerDetail_ShouldMapAllProperties()
+    {
+        // Arrange
+        var detail = new LedgerDetail
+        {
+            LedgerId = 1,
+            UseDate = new DateTime(2025, 1, 15, 9, 30, 0),
+            EntryStation = "博多駅",
+            ExitStation = "天神駅",
+            Amount = 210,
+            Balance = 4790,
+            IsCharge = false,
+            IsBus = false
+        };
+
+        // Act
+        var dto = detail.ToDto();
+
+        // Assert
+        dto.LedgerId.Should().Be(1);
+        dto.UseDate.Should().Be(new DateTime(2025, 1, 15, 9, 30, 0));
+        dto.UseDateDisplay.Should().Be("2025/01/15 09:30");
+        dto.EntryStation.Should().Be("博多駅");
+        dto.ExitStation.Should().Be("天神駅");
+        dto.Amount.Should().Be(210);
+        dto.Balance.Should().Be(4790);
+        dto.IsCharge.Should().BeFalse();
+        dto.IsBus.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 鉄道利用時のルート表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void LedgerDetailDto_RouteDisplay_ForRailway_ShouldShowStations()
+    {
+        // Arrange
+        var dto = new LedgerDetailDto
+        {
+            EntryStation = "博多駅",
+            ExitStation = "天神駅",
+            IsCharge = false,
+            IsBus = false
+        };
+
+        // Assert
+        dto.RouteDisplay.Should().Be("博多駅～天神駅");
+    }
+
+    /// <summary>
+    /// チャージ時のルート表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void LedgerDetailDto_RouteDisplay_ForCharge_ShouldShowCharge()
+    {
+        // Arrange
+        var dto = new LedgerDetailDto { IsCharge = true };
+
+        // Assert
+        dto.RouteDisplay.Should().Be("チャージ");
+    }
+
+    /// <summary>
+    /// バス利用時（バス停名あり）のルート表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void LedgerDetailDto_RouteDisplay_ForBusWithStops_ShouldShowBusStops()
+    {
+        // Arrange
+        var dto = new LedgerDetailDto
+        {
+            IsBus = true,
+            BusStops = "博多駅前→天神"
+        };
+
+        // Assert
+        dto.RouteDisplay.Should().Be("バス（博多駅前→天神）");
+    }
+
+    /// <summary>
+    /// バス利用時（バス停名なし）のルート表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void LedgerDetailDto_RouteDisplay_ForBusWithoutStops_ShouldShowStar()
+    {
+        // Arrange
+        var dto = new LedgerDetailDto
+        {
+            IsBus = true,
+            BusStops = null
+        };
+
+        // Assert
+        dto.RouteDisplay.Should().Be("バス（★）");
+    }
+
+    #endregion
+
+    #region AppSettings → SettingsDto
+
+    /// <summary>
+    /// AppSettingsからSettingsDtoへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToDto_FromAppSettings_ShouldMapAllProperties()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            WarningBalance = 3000,
+            BackupPath = @"C:\Backup",
+            FontSize = FontSizeOption.Large
+        };
+
+        // Act
+        var dto = settings.ToDto();
+
+        // Assert
+        dto.WarningBalance.Should().Be(3000);
+        dto.BackupPath.Should().Be(@"C:\Backup");
+        dto.FontSize.Should().Be(FontSizeOption.Large);
+    }
+
+    /// <summary>
+    /// 残額警告閾値の表示が正しいこと
+    /// </summary>
+    [Fact]
+    public void SettingsDto_WarningBalanceDisplay_ShouldFormatWithYen()
+    {
+        // Arrange
+        var dto = new SettingsDto { WarningBalance = 10000 };
+
+        // Assert
+        dto.WarningBalanceDisplay.Should().Be("10,000円");
+    }
+
+    /// <summary>
+    /// 文字サイズの表示が正しいこと
+    /// </summary>
+    [Theory]
+    [InlineData(FontSizeOption.Small, "小")]
+    [InlineData(FontSizeOption.Medium, "中（標準）")]
+    [InlineData(FontSizeOption.Large, "大")]
+    [InlineData(FontSizeOption.ExtraLarge, "特大")]
+    public void SettingsDto_FontSizeDisplay_ShouldShowCorrectText(FontSizeOption fontSize, string expected)
+    {
+        // Arrange
+        var dto = new SettingsDto { FontSize = fontSize };
+
+        // Assert
+        dto.FontSizeDisplay.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region DTO → Entity（逆変換）
+
+    /// <summary>
+    /// CardDtoからIcCardへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToEntity_FromCardDto_ShouldMapAllProperties()
+    {
+        // Arrange
+        var dto = new CardDto
+        {
+            CardIdm = "07FE112233445566",
+            CardType = "はやかけん",
+            CardNumber = "H-001",
+            Note = "テストカード",
+            IsLent = true,
+            LastLentStaff = "FFFF000000000001",
+            LentAt = new DateTime(2025, 1, 15)
+        };
+
+        // Act
+        var entity = dto.ToEntity();
+
+        // Assert
+        entity.CardIdm.Should().Be("07FE112233445566");
+        entity.CardType.Should().Be("はやかけん");
+        entity.CardNumber.Should().Be("H-001");
+        entity.Note.Should().Be("テストカード");
+        entity.IsLent.Should().BeTrue();
+        entity.LastLentStaff.Should().Be("FFFF000000000001");
+        entity.LastLentAt.Should().Be(new DateTime(2025, 1, 15));
+    }
+
+    /// <summary>
+    /// StaffDtoからStaffへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToEntity_FromStaffDto_ShouldMapAllProperties()
+    {
+        // Arrange
+        var dto = new StaffDto
+        {
+            StaffIdm = "FFFF000000000001",
+            Name = "山田太郎",
+            Number = "001",
+            Note = "テスト職員"
+        };
+
+        // Act
+        var entity = dto.ToEntity();
+
+        // Assert
+        entity.StaffIdm.Should().Be("FFFF000000000001");
+        entity.Name.Should().Be("山田太郎");
+        entity.Number.Should().Be("001");
+        entity.Note.Should().Be("テスト職員");
+    }
+
+    /// <summary>
+    /// SettingsDtoからAppSettingsへの変換が正しく行われること
+    /// </summary>
+    [Fact]
+    public void ToEntity_FromSettingsDto_ShouldMapAllProperties()
+    {
+        // Arrange
+        var dto = new SettingsDto
+        {
+            WarningBalance = 5000,
+            BackupPath = @"D:\Backup",
+            FontSize = FontSizeOption.ExtraLarge
+        };
+
+        // Act
+        var entity = dto.ToEntity();
+
+        // Assert
+        entity.WarningBalance.Should().Be(5000);
+        entity.BackupPath.Should().Be(@"D:\Backup");
+        entity.FontSize.Should().Be(FontSizeOption.ExtraLarge);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- ViewModel-Repository間にDTOレイヤーを導入し、関心の分離とテスタビリティを向上
- 5つのDTOクラスと拡張メソッドによるマッピング機能を実装
- 29件の単体テストでマッピング機能をカバー

## 実装内容

### 新規ファイル（DTOs）
| ファイル | 説明 |
|----------|------|
| `Dtos/CardDto.cs` | カード情報の表示用DTO |
| `Dtos/StaffDto.cs` | 職員情報の表示用DTO |
| `Dtos/LedgerDto.cs` | 履歴表示用DTO |
| `Dtos/LedgerDetailDto.cs` | 履歴詳細表示用DTO |
| `Dtos/SettingsDto.cs` | 設定情報の表示用DTO |
| `Dtos/DtoMapper.cs` | Entity ⇔ DTO 変換用拡張メソッド |

### 変更ファイル（ViewModels）
| ファイル | 変更内容 |
|----------|----------|
| `MainViewModel.cs` | `LentCards` を `ObservableCollection<CardDto>` に変更 |
| `CardManageViewModel.cs` | `Cards`, `SelectedCard` を CardDto に変更 |
| `StaffManageViewModel.cs` | `StaffList`, `SelectedStaff` を StaffDto に変更 |
| `ReportViewModel.cs` | `Cards`, `SelectedCards` を CardDto に変更 |
| `HistoryViewModel.cs` | `Card` を CardDto に、`LedgerDisplayItem` を `LedgerDto` に変更 |

### DTOの特徴

```csharp
// 表示用プロパティを持つDTO
public class CardDto
{
    public string CardIdm { get; init; }
    public string CardType { get; init; }
    public bool IsLent { get; init; }
    
    // 表示用（計算プロパティ）
    public string DisplayName => $"{CardType} {CardNumber}";
    public string LentStatusDisplay => IsLent ? "貸出中" : "在庫";
}

// 拡張メソッドによるマッピング
var dto = card.ToDto();
var dtoList = cards.ToDtoList();
```

## 設計上のポイント

1. **init アクセサ**: DTOは不変（immutable）として設計
2. **表示用プロパティ**: UI表示用の計算プロパティをDTO内に配置
3. **拡張メソッド**: `ToDto()`, `ToDtoList()`, `ToEntity()` でクリーンなマッピング
4. **逆変換サポート**: 更新操作のためのDTO→Entity変換も実装

## Test plan

- [x] `dotnet build` - ビルド成功
- [x] `dotnet test` - 234件のテストすべて成功
- [x] DtoMapperTests - 29件のテストで各マッピングメソッドをカバー

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)