### PR TITLE
test: Repository層の単体テストを追加 (Issue #12)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/CardRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/CardRepositoryTests.cs
@@ -1,0 +1,592 @@
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Tests.Data;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Repositories;
+
+/// <summary>
+/// CardRepositoryの単体テスト
+/// </summary>
+public class CardRepositoryTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly CardRepository _repository;
+    private readonly StaffRepository _staffRepository;
+
+    // テスト用定数
+    private const string TestStaffIdm = "STAFF00000000001";
+    private const string TestStaffName = "テスト職員";
+
+    public CardRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+        _repository = new CardRepository(_dbContext);
+        _staffRepository = new StaffRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region GetAllAsync テスト
+
+    /// <summary>
+    /// 空のデータベースでは空のリストを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_EmptyDatabase_ReturnsEmptyList()
+    {
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 登録済みカードが正しく取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_WithCards_ReturnsAllNonDeletedCards()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        var card2 = CreateTestCard("0102030405060709", "nimoca", "N001");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(c => c.CardIdm == card1.CardIdm);
+        result.Should().Contain(c => c.CardIdm == card2.CardIdm);
+    }
+
+    /// <summary>
+    /// 論理削除されたカードは取得されないことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_ExcludesDeletedCards()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        var card2 = CreateTestCard("0102030405060709", "nimoca", "N001");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+        await _repository.DeleteAsync(card2.CardIdm);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.First().CardIdm.Should().Be(card1.CardIdm);
+    }
+
+    #endregion
+
+    #region GetByIdmAsync テスト
+
+    /// <summary>
+    /// 存在するカードをIDmで取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_ExistingCard_ReturnsCard()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(card.CardIdm);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CardIdm.Should().Be(card.CardIdm);
+        result.CardType.Should().Be(card.CardType);
+        result.CardNumber.Should().Be(card.CardNumber);
+    }
+
+    /// <summary>
+    /// 存在しないカードIDmでnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_NonExistingCard_ReturnsNull()
+    {
+        // Act
+        var result = await _repository.GetByIdmAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 論理削除されたカードはデフォルトで取得されないことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_DeletedCard_ReturnsNull()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.DeleteAsync(card.CardIdm);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(card.CardIdm);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// includeDeletedオプションで論理削除されたカードも取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_DeletedCard_WithIncludeDeleted_ReturnsCard()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.DeleteAsync(card.CardIdm);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(card.CardIdm, includeDeleted: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.CardIdm.Should().Be(card.CardIdm);
+        result.IsDeleted.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GetAvailableAsync テスト
+
+    /// <summary>
+    /// 貸出可能なカードのみ取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAvailableAsync_ReturnsOnlyNonLentCards()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        var card2 = CreateTestCard("0102030405060709", "nimoca", "N001");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+        await _repository.UpdateLentStatusAsync(card2.CardIdm, true, DateTime.Now, null);
+
+        // Act
+        var result = await _repository.GetAvailableAsync();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.First().CardIdm.Should().Be(card1.CardIdm);
+    }
+
+    #endregion
+
+    #region GetLentAsync テスト
+
+    /// <summary>
+    /// 貸出中のカードのみ取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetLentAsync_ReturnsOnlyLentCards()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        var card2 = CreateTestCard("0102030405060709", "nimoca", "N001");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+        await _repository.UpdateLentStatusAsync(card2.CardIdm, true, DateTime.Now, null);
+
+        // Act
+        var result = await _repository.GetLentAsync();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.First().CardIdm.Should().Be(card2.CardIdm);
+        result.First().IsLent.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region InsertAsync テスト
+
+    /// <summary>
+    /// カードを正常に登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_ValidCard_ReturnsTrue()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+
+        // Act
+        var result = await _repository.InsertAsync(card);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var inserted = await _repository.GetByIdmAsync(card.CardIdm);
+        inserted.Should().NotBeNull();
+        inserted!.CardType.Should().Be(card.CardType);
+        inserted.CardNumber.Should().Be(card.CardNumber);
+    }
+
+    /// <summary>
+    /// 重複するIDmでの登録はエラーになることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_DuplicateIdm_ReturnsFalse()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        var card2 = CreateTestCard("0102030405060708", "nimoca", "N001"); // 同じIDm
+        await _repository.InsertAsync(card1);
+
+        // Act
+        var result = await _repository.InsertAsync(card2);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// メモ付きカードを登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_WithNote_SavesNote()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        card.Note = "テストメモ";
+
+        // Act
+        await _repository.InsertAsync(card);
+
+        // Assert
+        var inserted = await _repository.GetByIdmAsync(card.CardIdm);
+        inserted!.Note.Should().Be("テストメモ");
+    }
+
+    #endregion
+
+    #region UpdateAsync テスト
+
+    /// <summary>
+    /// カード情報を更新できることを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_ValidCard_ReturnsTrue()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+
+        card.CardNumber = "H002";
+        card.Note = "更新テスト";
+
+        // Act
+        var result = await _repository.UpdateAsync(card);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetByIdmAsync(card.CardIdm);
+        updated!.CardNumber.Should().Be("H002");
+        updated.Note.Should().Be("更新テスト");
+    }
+
+    /// <summary>
+    /// 存在しないカードの更新はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_NonExistingCard_ReturnsFalse()
+    {
+        // Arrange
+        var card = CreateTestCard("NOTEXISTINGIDM00", "はやかけん", "H001");
+
+        // Act
+        var result = await _repository.UpdateAsync(card);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 論理削除されたカードは更新できないことを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_DeletedCard_ReturnsFalse()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.DeleteAsync(card.CardIdm);
+
+        card.CardNumber = "H002";
+
+        // Act
+        var result = await _repository.UpdateAsync(card);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region UpdateLentStatusAsync テスト
+
+    /// <summary>
+    /// 貸出状態を更新できることを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateLentStatusAsync_SetLent_UpdatesCorrectly()
+    {
+        // Arrange
+        await _staffRepository.InsertAsync(CreateTestStaff());
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        var lentAt = DateTime.Now;
+
+        // Act
+        var result = await _repository.UpdateLentStatusAsync(card.CardIdm, true, lentAt, TestStaffIdm);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetByIdmAsync(card.CardIdm);
+        updated!.IsLent.Should().BeTrue();
+        updated.LastLentAt.Should().NotBeNull();
+        updated.LastLentStaff.Should().Be(TestStaffIdm);
+    }
+
+    /// <summary>
+    /// 返却状態を更新できることを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateLentStatusAsync_SetReturned_UpdatesCorrectly()
+    {
+        // Arrange
+        await _staffRepository.InsertAsync(CreateTestStaff());
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.UpdateLentStatusAsync(card.CardIdm, true, DateTime.Now, TestStaffIdm);
+
+        // Act
+        var result = await _repository.UpdateLentStatusAsync(card.CardIdm, false, null, null);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetByIdmAsync(card.CardIdm);
+        updated!.IsLent.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region DeleteAsync テスト
+
+    /// <summary>
+    /// カードを論理削除できることを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_NonLentCard_ReturnsTrue()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+
+        // Act
+        var result = await _repository.DeleteAsync(card.CardIdm);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var deleted = await _repository.GetByIdmAsync(card.CardIdm, includeDeleted: true);
+        deleted!.IsDeleted.Should().BeTrue();
+        deleted.DeletedAt.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// 貸出中のカードは削除できないことを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_LentCard_ReturnsFalse()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.UpdateLentStatusAsync(card.CardIdm, true, DateTime.Now, null);
+
+        // Act
+        var result = await _repository.DeleteAsync(card.CardIdm);
+
+        // Assert
+        result.Should().BeFalse();
+
+        var notDeleted = await _repository.GetByIdmAsync(card.CardIdm);
+        notDeleted.Should().NotBeNull();
+        notDeleted!.IsDeleted.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 存在しないカードの削除はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_NonExistingCard_ReturnsFalse()
+    {
+        // Act
+        var result = await _repository.DeleteAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ExistsAsync テスト
+
+    /// <summary>
+    /// 存在するカードでtrueを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_ExistingCard_ReturnsTrue()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+
+        // Act
+        var result = await _repository.ExistsAsync(card.CardIdm);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 存在しないカードでfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_NonExistingCard_ReturnsFalse()
+    {
+        // Act
+        var result = await _repository.ExistsAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 論理削除されたカードでもtrueを返すことを確認（物理的には存在する）
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_DeletedCard_ReturnsTrue()
+    {
+        // Arrange
+        var card = CreateTestCard("0102030405060708", "はやかけん", "H001");
+        await _repository.InsertAsync(card);
+        await _repository.DeleteAsync(card.CardIdm);
+
+        // Act
+        var result = await _repository.ExistsAsync(card.CardIdm);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GetNextCardNumberAsync テスト
+
+    /// <summary>
+    /// 最初のカード番号は1を返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetNextCardNumberAsync_NoCards_Returns1()
+    {
+        // Act
+        var result = await _repository.GetNextCardNumberAsync("はやかけん");
+
+        // Assert
+        result.Should().Be("1");
+    }
+
+    /// <summary>
+    /// 次のカード番号を正しく返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetNextCardNumberAsync_WithExistingCards_ReturnsNextNumber()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "1");
+        var card2 = CreateTestCard("0102030405060709", "はやかけん", "2");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+
+        // Act
+        var result = await _repository.GetNextCardNumberAsync("はやかけん");
+
+        // Assert
+        result.Should().Be("3");
+    }
+
+    /// <summary>
+    /// カード種別ごとに独立した番号を返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetNextCardNumberAsync_DifferentCardTypes_IndependentNumbering()
+    {
+        // Arrange
+        var card1 = CreateTestCard("0102030405060708", "はやかけん", "5");
+        var card2 = CreateTestCard("0102030405060709", "nimoca", "10");
+        await _repository.InsertAsync(card1);
+        await _repository.InsertAsync(card2);
+
+        // Act
+        var hayakakenNext = await _repository.GetNextCardNumberAsync("はやかけん");
+        var nimocaNext = await _repository.GetNextCardNumberAsync("nimoca");
+        var sugocaNext = await _repository.GetNextCardNumberAsync("SUGOCA");
+
+        // Assert
+        hayakakenNext.Should().Be("6");
+        nimocaNext.Should().Be("11");
+        sugocaNext.Should().Be("1");
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private static IcCard CreateTestCard(string cardIdm, string cardType, string cardNumber)
+    {
+        return new IcCard
+        {
+            CardIdm = cardIdm,
+            CardType = cardType,
+            CardNumber = cardNumber,
+            IsDeleted = false,
+            IsLent = false
+        };
+    }
+
+    private static Staff CreateTestStaff()
+    {
+        return new Staff
+        {
+            StaffIdm = TestStaffIdm,
+            Name = TestStaffName,
+            IsDeleted = false
+        };
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerRepositoryTests.cs
@@ -1,0 +1,636 @@
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Tests.Data;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Repositories;
+
+/// <summary>
+/// LedgerRepositoryの単体テスト
+/// </summary>
+public class LedgerRepositoryTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly LedgerRepository _repository;
+    private readonly CardRepository _cardRepository;
+    private readonly StaffRepository _staffRepository;
+
+    // テスト用定数
+    private const string TestCardIdm = "0102030405060708";
+    private const string TestStaffIdm = "STAFF00000000001";
+    private const string TestStaffName = "テスト職員";
+
+    public LedgerRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+        _repository = new LedgerRepository(_dbContext);
+        _cardRepository = new CardRepository(_dbContext);
+        _staffRepository = new StaffRepository(_dbContext);
+
+        // テスト用データを事前登録（外部キー制約対応）
+        SetupTestData().Wait();
+    }
+
+    private async Task SetupTestData()
+    {
+        // テスト用職員を登録
+        var staff = new Staff
+        {
+            StaffIdm = TestStaffIdm,
+            Name = TestStaffName,
+            IsDeleted = false
+        };
+        await _staffRepository.InsertAsync(staff);
+
+        // テスト用カードを登録
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "H001"
+        };
+        await _cardRepository.InsertAsync(card);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region InsertAsync テスト
+
+    /// <summary>
+    /// 利用履歴を正常に登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_ValidLedger_ReturnsInsertedId()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "鉄道（博多～天神）", expense: 260);
+
+        // Act
+        var id = await _repository.InsertAsync(ledger);
+
+        // Assert
+        id.Should().BeGreaterThan(0);
+
+        var inserted = await _repository.GetByIdAsync(id);
+        inserted.Should().NotBeNull();
+        inserted!.CardIdm.Should().Be(TestCardIdm);
+        inserted.Summary.Should().Be("鉄道（博多～天神）");
+        inserted.Expense.Should().Be(260);
+    }
+
+    /// <summary>
+    /// チャージ履歴を登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_ChargeRecord_SavesCorrectly()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "チャージ", income: 3000);
+        ledger.Balance = 13000;
+
+        // Act
+        var id = await _repository.InsertAsync(ledger);
+
+        // Assert
+        var inserted = await _repository.GetByIdAsync(id);
+        inserted!.Income.Should().Be(3000);
+        inserted.Expense.Should().Be(0);
+        inserted.Balance.Should().Be(13000);
+    }
+
+    /// <summary>
+    /// 貸出中レコードを登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_LentRecord_SavesCorrectly()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "（貸出中）");
+        ledger.IsLentRecord = true;
+        ledger.LenderIdm = TestStaffIdm;
+        ledger.StaffName = "山田太郎";
+        ledger.LentAt = DateTime.Now;
+
+        // Act
+        var id = await _repository.InsertAsync(ledger);
+
+        // Assert
+        var inserted = await _repository.GetByIdAsync(id);
+        inserted!.IsLentRecord.Should().BeTrue();
+        inserted.LenderIdm.Should().Be(TestStaffIdm);
+        inserted.StaffName.Should().Be("山田太郎");
+        inserted.LentAt.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region GetByIdAsync テスト
+
+    /// <summary>
+    /// 存在する履歴をIDで取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdAsync_ExistingLedger_ReturnsLedger()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "鉄道（博多～天神）", expense: 260);
+        var id = await _repository.InsertAsync(ledger);
+
+        // Act
+        var result = await _repository.GetByIdAsync(id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(id);
+        result.Summary.Should().Be("鉄道（博多～天神）");
+    }
+
+    /// <summary>
+    /// 存在しないIDでnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdAsync_NonExistingId_ReturnsNull()
+    {
+        // Act
+        var result = await _repository.GetByIdAsync(99999);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetByDateRangeAsync テスト
+
+    /// <summary>
+    /// 期間内の履歴を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByDateRangeAsync_WithData_ReturnsMatchingRecords()
+    {
+        // Arrange
+        var today = DateTime.Today;
+        var ledger1 = CreateTestLedger(TestCardIdm, today.AddDays(-5), "利用1", expense: 260);
+        var ledger2 = CreateTestLedger(TestCardIdm, today.AddDays(-3), "利用2", expense: 310);
+        var ledger3 = CreateTestLedger(TestCardIdm, today, "利用3", expense: 200);
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+        await _repository.InsertAsync(ledger3);
+
+        // Act - 過去4日間を取得
+        var result = await _repository.GetByDateRangeAsync(TestCardIdm, today.AddDays(-4), today);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(l => l.Summary == "利用2");
+        result.Should().Contain(l => l.Summary == "利用3");
+    }
+
+    /// <summary>
+    /// カードIDmがnullの場合、全カードの履歴を返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByDateRangeAsync_NullCardIdm_ReturnsAllCards()
+    {
+        // Arrange - 2枚目のカードを追加
+        var card2 = new IcCard
+        {
+            CardIdm = "0102030405060709",
+            CardType = "nimoca",
+            CardNumber = "N001"
+        };
+        await _cardRepository.InsertAsync(card2);
+
+        var today = DateTime.Today;
+        var ledger1 = CreateTestLedger(TestCardIdm, today, "カード1利用", expense: 260);
+        var ledger2 = CreateTestLedger(card2.CardIdm, today, "カード2利用", expense: 310);
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+
+        // Act
+        var result = await _repository.GetByDateRangeAsync(null, today.AddDays(-1), today);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(l => l.CardIdm == TestCardIdm);
+        result.Should().Contain(l => l.CardIdm == card2.CardIdm);
+    }
+
+    /// <summary>
+    /// 結果が日付順でソートされていることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByDateRangeAsync_ReturnsRecordsSortedByDate()
+    {
+        // Arrange
+        var today = DateTime.Today;
+        var ledger1 = CreateTestLedger(TestCardIdm, today, "最新", expense: 260);
+        var ledger2 = CreateTestLedger(TestCardIdm, today.AddDays(-2), "2日前", expense: 310);
+        var ledger3 = CreateTestLedger(TestCardIdm, today.AddDays(-1), "昨日", expense: 200);
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+        await _repository.InsertAsync(ledger3);
+
+        // Act
+        var result = (await _repository.GetByDateRangeAsync(TestCardIdm, today.AddDays(-5), today)).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].Summary.Should().Be("2日前");
+        result[1].Summary.Should().Be("昨日");
+        result[2].Summary.Should().Be("最新");
+    }
+
+    #endregion
+
+    #region GetByMonthAsync テスト
+
+    /// <summary>
+    /// 指定月の履歴を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByMonthAsync_ReturnsRecordsForSpecifiedMonth()
+    {
+        // Arrange
+        var targetYear = 2024;
+        var targetMonth = 6;
+
+        var ledger1 = CreateTestLedger(TestCardIdm, new DateTime(2024, 6, 1), "6月初日", expense: 260);
+        var ledger2 = CreateTestLedger(TestCardIdm, new DateTime(2024, 6, 15), "6月中旬", expense: 310);
+        var ledger3 = CreateTestLedger(TestCardIdm, new DateTime(2024, 6, 30), "6月末日", expense: 200);
+        var ledger4 = CreateTestLedger(TestCardIdm, new DateTime(2024, 7, 1), "7月初日", expense: 100);
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+        await _repository.InsertAsync(ledger3);
+        await _repository.InsertAsync(ledger4);
+
+        // Act
+        var result = await _repository.GetByMonthAsync(TestCardIdm, targetYear, targetMonth);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Should().OnlyContain(l => l.Date.Month == 6 && l.Date.Year == 2024);
+    }
+
+    #endregion
+
+    #region GetLentRecordAsync テスト
+
+    /// <summary>
+    /// 貸出中レコードを取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetLentRecordAsync_WithLentRecord_ReturnsLatestLentRecord()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "（貸出中）");
+        ledger.IsLentRecord = true;
+        ledger.LenderIdm = TestStaffIdm;
+        ledger.StaffName = "山田太郎";
+        ledger.LentAt = DateTime.Now;
+
+        await _repository.InsertAsync(ledger);
+
+        // Act
+        var result = await _repository.GetLentRecordAsync(TestCardIdm);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.IsLentRecord.Should().BeTrue();
+        result.Summary.Should().Be("（貸出中）");
+    }
+
+    /// <summary>
+    /// 貸出中レコードがない場合はnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetLentRecordAsync_NoLentRecord_ReturnsNull()
+    {
+        // Arrange - 通常の利用履歴のみ登録
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "鉄道（博多～天神）", expense: 260);
+        ledger.IsLentRecord = false;
+        await _repository.InsertAsync(ledger);
+
+        // Act
+        var result = await _repository.GetLentRecordAsync(TestCardIdm);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region UpdateAsync テスト
+
+    /// <summary>
+    /// 履歴を更新できることを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_ValidUpdate_ReturnsTrue()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "（貸出中）");
+        ledger.IsLentRecord = true;
+        var id = await _repository.InsertAsync(ledger);
+
+        var insertedLedger = await _repository.GetByIdAsync(id);
+        insertedLedger!.Summary = "鉄道（博多～天神）";
+        insertedLedger.Expense = 260;
+        insertedLedger.IsLentRecord = false;
+        insertedLedger.ReturnedAt = DateTime.Now;
+
+        // Act
+        var result = await _repository.UpdateAsync(insertedLedger);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetByIdAsync(id);
+        updated!.Summary.Should().Be("鉄道（博多～天神）");
+        updated.Expense.Should().Be(260);
+        updated.IsLentRecord.Should().BeFalse();
+        updated.ReturnedAt.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// 存在しないIDの更新はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_NonExistingId_ReturnsFalse()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "テスト");
+        ledger.Id = 99999; // 存在しないID
+
+        // Act
+        var result = await _repository.UpdateAsync(ledger);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region GetLatestBeforeDateAsync テスト
+
+    /// <summary>
+    /// 指定日以前の最新履歴を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetLatestBeforeDateAsync_WithData_ReturnsLatestBeforeDate()
+    {
+        // Arrange
+        var today = DateTime.Today;
+        var ledger1 = CreateTestLedger(TestCardIdm, today.AddDays(-10), "10日前", expense: 100);
+        ledger1.Balance = 9900;
+        var ledger2 = CreateTestLedger(TestCardIdm, today.AddDays(-5), "5日前", expense: 200);
+        ledger2.Balance = 9700;
+        var ledger3 = CreateTestLedger(TestCardIdm, today, "今日", expense: 300);
+        ledger3.Balance = 9400;
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+        await _repository.InsertAsync(ledger3);
+
+        // Act - 3日前より前の最新
+        var result = await _repository.GetLatestBeforeDateAsync(TestCardIdm, today.AddDays(-3));
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Summary.Should().Be("5日前");
+        result.Balance.Should().Be(9700);
+    }
+
+    /// <summary>
+    /// 該当データがない場合はnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetLatestBeforeDateAsync_NoData_ReturnsNull()
+    {
+        // Arrange
+        var today = DateTime.Today;
+        var ledger = CreateTestLedger(TestCardIdm, today, "今日", expense: 300);
+        await _repository.InsertAsync(ledger);
+
+        // Act - 1週間前より前のデータを検索
+        var result = await _repository.GetLatestBeforeDateAsync(TestCardIdm, today.AddDays(-7));
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetCarryoverBalanceAsync テスト
+
+    /// <summary>
+    /// 年度繰越残高を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetCarryoverBalanceAsync_WithData_ReturnsBalanceAtFiscalYearEnd()
+    {
+        // Arrange - 2023年度末（2024年3月31日）時点の残高
+        var ledger1 = CreateTestLedger(TestCardIdm, new DateTime(2024, 3, 25), "3月利用", expense: 500);
+        ledger1.Balance = 9500;
+        var ledger2 = CreateTestLedger(TestCardIdm, new DateTime(2024, 3, 31), "年度末利用", expense: 300);
+        ledger2.Balance = 9200;
+        var ledger3 = CreateTestLedger(TestCardIdm, new DateTime(2024, 4, 1), "新年度利用", expense: 200);
+        ledger3.Balance = 9000;
+
+        await _repository.InsertAsync(ledger1);
+        await _repository.InsertAsync(ledger2);
+        await _repository.InsertAsync(ledger3);
+
+        // Act
+        var result = await _repository.GetCarryoverBalanceAsync(TestCardIdm, 2023);
+
+        // Assert
+        result.Should().Be(9200);
+    }
+
+    /// <summary>
+    /// 該当年度のデータがない場合はnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetCarryoverBalanceAsync_NoData_ReturnsNull()
+    {
+        // Act - データがない年度
+        var result = await _repository.GetCarryoverBalanceAsync(TestCardIdm, 2020);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region InsertDetailAsync / InsertDetailsAsync テスト
+
+    /// <summary>
+    /// 利用詳細を登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertDetailAsync_ValidDetail_ReturnsTrue()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "鉄道（博多～天神）", expense: 260);
+        var ledgerId = await _repository.InsertAsync(ledger);
+
+        var detail = new LedgerDetail
+        {
+            LedgerId = ledgerId,
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 260,
+            Balance = 9740,
+            IsCharge = false,
+            IsBus = false
+        };
+
+        // Act
+        var result = await _repository.InsertDetailAsync(detail);
+
+        // Assert
+        result.Should().BeTrue();
+
+        // 詳細を含めて取得
+        var ledgerWithDetails = await _repository.GetByIdAsync(ledgerId);
+        ledgerWithDetails!.Details.Should().HaveCount(1);
+        ledgerWithDetails.Details[0].EntryStation.Should().Be("博多");
+        ledgerWithDetails.Details[0].ExitStation.Should().Be("天神");
+    }
+
+    /// <summary>
+    /// バス利用詳細を登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertDetailAsync_BusUsage_SavesCorrectly()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "バス（★）", expense: 200);
+        var ledgerId = await _repository.InsertAsync(ledger);
+
+        var detail = new LedgerDetail
+        {
+            LedgerId = ledgerId,
+            UseDate = DateTime.Today,
+            BusStops = "天神→博多駅",
+            Amount = 200,
+            Balance = 9800,
+            IsCharge = false,
+            IsBus = true
+        };
+
+        // Act
+        var result = await _repository.InsertDetailAsync(detail);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var ledgerWithDetails = await _repository.GetByIdAsync(ledgerId);
+        ledgerWithDetails!.Details.Should().HaveCount(1);
+        ledgerWithDetails.Details[0].IsBus.Should().BeTrue();
+        ledgerWithDetails.Details[0].BusStops.Should().Be("天神→博多駅");
+    }
+
+    /// <summary>
+    /// 複数の詳細を一括登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertDetailsAsync_MultipleDetails_SavesAll()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "複数利用", expense: 520);
+        var ledgerId = await _repository.InsertAsync(ledger);
+
+        var details = new List<LedgerDetail>
+        {
+            new()
+            {
+                UseDate = DateTime.Today.AddHours(9),
+                EntryStation = "博多",
+                ExitStation = "天神",
+                Amount = 260,
+                Balance = 9740
+            },
+            new()
+            {
+                UseDate = DateTime.Today.AddHours(18),
+                EntryStation = "天神",
+                ExitStation = "博多",
+                Amount = 260,
+                Balance = 9480
+            }
+        };
+
+        // Act
+        var result = await _repository.InsertDetailsAsync(ledgerId, details);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var ledgerWithDetails = await _repository.GetByIdAsync(ledgerId);
+        ledgerWithDetails!.Details.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// チャージ詳細を登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertDetailAsync_ChargeRecord_SavesCorrectly()
+    {
+        // Arrange
+        var ledger = CreateTestLedger(TestCardIdm, DateTime.Today, "チャージ", income: 3000);
+        var ledgerId = await _repository.InsertAsync(ledger);
+
+        var detail = new LedgerDetail
+        {
+            LedgerId = ledgerId,
+            UseDate = DateTime.Today,
+            Amount = 3000,
+            Balance = 13000,
+            IsCharge = true,
+            IsBus = false
+        };
+
+        // Act
+        var result = await _repository.InsertDetailAsync(detail);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var ledgerWithDetails = await _repository.GetByIdAsync(ledgerId);
+        ledgerWithDetails!.Details.Should().HaveCount(1);
+        ledgerWithDetails.Details[0].IsCharge.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private static Ledger CreateTestLedger(string cardIdm, DateTime date, string summary, int income = 0, int expense = 0)
+    {
+        return new Ledger
+        {
+            CardIdm = cardIdm,
+            Date = date,
+            Summary = summary,
+            Income = income,
+            Expense = expense,
+            Balance = 10000 - expense + income,
+            IsLentRecord = false
+        };
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/SettingsRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/SettingsRepositoryTests.cs
@@ -1,0 +1,366 @@
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Tests.Data;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Repositories;
+
+/// <summary>
+/// SettingsRepositoryの単体テスト
+/// </summary>
+public class SettingsRepositoryTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly SettingsRepository _repository;
+
+    public SettingsRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+        _repository = new SettingsRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region GetAsync テスト
+
+    /// <summary>
+    /// 存在するキーの値を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAsync_ExistingKey_ReturnsValue()
+    {
+        // Arrange - スキーマ初期化時にデフォルト値が設定される
+        // warning_balance = '10000', font_size = 'medium'
+
+        // Act
+        var result = await _repository.GetAsync(SettingsRepository.KeyWarningBalance);
+
+        // Assert
+        result.Should().Be("10000");
+    }
+
+    /// <summary>
+    /// 存在しないキーでnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAsync_NonExistingKey_ReturnsNull()
+    {
+        // Act
+        var result = await _repository.GetAsync("non_existing_key");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// font_sizeのデフォルト値を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAsync_FontSizeKey_ReturnsDefaultValue()
+    {
+        // Act
+        var result = await _repository.GetAsync(SettingsRepository.KeyFontSize);
+
+        // Assert
+        result.Should().Be("medium");
+    }
+
+    #endregion
+
+    #region SetAsync テスト
+
+    /// <summary>
+    /// 新しい設定を保存できることを確認
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_NewKey_SavesValue()
+    {
+        // Arrange
+        var key = "test_key";
+        var value = "test_value";
+
+        // Act
+        var result = await _repository.SetAsync(key, value);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var saved = await _repository.GetAsync(key);
+        saved.Should().Be(value);
+    }
+
+    /// <summary>
+    /// 既存の設定を更新できることを確認（UPSERT動作）
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_ExistingKey_UpdatesValue()
+    {
+        // Arrange - デフォルト値は10000
+        var newValue = "5000";
+
+        // Act
+        var result = await _repository.SetAsync(SettingsRepository.KeyWarningBalance, newValue);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetAsync(SettingsRepository.KeyWarningBalance);
+        updated.Should().Be(newValue);
+    }
+
+    /// <summary>
+    /// nullを保存できることを確認
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_NullValue_SavesNull()
+    {
+        // Arrange
+        var key = "nullable_key";
+
+        // Act
+        var result = await _repository.SetAsync(key, null);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var saved = await _repository.GetAsync(key);
+        saved.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 空文字を保存できることを確認
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_EmptyString_SavesEmptyString()
+    {
+        // Arrange
+        var key = "empty_key";
+
+        // Act
+        var result = await _repository.SetAsync(key, string.Empty);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var saved = await _repository.GetAsync(key);
+        saved.Should().Be(string.Empty);
+    }
+
+    #endregion
+
+    #region GetAppSettingsAsync テスト
+
+    /// <summary>
+    /// デフォルトのアプリ設定を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAppSettingsAsync_WithDefaults_ReturnsCorrectSettings()
+    {
+        // Act
+        var result = await _repository.GetAppSettingsAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.WarningBalance.Should().Be(10000); // デフォルト値
+        result.FontSize.Should().Be(FontSizeOption.Medium); // デフォルト値
+        result.BackupPath.Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// カスタム設定を取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAppSettingsAsync_WithCustomValues_ReturnsCustomSettings()
+    {
+        // Arrange
+        await _repository.SetAsync(SettingsRepository.KeyWarningBalance, "5000");
+        await _repository.SetAsync(SettingsRepository.KeyFontSize, "large");
+        await _repository.SetAsync(SettingsRepository.KeyBackupPath, @"C:\Backup");
+        await _repository.SetAsync(SettingsRepository.KeyLastVacuumDate, "2024-06-15");
+
+        // Act
+        var result = await _repository.GetAppSettingsAsync();
+
+        // Assert
+        result.WarningBalance.Should().Be(5000);
+        result.FontSize.Should().Be(FontSizeOption.Large);
+        result.BackupPath.Should().Be(@"C:\Backup");
+        result.LastVacuumDate.Should().Be(new DateTime(2024, 6, 15));
+    }
+
+    /// <summary>
+    /// 不正な残額警告値はAppSettingsのプロパティ初期値（10000）になることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAppSettingsAsync_InvalidWarningBalance_UsesPropertyDefault()
+    {
+        // Arrange
+        // 不正な値を設定（数値に変換できない文字列）
+        await _repository.SetAsync(SettingsRepository.KeyWarningBalance, "invalid");
+
+        // Act
+        var result = await _repository.GetAppSettingsAsync();
+
+        // Assert
+        // int.TryParseが失敗した場合、AppSettingsのプロパティ初期値（10000）が保持される
+        // AppSettings.WarningBalance { get; set; } = 10000 がデフォルト値
+        result.WarningBalance.Should().Be(10000);
+    }
+
+    /// <summary>
+    /// 各フォントサイズオプションが正しくパースされることを確認
+    /// </summary>
+    [Theory]
+    [InlineData("small", FontSizeOption.Small)]
+    [InlineData("medium", FontSizeOption.Medium)]
+    [InlineData("large", FontSizeOption.Large)]
+    [InlineData("xlarge", FontSizeOption.ExtraLarge)]
+    [InlineData("extralarge", FontSizeOption.ExtraLarge)]
+    [InlineData("SMALL", FontSizeOption.Small)] // 大文字小文字無視
+    [InlineData("invalid", FontSizeOption.Medium)] // 不正値はMedium
+    public async Task GetAppSettingsAsync_FontSizeOptions_ParsedCorrectly(string value, FontSizeOption expected)
+    {
+        // Arrange
+        await _repository.SetAsync(SettingsRepository.KeyFontSize, value);
+
+        // Act
+        var result = await _repository.GetAppSettingsAsync();
+
+        // Assert
+        result.FontSize.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region SaveAppSettingsAsync テスト
+
+    /// <summary>
+    /// アプリ設定を保存できることを確認
+    /// </summary>
+    [Fact]
+    public async Task SaveAppSettingsAsync_ValidSettings_SavesAllValues()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            WarningBalance = 3000,
+            FontSize = FontSizeOption.Large,
+            BackupPath = @"D:\MyBackup",
+            LastVacuumDate = new DateTime(2024, 7, 1)
+        };
+
+        // Act
+        var result = await _repository.SaveAppSettingsAsync(settings);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var loaded = await _repository.GetAppSettingsAsync();
+        loaded.WarningBalance.Should().Be(3000);
+        loaded.FontSize.Should().Be(FontSizeOption.Large);
+        loaded.BackupPath.Should().Be(@"D:\MyBackup");
+        loaded.LastVacuumDate.Should().Be(new DateTime(2024, 7, 1));
+    }
+
+    /// <summary>
+    /// LastVacuumDateがnullの場合は保存しないことを確認
+    /// </summary>
+    [Fact]
+    public async Task SaveAppSettingsAsync_NullLastVacuumDate_DoesNotSaveDate()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            WarningBalance = 5000,
+            FontSize = FontSizeOption.Small,
+            BackupPath = @"C:\Backup",
+            LastVacuumDate = null
+        };
+
+        // Act
+        var result = await _repository.SaveAppSettingsAsync(settings);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var lastVacuumDate = await _repository.GetAsync(SettingsRepository.KeyLastVacuumDate);
+        lastVacuumDate.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 各フォントサイズオプションが正しく文字列化されることを確認
+    /// </summary>
+    [Theory]
+    [InlineData(FontSizeOption.Small, "small")]
+    [InlineData(FontSizeOption.Medium, "medium")]
+    [InlineData(FontSizeOption.Large, "large")]
+    [InlineData(FontSizeOption.ExtraLarge, "xlarge")]
+    public async Task SaveAppSettingsAsync_FontSizeOptions_SerializedCorrectly(FontSizeOption option, string expected)
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            WarningBalance = 10000,
+            FontSize = option,
+            BackupPath = @"C:\Backup"
+        };
+
+        // Act
+        await _repository.SaveAppSettingsAsync(settings);
+
+        // Assert
+        var saved = await _repository.GetAsync(SettingsRepository.KeyFontSize);
+        saved.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// 設定の保存と読み込みのラウンドトリップを確認
+    /// </summary>
+    [Fact]
+    public async Task SaveAndLoadAppSettings_RoundTrip_PreservesAllValues()
+    {
+        // Arrange
+        var original = new AppSettings
+        {
+            WarningBalance = 7500,
+            FontSize = FontSizeOption.ExtraLarge,
+            BackupPath = @"E:\CustomBackup\ICCard",
+            LastVacuumDate = new DateTime(2024, 12, 25)
+        };
+
+        // Act
+        await _repository.SaveAppSettingsAsync(original);
+        var loaded = await _repository.GetAppSettingsAsync();
+
+        // Assert
+        loaded.WarningBalance.Should().Be(original.WarningBalance);
+        loaded.FontSize.Should().Be(original.FontSize);
+        loaded.BackupPath.Should().Be(original.BackupPath);
+        loaded.LastVacuumDate.Should().Be(original.LastVacuumDate);
+    }
+
+    #endregion
+
+    #region 設定キー定数テスト
+
+    /// <summary>
+    /// 設定キー定数が正しく定義されていることを確認
+    /// </summary>
+    [Fact]
+    public void SettingsKeys_AreDefinedCorrectly()
+    {
+        // Assert
+        SettingsRepository.KeyWarningBalance.Should().Be("warning_balance");
+        SettingsRepository.KeyBackupPath.Should().Be("backup_path");
+        SettingsRepository.KeyFontSize.Should().Be("font_size");
+        SettingsRepository.KeyLastVacuumDate.Should().Be("last_vacuum_date");
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/StaffRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/StaffRepositoryTests.cs
@@ -1,0 +1,478 @@
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Tests.Data;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Repositories;
+
+/// <summary>
+/// StaffRepositoryの単体テスト
+/// </summary>
+public class StaffRepositoryTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly StaffRepository _repository;
+
+    public StaffRepositoryTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+        _repository = new StaffRepository(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region GetAllAsync テスト
+
+    /// <summary>
+    /// 空のデータベースでは空のリストを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_EmptyDatabase_ReturnsEmptyList()
+    {
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 登録済み職員が正しく取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_WithStaff_ReturnsAllNonDeletedStaff()
+    {
+        // Arrange
+        var staff1 = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        var staff2 = CreateTestStaff("STAFF00000000002", "鈴木花子", "002");
+        await _repository.InsertAsync(staff1);
+        await _repository.InsertAsync(staff2);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(s => s.StaffIdm == staff1.StaffIdm);
+        result.Should().Contain(s => s.StaffIdm == staff2.StaffIdm);
+    }
+
+    /// <summary>
+    /// 結果が名前順でソートされていることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_ReturnsStaffSortedByName()
+    {
+        // Arrange
+        var staffYamada = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        var staffSuzuki = CreateTestStaff("STAFF00000000002", "鈴木花子", "002");
+        var staffSato = CreateTestStaff("STAFF00000000003", "佐藤一郎", "003");
+        await _repository.InsertAsync(staffYamada);
+        await _repository.InsertAsync(staffSuzuki);
+        await _repository.InsertAsync(staffSato);
+
+        // Act
+        var result = (await _repository.GetAllAsync()).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+        // SQLiteはUnicodeコードポイント順でソートされる（五十音順ではない）
+        // 佐(U+4F50) < 山(U+5C71) < 鈴(U+9234)
+        result[0].Name.Should().Be("佐藤一郎");
+        result[1].Name.Should().Be("山田太郎");
+        result[2].Name.Should().Be("鈴木花子");
+    }
+
+    /// <summary>
+    /// 論理削除された職員は取得されないことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetAllAsync_ExcludesDeletedStaff()
+    {
+        // Arrange
+        var staff1 = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        var staff2 = CreateTestStaff("STAFF00000000002", "鈴木花子", "002");
+        await _repository.InsertAsync(staff1);
+        await _repository.InsertAsync(staff2);
+        await _repository.DeleteAsync(staff2.StaffIdm);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result.First().StaffIdm.Should().Be(staff1.StaffIdm);
+    }
+
+    #endregion
+
+    #region GetByIdmAsync テスト
+
+    /// <summary>
+    /// 存在する職員をIDmで取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_ExistingStaff_ReturnsStaff()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.StaffIdm.Should().Be(staff.StaffIdm);
+        result.Name.Should().Be(staff.Name);
+        result.Number.Should().Be(staff.Number);
+    }
+
+    /// <summary>
+    /// 存在しない職員IDmでnullを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_NonExistingStaff_ReturnsNull()
+    {
+        // Act
+        var result = await _repository.GetByIdmAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 論理削除された職員はデフォルトで取得されないことを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_DeletedStaff_ReturnsNull()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+        await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// includeDeletedオプションで論理削除された職員も取得できることを確認
+    /// </summary>
+    [Fact]
+    public async Task GetByIdmAsync_DeletedStaff_WithIncludeDeleted_ReturnsStaff()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+        await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Act
+        var result = await _repository.GetByIdmAsync(staff.StaffIdm, includeDeleted: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.StaffIdm.Should().Be(staff.StaffIdm);
+        result.IsDeleted.Should().BeTrue();
+        result.DeletedAt.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region InsertAsync テスト
+
+    /// <summary>
+    /// 職員を正常に登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_ValidStaff_ReturnsTrue()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+
+        // Act
+        var result = await _repository.InsertAsync(staff);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var inserted = await _repository.GetByIdmAsync(staff.StaffIdm);
+        inserted.Should().NotBeNull();
+        inserted!.Name.Should().Be(staff.Name);
+        inserted.Number.Should().Be(staff.Number);
+    }
+
+    /// <summary>
+    /// 重複するIDmでの登録はエラーになることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_DuplicateIdm_ReturnsFalse()
+    {
+        // Arrange
+        var staff1 = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        var staff2 = CreateTestStaff("STAFF00000000001", "鈴木花子", "002"); // 同じIDm
+        await _repository.InsertAsync(staff1);
+
+        // Act
+        var result = await _repository.InsertAsync(staff2);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 職員番号がnullでも登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_WithNullNumber_SavesCorrectly()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", null);
+
+        // Act
+        var result = await _repository.InsertAsync(staff);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var inserted = await _repository.GetByIdmAsync(staff.StaffIdm);
+        inserted!.Number.Should().BeNull();
+    }
+
+    /// <summary>
+    /// メモ付き職員を登録できることを確認
+    /// </summary>
+    [Fact]
+    public async Task InsertAsync_WithNote_SavesNote()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        staff.Note = "テストメモ";
+
+        // Act
+        await _repository.InsertAsync(staff);
+
+        // Assert
+        var inserted = await _repository.GetByIdmAsync(staff.StaffIdm);
+        inserted!.Note.Should().Be("テストメモ");
+    }
+
+    #endregion
+
+    #region UpdateAsync テスト
+
+    /// <summary>
+    /// 職員情報を更新できることを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_ValidStaff_ReturnsTrue()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+
+        staff.Name = "山田次郎";
+        staff.Number = "999";
+        staff.Note = "更新テスト";
+
+        // Act
+        var result = await _repository.UpdateAsync(staff);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var updated = await _repository.GetByIdmAsync(staff.StaffIdm);
+        updated!.Name.Should().Be("山田次郎");
+        updated.Number.Should().Be("999");
+        updated.Note.Should().Be("更新テスト");
+    }
+
+    /// <summary>
+    /// 存在しない職員の更新はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_NonExistingStaff_ReturnsFalse()
+    {
+        // Arrange
+        var staff = CreateTestStaff("NOTEXISTINGIDM00", "山田太郎", "001");
+
+        // Act
+        var result = await _repository.UpdateAsync(staff);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 論理削除された職員は更新できないことを確認
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_DeletedStaff_ReturnsFalse()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+        await _repository.DeleteAsync(staff.StaffIdm);
+
+        staff.Name = "山田次郎";
+
+        // Act
+        var result = await _repository.UpdateAsync(staff);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 名前をnullに更新はできない（必須項目）
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_WithNullName_StillRequiresName()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+
+        // 更新後も名前が残っていることを確認
+        staff.Number = null;
+        await _repository.UpdateAsync(staff);
+
+        var updated = await _repository.GetByIdmAsync(staff.StaffIdm);
+        updated!.Name.Should().Be("山田太郎");
+        updated.Number.Should().BeNull();
+    }
+
+    #endregion
+
+    #region DeleteAsync テスト
+
+    /// <summary>
+    /// 職員を論理削除できることを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_ExistingStaff_ReturnsTrue()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+
+        // Act
+        var result = await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().BeTrue();
+
+        var deleted = await _repository.GetByIdmAsync(staff.StaffIdm, includeDeleted: true);
+        deleted!.IsDeleted.Should().BeTrue();
+        deleted.DeletedAt.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// 存在しない職員の削除はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_NonExistingStaff_ReturnsFalse()
+    {
+        // Act
+        var result = await _repository.DeleteAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 既に削除された職員の再削除はfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_AlreadyDeletedStaff_ReturnsFalse()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+        await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Act
+        var result = await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ExistsAsync テスト
+
+    /// <summary>
+    /// 存在する職員でtrueを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_ExistingStaff_ReturnsTrue()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+
+        // Act
+        var result = await _repository.ExistsAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 存在しない職員でfalseを返すことを確認
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_NonExistingStaff_ReturnsFalse()
+    {
+        // Act
+        var result = await _repository.ExistsAsync("NOTEXISTINGIDM00");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 論理削除された職員でもtrueを返すことを確認（物理的には存在する）
+    /// </summary>
+    [Fact]
+    public async Task ExistsAsync_DeletedStaff_ReturnsTrue()
+    {
+        // Arrange
+        var staff = CreateTestStaff("STAFF00000000001", "山田太郎", "001");
+        await _repository.InsertAsync(staff);
+        await _repository.DeleteAsync(staff.StaffIdm);
+
+        // Act
+        var result = await _repository.ExistsAsync(staff.StaffIdm);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private static Staff CreateTestStaff(string staffIdm, string name, string? number)
+    {
+        return new Staff
+        {
+            StaffIdm = staffIdm,
+            Name = name,
+            Number = number,
+            IsDeleted = false
+        };
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/TestDbContext.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/TestDbContext.cs
@@ -1,0 +1,20 @@
+namespace ICCardManager.Tests.Data;
+
+/// <summary>
+/// テスト用のDbContextファクトリ
+/// インメモリSQLiteを使用して、テスト毎に独立したデータベースを提供
+/// </summary>
+public static class TestDbContextFactory
+{
+    /// <summary>
+    /// テスト用のDbContextインスタンスを作成
+    /// インメモリSQLiteを使用し、初期化済みの状態で返す
+    /// </summary>
+    public static ICCardManager.Data.DbContext Create()
+    {
+        // インメモリSQLiteを使用
+        var dbContext = new ICCardManager.Data.DbContext(":memory:");
+        dbContext.InitializeDatabase();
+        return dbContext;
+    }
+}


### PR DESCRIPTION
## Summary
- Repository層の単体テストを94ケース追加
- インメモリSQLite（`:memory:`）を使用したテスト基盤を構築
- 4つのリポジトリ（Card, Staff, Ledger, Settings）をカバー

## 追加ファイル

| ファイル | 説明 | テストケース数 |
|----------|------|---------------|
| `TestDbContextFactory.cs` | テスト用DBコンテキスト生成 | - |
| `CardRepositoryTests.cs` | カードリポジトリのテスト | 28 |
| `StaffRepositoryTests.cs` | 職員リポジトリのテスト | 22 |
| `LedgerRepositoryTests.cs` | 利用履歴リポジトリのテスト | 20 |
| `SettingsRepositoryTests.cs` | 設定リポジトリのテスト | 24 |

## テストカバレッジ

### CardRepository
- ✅ `GetAllAsync` - 全件取得、論理削除除外
- ✅ `GetByIdmAsync` - IDm指定取得、includeDeleted対応
- ✅ `GetAvailableAsync` - 貸出可能カードのみ取得
- ✅ `GetLentAsync` - 貸出中カードのみ取得
- ✅ `InsertAsync` - 新規登録、重複チェック
- ✅ `UpdateAsync` - 更新、論理削除済み除外
- ✅ `UpdateLentStatusAsync` - 貸出/返却状態更新
- ✅ `DeleteAsync` - 論理削除、貸出中チェック
- ✅ `ExistsAsync` - 存在確認
- ✅ `GetNextCardNumberAsync` - 次番号採番

### StaffRepository
- ✅ `GetAllAsync` - 全件取得、名前ソート
- ✅ `GetByIdmAsync` - IDm指定取得
- ✅ `InsertAsync` - 新規登録
- ✅ `UpdateAsync` - 更新
- ✅ `DeleteAsync` - 論理削除
- ✅ `ExistsAsync` - 存在確認

### LedgerRepository
- ✅ `GetByDateRangeAsync` - 期間指定取得
- ✅ `GetByMonthAsync` - 月指定取得
- ✅ `GetByIdAsync` - ID指定取得（詳細含む）
- ✅ `GetLentRecordAsync` - 貸出中レコード取得
- ✅ `InsertAsync` - 新規登録
- ✅ `UpdateAsync` - 更新
- ✅ `InsertDetailAsync` - 詳細登録
- ✅ `InsertDetailsAsync` - 詳細一括登録
- ✅ `GetLatestBeforeDateAsync` - 指定日以前の最新取得
- ✅ `GetCarryoverBalanceAsync` - 年度繰越残高取得

### SettingsRepository
- ✅ `GetAsync` / `SetAsync` - KVS操作
- ✅ `GetAppSettingsAsync` - 設定読み込み
- ✅ `SaveAppSettingsAsync` - 設定保存
- ✅ フォントサイズ変換（Small/Medium/Large/ExtraLarge）
- ✅ 不正値時のデフォルト値復元

## Test plan
- [x] 全テストが成功することを確認（94件）
- [x] 既存テストに影響がないことを確認（全299件成功）
- [x] 外部キー制約が正しく動作することを確認
- [x] 論理削除の動作を確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)