### PR TITLE
fix: テストファイルをICacheService・IValidationService・DTOパターンに対応

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/CardRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/CardRepositoryTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
 using ICCardManager.Models;
 using ICCardManager.Tests.Data;
+using Moq;
 using Xunit;
 
 namespace ICCardManager.Tests.Data.Repositories;
@@ -13,6 +15,7 @@ namespace ICCardManager.Tests.Data.Repositories;
 public class CardRepositoryTests : IDisposable
 {
     private readonly DbContext _dbContext;
+    private readonly Mock<ICacheService> _cacheServiceMock;
     private readonly CardRepository _repository;
     private readonly StaffRepository _staffRepository;
 
@@ -23,8 +26,23 @@ public class CardRepositoryTests : IDisposable
     public CardRepositoryTests()
     {
         _dbContext = TestDbContextFactory.Create();
-        _repository = new CardRepository(_dbContext);
-        _staffRepository = new StaffRepository(_dbContext);
+        _cacheServiceMock = new Mock<ICacheService>();
+
+        // キャッシュをバイパスしてファクトリ関数を直接実行するよう設定
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<IcCard>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<IcCard>>> factory, TimeSpan expiration) => factory());
+
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<Staff>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<Staff>>> factory, TimeSpan expiration) => factory());
+
+        _repository = new CardRepository(_dbContext, _cacheServiceMock.Object);
+        _staffRepository = new StaffRepository(_dbContext, _cacheServiceMock.Object);
     }
 
     public void Dispose()

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerRepositoryTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
 using ICCardManager.Models;
 using ICCardManager.Tests.Data;
+using Moq;
 using Xunit;
 
 namespace ICCardManager.Tests.Data.Repositories;
@@ -13,6 +15,7 @@ namespace ICCardManager.Tests.Data.Repositories;
 public class LedgerRepositoryTests : IDisposable
 {
     private readonly DbContext _dbContext;
+    private readonly Mock<ICacheService> _cacheServiceMock;
     private readonly LedgerRepository _repository;
     private readonly CardRepository _cardRepository;
     private readonly StaffRepository _staffRepository;
@@ -25,9 +28,24 @@ public class LedgerRepositoryTests : IDisposable
     public LedgerRepositoryTests()
     {
         _dbContext = TestDbContextFactory.Create();
+        _cacheServiceMock = new Mock<ICacheService>();
+
+        // キャッシュをバイパスしてファクトリ関数を直接実行するよう設定
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<IcCard>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<IcCard>>> factory, TimeSpan expiration) => factory());
+
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<Staff>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<Staff>>> factory, TimeSpan expiration) => factory());
+
         _repository = new LedgerRepository(_dbContext);
-        _cardRepository = new CardRepository(_dbContext);
-        _staffRepository = new StaffRepository(_dbContext);
+        _cardRepository = new CardRepository(_dbContext, _cacheServiceMock.Object);
+        _staffRepository = new StaffRepository(_dbContext, _cacheServiceMock.Object);
 
         // テスト用データを事前登録（外部キー制約対応）
         SetupTestData().Wait();

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/StaffRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/StaffRepositoryTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
 using ICCardManager.Models;
 using ICCardManager.Tests.Data;
+using Moq;
 using Xunit;
 
 namespace ICCardManager.Tests.Data.Repositories;
@@ -13,12 +15,22 @@ namespace ICCardManager.Tests.Data.Repositories;
 public class StaffRepositoryTests : IDisposable
 {
     private readonly DbContext _dbContext;
+    private readonly Mock<ICacheService> _cacheServiceMock;
     private readonly StaffRepository _repository;
 
     public StaffRepositoryTests()
     {
         _dbContext = TestDbContextFactory.Create();
-        _repository = new StaffRepository(_dbContext);
+        _cacheServiceMock = new Mock<ICacheService>();
+
+        // キャッシュをバイパスしてファクトリ関数を直接実行するよう設定
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<Staff>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<Staff>>> factory, TimeSpan expiration) => factory());
+
+        _repository = new StaffRepository(_dbContext, _cacheServiceMock.Object);
     }
 
     public void Dispose()

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Models;
 using ICCardManager.ViewModels;
 using Moq;
@@ -87,7 +88,7 @@ public class HistoryViewModelTests
     public async Task InitializeAsync_ShouldSetCardAndLoadHistory()
     {
         // Arrange
-        var card = new IcCard { CardIdm = "01020304050607FF", CardType = "はやかけん", CardNumber = "H-001" };
+        var card = new CardDto { CardIdm = "01020304050607FF", CardType = "はやかけん", CardNumber = "H-001" };
         _ledgerRepositoryMock
             .Setup(r => r.GetByDateRangeAsync(card.CardIdm, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .ReturnsAsync(new List<Ledger>());
@@ -114,7 +115,7 @@ public class HistoryViewModelTests
     public async Task LoadHistoryAsync_ShouldLoadLedgersOrderedByDateDesc()
     {
         // Arrange
-        var card = new IcCard { CardIdm = "01020304050607FF" };
+        var card = new CardDto { CardIdm = "01020304050607FF", CardType = "test", CardNumber = "001" };
         _viewModel.Card = card;
 
         var ledgers = new List<Ledger>
@@ -165,7 +166,7 @@ public class HistoryViewModelTests
     public async Task LoadHistoryAsync_WithNoHistory_ShouldSetBalanceToZero()
     {
         // Arrange
-        var card = new IcCard { CardIdm = "01020304050607FF" };
+        var card = new CardDto { CardIdm = "01020304050607FF", CardType = "test", CardNumber = "001" };
         _viewModel.Card = card;
 
         _ledgerRepositoryMock
@@ -306,16 +307,16 @@ public class HistoryViewModelTests
 
     #endregion
 
-    #region LedgerDisplayItemテスト
+    #region LedgerDtoテスト
 
     /// <summary>
-    /// LedgerDisplayItemが正しく表示用データを生成すること
+    /// LedgerDtoが正しく表示用データを生成すること
     /// </summary>
     [Fact]
-    public void LedgerDisplayItem_ShouldFormatDataCorrectly()
+    public void LedgerDto_ShouldFormatDataCorrectly()
     {
         // Arrange
-        var ledger = new Ledger
+        var displayItem = new LedgerDto
         {
             Id = 1,
             CardIdm = "01020304050607FF",
@@ -328,14 +329,11 @@ public class HistoryViewModelTests
             Note = "テスト"
         };
 
-        // Act
-        var displayItem = new LedgerDisplayItem(ledger);
-
         // Assert
         displayItem.Id.Should().Be(1);
         displayItem.Date.Should().Be(new DateTime(2024, 6, 15));
         displayItem.Summary.Should().Be("鉄道（福岡空港駅～博多駅）");
-        displayItem.Income.Should().BeNull(); // 0の場合はnull
+        displayItem.HasIncome.Should().BeFalse();
         displayItem.Expense.Should().Be(260);
         displayItem.Balance.Should().Be(1240);
         displayItem.StaffName.Should().Be("田中太郎");
@@ -349,10 +347,10 @@ public class HistoryViewModelTests
     /// チャージ時の表示が正しいこと
     /// </summary>
     [Fact]
-    public void LedgerDisplayItem_WithIncome_ShouldShowIncomeDisplay()
+    public void LedgerDto_WithIncome_ShouldShowIncomeDisplay()
     {
         // Arrange
-        var ledger = new Ledger
+        var displayItem = new LedgerDto
         {
             Id = 2,
             CardIdm = "01020304050607FF",
@@ -363,12 +361,9 @@ public class HistoryViewModelTests
             Balance = 4000
         };
 
-        // Act
-        var displayItem = new LedgerDisplayItem(ledger);
-
         // Assert
         displayItem.Income.Should().Be(3000);
-        displayItem.Expense.Should().BeNull(); // 0の場合はnull
+        displayItem.HasExpense.Should().BeFalse();
         displayItem.IncomeDisplay.Should().Be("+3,000");
         displayItem.ExpenseDisplay.Should().BeEmpty();
     }

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using FluentAssertions;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
 using ICCardManager.Models;
 using ICCardManager.Services;
 using ICCardManager.ViewModels;
@@ -266,7 +267,7 @@ public class ReportViewModelTests
     public async Task CreateReportAsync_WithEmptyOutputFolder_ShouldShowError()
     {
         // Arrange
-        var card = new IcCard { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" };
+        var card = new CardDto { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" };
         _viewModel.SelectedCards.Add(card);
         _viewModel.OutputFolder = "";
 
@@ -284,7 +285,7 @@ public class ReportViewModelTests
     public async Task CreateReportAsync_WithNonExistentFolder_ShouldShowError()
     {
         // Arrange
-        var card = new IcCard { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" };
+        var card = new CardDto { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" };
         _viewModel.SelectedCards.Add(card);
         _viewModel.OutputFolder = @"C:\NonExistentFolder12345";
 


### PR DESCRIPTION
## Summary
- Issue #8（バリデーションサービス）、Issue #9（DTOパターン）、Issue #10（キャッシュ戦略）で導入された変更に対応するため、テストファイルを更新
- これにより、mainブランチでのビルドとテストが正常に通るようになります

## 変更内容

### Repository系テスト
- `ICacheService`モックにキャッシュバイパス設定を追加
  - `GetOrCreateAsync`が呼ばれた際にファクトリ関数を直接実行するよう設定

### ViewModel系テスト
- `IValidationService`モックを追加
- Model型（`IcCard`、`Staff`）をDTO型（`CardDto`、`StaffDto`）に変更
- `LedgerDisplayItem`を`LedgerDto`に変更

### バリデーションエラーテスト
- 空の入力値や無効な値に対して`ValidationResult.Failure()`を返すようモック設定を追加

## Test plan
- [x] `dotnet build` - ビルド成功
- [x] `dotnet test` - 全610テスト成功

## 対象ファイル（10ファイル）
- `DbContextCleanupTests.cs`
- `CardRepositoryTests.cs`
- `LedgerRepositoryTests.cs`
- `SettingsRepositoryTests.cs`
- `StaffRepositoryTests.cs`
- `CardManageViewModelTests.cs`
- `HistoryViewModelTests.cs`
- `ReportViewModelTests.cs`
- `SettingsViewModelTests.cs`
- `StaffManageViewModelTests.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)