### PR TITLE
feat: 印刷プレビュー機能の追加 (Issue #17)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -113,6 +113,7 @@ public partial class App : Application
         services.AddSingleton<SummaryGenerator>();
         services.AddSingleton<LendingService>();
         services.AddSingleton<ReportService>();
+        services.AddSingleton<PrintService>();
         services.AddSingleton<BackupService>();
         services.AddSingleton<OperationLogger>();
 
@@ -133,6 +134,7 @@ public partial class App : Application
         services.AddTransient<ReportViewModel>();
         services.AddTransient<HistoryViewModel>();
         services.AddTransient<BusStopInputViewModel>();
+        services.AddTransient<PrintPreviewViewModel>();
 
         // Views
         services.AddTransient<MainWindow>();
@@ -142,6 +144,7 @@ public partial class App : Application
         services.AddTransient<Views.Dialogs.ReportDialog>();
         services.AddTransient<Views.Dialogs.HistoryDialog>();
         services.AddTransient<Views.Dialogs.BusStopInputDialog>();
+        services.AddTransient<Views.Dialogs.PrintPreviewDialog>();
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Common/OrientationToDisplayNameConverter.cs
+++ b/ICCardManager/src/ICCardManager/Common/OrientationToDisplayNameConverter.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using System.Printing;
+using System.Windows.Data;
+
+namespace ICCardManager.Common;
+
+/// <summary>
+/// PageOrientationを日本語表示名に変換するコンバーター
+/// </summary>
+public class OrientationToDisplayNameConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is PageOrientation orientation)
+        {
+            return orientation switch
+            {
+                PageOrientation.Landscape => "横向き（A4横）",
+                PageOrientation.Portrait => "縦向き（A4縦）",
+                PageOrientation.ReverseLandscape => "横向き（逆）",
+                PageOrientation.ReversePortrait => "縦向き（逆）",
+                _ => orientation.ToString()
+            };
+        }
+
+        return value?.ToString() ?? string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -1,0 +1,467 @@
+using System.Printing;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using ICCardManager.Common;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+
+namespace ICCardManager.Services;
+
+/// <summary>
+/// 帳票印刷用データ
+/// </summary>
+public record ReportPrintData
+{
+    /// <summary>カード種別</summary>
+    public string CardType { get; init; } = string.Empty;
+
+    /// <summary>管理番号</summary>
+    public string CardNumber { get; init; } = string.Empty;
+
+    /// <summary>年</summary>
+    public int Year { get; init; }
+
+    /// <summary>月</summary>
+    public int Month { get; init; }
+
+    /// <summary>和暦年月</summary>
+    public string WarekiYearMonth { get; init; } = string.Empty;
+
+    /// <summary>履歴データ</summary>
+    public List<ReportPrintRow> Rows { get; init; } = new();
+
+    /// <summary>月計</summary>
+    public ReportPrintTotal MonthlyTotal { get; init; } = new();
+
+    /// <summary>累計（3月のみ）</summary>
+    public ReportPrintTotal? CumulativeTotal { get; init; }
+
+    /// <summary>次年度繰越（3月のみ）</summary>
+    public int? CarryoverToNextYear { get; init; }
+}
+
+/// <summary>
+/// 帳票印刷用行データ
+/// </summary>
+public class ReportPrintRow
+{
+    /// <summary>日付表示</summary>
+    public string DateDisplay { get; init; } = string.Empty;
+
+    /// <summary>摘要</summary>
+    public string Summary { get; init; } = string.Empty;
+
+    /// <summary>受入金額</summary>
+    public int? Income { get; init; }
+
+    /// <summary>払出金額</summary>
+    public int? Expense { get; init; }
+
+    /// <summary>残額</summary>
+    public int? Balance { get; init; }
+
+    /// <summary>利用者</summary>
+    public string? StaffName { get; init; }
+
+    /// <summary>備考</summary>
+    public string? Note { get; init; }
+
+    /// <summary>太字表示するか</summary>
+    public bool IsBold { get; init; }
+}
+
+/// <summary>
+/// 帳票印刷用合計データ
+/// </summary>
+public class ReportPrintTotal
+{
+    /// <summary>ラベル</summary>
+    public string Label { get; init; } = string.Empty;
+
+    /// <summary>受入合計</summary>
+    public int Income { get; init; }
+
+    /// <summary>払出合計</summary>
+    public int Expense { get; init; }
+
+    /// <summary>残高</summary>
+    public int? Balance { get; init; }
+}
+
+/// <summary>
+/// 印刷サービス
+/// </summary>
+public class PrintService
+{
+    private readonly ICardRepository _cardRepository;
+    private readonly ILedgerRepository _ledgerRepository;
+
+    public PrintService(
+        ICardRepository cardRepository,
+        ILedgerRepository ledgerRepository)
+    {
+        _cardRepository = cardRepository;
+        _ledgerRepository = ledgerRepository;
+    }
+
+    /// <summary>
+    /// 帳票データを取得
+    /// </summary>
+    public async Task<ReportPrintData?> GetReportDataAsync(string cardIdm, int year, int month)
+    {
+        var card = await _cardRepository.GetByIdmAsync(cardIdm, includeDeleted: true);
+        if (card == null)
+        {
+            return null;
+        }
+
+        var ledgers = (await _ledgerRepository.GetByMonthAsync(cardIdm, year, month))
+            .Where(l => l.Summary != SummaryGenerator.GetLendingSummary())
+            .OrderBy(l => l.Date)
+            .ThenBy(l => l.Id)
+            .ToList();
+
+        var targetDate = new DateTime(year, month, 1);
+        var warekiYearMonth = WarekiConverter.ToWarekiYearMonth(targetDate);
+
+        var rows = new List<ReportPrintRow>();
+
+        // 4月の場合は前年度繰越を追加
+        if (month == 4)
+        {
+            var carryover = await _ledgerRepository.GetCarryoverBalanceAsync(cardIdm, year - 1);
+            rows.Add(new ReportPrintRow
+            {
+                DateDisplay = "4/1",
+                Summary = SummaryGenerator.GetCarryoverFromPreviousYearSummary(),
+                Income = carryover ?? 0,
+                Balance = carryover ?? 0,
+                IsBold = true
+            });
+        }
+
+        // 各履歴行
+        foreach (var ledger in ledgers)
+        {
+            rows.Add(new ReportPrintRow
+            {
+                DateDisplay = $"{ledger.Date.Month}/{ledger.Date.Day}",
+                Summary = ledger.Summary,
+                Income = ledger.Income > 0 ? ledger.Income : null,
+                Expense = ledger.Expense > 0 ? ledger.Expense : null,
+                Balance = ledger.Balance,
+                StaffName = ledger.StaffName,
+                Note = ledger.Note
+            });
+        }
+
+        var monthlyIncome = ledgers.Sum(l => l.Income);
+        var monthlyExpense = ledgers.Sum(l => l.Expense);
+        var monthEndBalance = ledgers.LastOrDefault()?.Balance ?? 0;
+
+        var result = new ReportPrintData
+        {
+            CardType = card.CardType,
+            CardNumber = card.CardNumber,
+            Year = year,
+            Month = month,
+            WarekiYearMonth = warekiYearMonth,
+            Rows = rows,
+            MonthlyTotal = new ReportPrintTotal
+            {
+                Label = SummaryGenerator.GetMonthlySummary(month),
+                Income = monthlyIncome,
+                Expense = monthlyExpense,
+                Balance = month == 3 ? null : monthEndBalance
+            }
+        };
+
+        // 3月の場合は累計と次年度繰越を追加
+        if (month == 3)
+        {
+            var fiscalYearStart = new DateTime(year, 4, 1);
+            var fiscalYearEnd = new DateTime(year + 1, 3, 31);
+            var yearlyLedgers = await _ledgerRepository.GetByDateRangeAsync(cardIdm, fiscalYearStart, fiscalYearEnd);
+
+            var yearlyIncome = yearlyLedgers.Sum(l => l.Income);
+            var yearlyExpense = yearlyLedgers.Sum(l => l.Expense);
+
+            result = result with
+            {
+                CumulativeTotal = new ReportPrintTotal
+                {
+                    Label = SummaryGenerator.GetCumulativeSummary(),
+                    Income = yearlyIncome,
+                    Expense = yearlyExpense,
+                    Balance = monthEndBalance
+                },
+                CarryoverToNextYear = monthEndBalance
+            };
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// FlowDocumentを生成
+    /// </summary>
+    public FlowDocument CreateFlowDocument(ReportPrintData data)
+    {
+        var doc = new FlowDocument
+        {
+            PageWidth = 842,  // A4横 (約29.7cm)
+            PageHeight = 595, // A4横 (約21cm)
+            PagePadding = new Thickness(50),
+            ColumnWidth = double.MaxValue,
+            FontFamily = new FontFamily("Yu Gothic UI, Meiryo, MS Gothic"),
+            FontSize = 11
+        };
+
+        // タイトル
+        var titlePara = new Paragraph(new Run("物品出納簿"))
+        {
+            FontSize = 18,
+            FontWeight = FontWeights.Bold,
+            TextAlignment = TextAlignment.Center,
+            Margin = new Thickness(0, 0, 0, 20)
+        };
+        doc.Blocks.Add(titlePara);
+
+        // ヘッダ情報
+        var headerTable = CreateHeaderTable(data);
+        doc.Blocks.Add(headerTable);
+
+        // データテーブル
+        var dataTable = CreateDataTable(data);
+        doc.Blocks.Add(dataTable);
+
+        return doc;
+    }
+
+    /// <summary>
+    /// ヘッダテーブルを作成
+    /// </summary>
+    private Table CreateHeaderTable(ReportPrintData data)
+    {
+        var table = new Table
+        {
+            CellSpacing = 0,
+            Margin = new Thickness(0, 0, 0, 15)
+        };
+
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+        table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+        table.Columns.Add(new TableColumn { Width = new GridLength(100) });
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });
+        table.Columns.Add(new TableColumn { Width = new GridLength(150) });
+
+        var rowGroup = new TableRowGroup();
+        var row = new TableRow();
+
+        row.Cells.Add(CreateHeaderCell("物品分類:", false));
+        row.Cells.Add(CreateHeaderCell("雑品（金券類）", true));
+        row.Cells.Add(CreateHeaderCell("品名:", false));
+        row.Cells.Add(CreateHeaderCell(data.CardType, true));
+        row.Cells.Add(CreateHeaderCell("規格:", false));
+        row.Cells.Add(CreateHeaderCell(data.CardNumber, true));
+
+        rowGroup.Rows.Add(row);
+
+        var row2 = new TableRow();
+        row2.Cells.Add(CreateHeaderCell("年月:", false));
+        row2.Cells.Add(CreateHeaderCell(data.WarekiYearMonth, true));
+        row2.Cells.Add(CreateHeaderCell("単位:", false));
+        row2.Cells.Add(CreateHeaderCell("円", true));
+        row2.Cells.Add(CreateHeaderCell("", false));
+        row2.Cells.Add(CreateHeaderCell("", false));
+
+        rowGroup.Rows.Add(row2);
+        table.RowGroups.Add(rowGroup);
+
+        return table;
+    }
+
+    /// <summary>
+    /// ヘッダセルを作成
+    /// </summary>
+    private TableCell CreateHeaderCell(string text, bool isBold)
+    {
+        var cell = new TableCell(new Paragraph(new Run(text))
+        {
+            Margin = new Thickness(2)
+        });
+
+        if (isBold)
+        {
+            cell.FontWeight = FontWeights.Bold;
+        }
+
+        return cell;
+    }
+
+    /// <summary>
+    /// データテーブルを作成
+    /// </summary>
+    private Table CreateDataTable(ReportPrintData data)
+    {
+        var table = new Table
+        {
+            CellSpacing = 0,
+            BorderBrush = Brushes.Black,
+            BorderThickness = new Thickness(1)
+        };
+
+        // 列定義
+        table.Columns.Add(new TableColumn { Width = new GridLength(60) });   // 日付
+        table.Columns.Add(new TableColumn { Width = new GridLength(200) });  // 摘要
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });   // 受入
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });   // 払出
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });   // 残高
+        table.Columns.Add(new TableColumn { Width = new GridLength(80) });   // 氏名
+        table.Columns.Add(new TableColumn { Width = new GridLength(100) });  // 備考
+
+        var rowGroup = new TableRowGroup();
+
+        // ヘッダ行
+        var headerRow = new TableRow { Background = Brushes.LightGray };
+        headerRow.Cells.Add(CreateDataCell("出納日", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("摘要", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("受入金額", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("払出金額", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("残額", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("氏名", true, TextAlignment.Center));
+        headerRow.Cells.Add(CreateDataCell("備考", true, TextAlignment.Center));
+        rowGroup.Rows.Add(headerRow);
+
+        // データ行
+        foreach (var row in data.Rows)
+        {
+            var dataRow = new TableRow();
+            dataRow.Cells.Add(CreateDataCell(row.DateDisplay, row.IsBold, TextAlignment.Center));
+            dataRow.Cells.Add(CreateDataCell(row.Summary, row.IsBold, TextAlignment.Left));
+            dataRow.Cells.Add(CreateDataCell(row.Income?.ToString("N0") ?? "", row.IsBold, TextAlignment.Right));
+            dataRow.Cells.Add(CreateDataCell(row.Expense?.ToString("N0") ?? "", row.IsBold, TextAlignment.Right));
+            dataRow.Cells.Add(CreateDataCell(row.Balance?.ToString("N0") ?? "", row.IsBold, TextAlignment.Right));
+            dataRow.Cells.Add(CreateDataCell(row.StaffName ?? "", row.IsBold, TextAlignment.Left));
+            dataRow.Cells.Add(CreateDataCell(row.Note ?? "", row.IsBold, TextAlignment.Left));
+            rowGroup.Rows.Add(dataRow);
+        }
+
+        // 月計行
+        var monthlyRow = new TableRow { Background = new SolidColorBrush(Color.FromRgb(240, 240, 240)) };
+        monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Center));
+        monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Label, true, TextAlignment.Left));
+        monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Income > 0 ? data.MonthlyTotal.Income.ToString("N0") : "", true, TextAlignment.Right));
+        monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Expense > 0 ? data.MonthlyTotal.Expense.ToString("N0") : "", true, TextAlignment.Right));
+        monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Balance?.ToString("N0") ?? "", true, TextAlignment.Right));
+        monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+        monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+        rowGroup.Rows.Add(monthlyRow);
+
+        // 累計行（3月のみ）
+        if (data.CumulativeTotal != null)
+        {
+            var cumulativeRow = new TableRow { Background = new SolidColorBrush(Color.FromRgb(230, 230, 230)) };
+            cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Center));
+            cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Label, true, TextAlignment.Left));
+            cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Income > 0 ? data.CumulativeTotal.Income.ToString("N0") : "", true, TextAlignment.Right));
+            cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Expense > 0 ? data.CumulativeTotal.Expense.ToString("N0") : "", true, TextAlignment.Right));
+            cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Balance?.ToString("N0") ?? "", true, TextAlignment.Right));
+            cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+            cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+            rowGroup.Rows.Add(cumulativeRow);
+        }
+
+        // 次年度繰越行（3月のみ）
+        if (data.CarryoverToNextYear.HasValue)
+        {
+            var carryoverRow = new TableRow { Background = new SolidColorBrush(Color.FromRgb(220, 220, 220)) };
+            carryoverRow.Cells.Add(CreateDataCell("", true, TextAlignment.Center));
+            carryoverRow.Cells.Add(CreateDataCell(SummaryGenerator.GetCarryoverToNextYearSummary(), true, TextAlignment.Left));
+            carryoverRow.Cells.Add(CreateDataCell("", true, TextAlignment.Right));
+            carryoverRow.Cells.Add(CreateDataCell(data.CarryoverToNextYear.Value.ToString("N0"), true, TextAlignment.Right));
+            carryoverRow.Cells.Add(CreateDataCell("0", true, TextAlignment.Right));
+            carryoverRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+            carryoverRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
+            rowGroup.Rows.Add(carryoverRow);
+        }
+
+        table.RowGroups.Add(rowGroup);
+        return table;
+    }
+
+    /// <summary>
+    /// データセルを作成
+    /// </summary>
+    private TableCell CreateDataCell(string text, bool isBold, TextAlignment alignment)
+    {
+        var para = new Paragraph(new Run(text))
+        {
+            TextAlignment = alignment,
+            Margin = new Thickness(4, 2, 4, 2)
+        };
+
+        var cell = new TableCell(para)
+        {
+            BorderBrush = Brushes.Black,
+            BorderThickness = new Thickness(0.5)
+        };
+
+        if (isBold)
+        {
+            cell.FontWeight = FontWeights.Bold;
+        }
+
+        return cell;
+    }
+
+    /// <summary>
+    /// 印刷を実行
+    /// </summary>
+    public bool Print(FlowDocument document, string documentName)
+    {
+        var printDialog = new PrintDialog();
+
+        if (printDialog.ShowDialog() == true)
+        {
+            // ページ設定
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+
+            var paginator = ((IDocumentPaginatorSource)document).DocumentPaginator;
+            printDialog.PrintDocument(paginator, documentName);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 印刷設定付きで印刷を実行
+    /// </summary>
+    public bool PrintWithSettings(FlowDocument document, string documentName, PageOrientation orientation)
+    {
+        var printDialog = new PrintDialog();
+
+        // 用紙方向を設定
+        printDialog.PrintTicket.PageOrientation = orientation;
+
+        if (printDialog.ShowDialog() == true)
+        {
+            // ページ設定
+            document.PageWidth = printDialog.PrintableAreaWidth;
+            document.PageHeight = printDialog.PrintableAreaHeight;
+
+            var paginator = ((IDocumentPaginatorSource)document).DocumentPaginator;
+            printDialog.PrintDocument(paginator, documentName);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/PrintPreviewViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/PrintPreviewViewModel.cs
@@ -1,0 +1,290 @@
+using System.Printing;
+using System.Windows.Documents;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ICCardManager.Services;
+
+namespace ICCardManager.ViewModels;
+
+/// <summary>
+/// 印刷プレビューViewModel
+/// </summary>
+public partial class PrintPreviewViewModel : ViewModelBase
+{
+    private readonly PrintService _printService;
+
+    [ObservableProperty]
+    private FlowDocument? _document;
+
+    [ObservableProperty]
+    private string _documentTitle = string.Empty;
+
+    [ObservableProperty]
+    private double _zoomLevel = 100;
+
+    [ObservableProperty]
+    private int _currentPage = 1;
+
+    [ObservableProperty]
+    private int _totalPages = 1;
+
+    [ObservableProperty]
+    private PageOrientation _selectedOrientation = PageOrientation.Landscape;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    /// <summary>
+    /// ズーム倍率の選択肢
+    /// </summary>
+    public double[] ZoomLevels { get; } = { 50, 75, 100, 125, 150, 200 };
+
+    /// <summary>
+    /// 用紙方向の選択肢
+    /// </summary>
+    public PageOrientation[] Orientations { get; } =
+    {
+        PageOrientation.Landscape,
+        PageOrientation.Portrait
+    };
+
+    /// <summary>
+    /// 最初のページかどうか
+    /// </summary>
+    public bool IsFirstPage => CurrentPage <= 1;
+
+    /// <summary>
+    /// 最後のページかどうか
+    /// </summary>
+    public bool IsLastPage => CurrentPage >= TotalPages;
+
+    /// <summary>
+    /// ページ表示テキスト
+    /// </summary>
+    public string PageDisplayText => TotalPages > 0
+        ? $"{CurrentPage} / {TotalPages} ページ"
+        : "ページなし";
+
+    /// <summary>
+    /// 用紙方向の表示名を取得
+    /// </summary>
+    public static string GetOrientationDisplayName(PageOrientation orientation)
+    {
+        return orientation switch
+        {
+            PageOrientation.Landscape => "横向き（A4横）",
+            PageOrientation.Portrait => "縦向き（A4縦）",
+            _ => orientation.ToString()
+        };
+    }
+
+    public PrintPreviewViewModel(PrintService printService)
+    {
+        _printService = printService;
+    }
+
+    /// <summary>
+    /// ドキュメントを設定
+    /// </summary>
+    public void SetDocument(FlowDocument document, string title)
+    {
+        Document = document;
+        DocumentTitle = title;
+        CurrentPage = 1;
+        UpdatePageCount();
+        StatusMessage = $"「{title}」を表示中";
+    }
+
+    /// <summary>
+    /// ページ数を更新
+    /// </summary>
+    private void UpdatePageCount()
+    {
+        if (Document != null)
+        {
+            var paginator = ((IDocumentPaginatorSource)Document).DocumentPaginator;
+
+            // ページ数計算のためにコンテンツサイズを設定
+            paginator.PageSize = new System.Windows.Size(
+                Document.PageWidth,
+                Document.PageHeight);
+
+            TotalPages = paginator.PageCount > 0 ? paginator.PageCount : 1;
+        }
+        else
+        {
+            TotalPages = 0;
+        }
+
+        OnPropertyChanged(nameof(PageDisplayText));
+        OnPropertyChanged(nameof(IsFirstPage));
+        OnPropertyChanged(nameof(IsLastPage));
+    }
+
+    partial void OnCurrentPageChanged(int value)
+    {
+        OnPropertyChanged(nameof(PageDisplayText));
+        OnPropertyChanged(nameof(IsFirstPage));
+        OnPropertyChanged(nameof(IsLastPage));
+    }
+
+    partial void OnTotalPagesChanged(int value)
+    {
+        OnPropertyChanged(nameof(PageDisplayText));
+        OnPropertyChanged(nameof(IsFirstPage));
+        OnPropertyChanged(nameof(IsLastPage));
+    }
+
+    /// <summary>
+    /// 次のページへ
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanGoNextPage))]
+    private void NextPage()
+    {
+        if (CurrentPage < TotalPages)
+        {
+            CurrentPage++;
+        }
+    }
+
+    private bool CanGoNextPage() => !IsLastPage;
+
+    /// <summary>
+    /// 前のページへ
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanGoPreviousPage))]
+    private void PreviousPage()
+    {
+        if (CurrentPage > 1)
+        {
+            CurrentPage--;
+        }
+    }
+
+    private bool CanGoPreviousPage() => !IsFirstPage;
+
+    /// <summary>
+    /// 最初のページへ
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanGoFirstPage))]
+    private void FirstPage()
+    {
+        CurrentPage = 1;
+    }
+
+    private bool CanGoFirstPage() => !IsFirstPage;
+
+    /// <summary>
+    /// 最後のページへ
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanGoLastPage))]
+    private void LastPage()
+    {
+        CurrentPage = TotalPages;
+    }
+
+    private bool CanGoLastPage() => !IsLastPage;
+
+    /// <summary>
+    /// ズームイン
+    /// </summary>
+    [RelayCommand]
+    private void ZoomIn()
+    {
+        var currentIndex = Array.IndexOf(ZoomLevels, ZoomLevel);
+        if (currentIndex < ZoomLevels.Length - 1)
+        {
+            ZoomLevel = ZoomLevels[currentIndex + 1];
+        }
+        else if (currentIndex == -1)
+        {
+            // 現在の値がリストにない場合、次に大きい値を選択
+            var nextLevel = ZoomLevels.FirstOrDefault(z => z > ZoomLevel);
+            if (nextLevel > 0)
+            {
+                ZoomLevel = nextLevel;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ズームアウト
+    /// </summary>
+    [RelayCommand]
+    private void ZoomOut()
+    {
+        var currentIndex = Array.IndexOf(ZoomLevels, ZoomLevel);
+        if (currentIndex > 0)
+        {
+            ZoomLevel = ZoomLevels[currentIndex - 1];
+        }
+        else if (currentIndex == -1)
+        {
+            // 現在の値がリストにない場合、次に小さい値を選択
+            var prevLevel = ZoomLevels.LastOrDefault(z => z < ZoomLevel);
+            if (prevLevel > 0)
+            {
+                ZoomLevel = prevLevel;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 100%にリセット
+    /// </summary>
+    [RelayCommand]
+    private void ResetZoom()
+    {
+        ZoomLevel = 100;
+    }
+
+    /// <summary>
+    /// 印刷を実行
+    /// </summary>
+    [RelayCommand]
+    private void Print()
+    {
+        if (Document == null)
+        {
+            StatusMessage = "印刷するドキュメントがありません";
+            return;
+        }
+
+        var result = _printService.PrintWithSettings(Document, DocumentTitle, SelectedOrientation);
+
+        if (result)
+        {
+            StatusMessage = "印刷を開始しました";
+        }
+        else
+        {
+            StatusMessage = "印刷がキャンセルされました";
+        }
+    }
+
+    /// <summary>
+    /// 用紙方向変更時の処理
+    /// </summary>
+    partial void OnSelectedOrientationChanged(PageOrientation value)
+    {
+        if (Document != null)
+        {
+            // A4サイズに基づいて用紙サイズを更新
+            if (value == PageOrientation.Landscape)
+            {
+                Document.PageWidth = 842;   // A4横 (約29.7cm)
+                Document.PageHeight = 595;  // A4横 (約21cm)
+            }
+            else
+            {
+                Document.PageWidth = 595;   // A4縦 (約21cm)
+                Document.PageHeight = 842;  // A4縦 (約29.7cm)
+            }
+
+            UpdatePageCount();
+
+            var orientationName = GetOrientationDisplayName(value);
+            StatusMessage = $"用紙方向を{orientationName}に変更しました";
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml
@@ -1,0 +1,236 @@
+<Window x:Class="ICCardManager.Views.Dialogs.PrintPreviewDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        xmlns:common="clr-namespace:ICCardManager.Common"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:PrintPreviewViewModel}"
+        Title="{Binding DocumentTitle, StringFormat='印刷プレビュー - {0}'}"
+        Height="700"
+        Width="950"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        AutomationProperties.Name="印刷プレビューダイアログ"
+        AutomationProperties.HelpText="帳票の印刷プレビューを表示します。ズームやページ送りができます。">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <common:OrientationToDisplayNameConverter x:Key="OrientationConverter"/>
+    </Window.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- ツールバー -->
+        <Border Grid.Row="0" Background="#F0F0F0" Padding="10" BorderBrush="#CCCCCC" BorderThickness="0,0,0,1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- ズームコントロール -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Margin="0,0,20,0">
+                    <TextBlock Text="ズーム:"
+                               VerticalAlignment="Center"
+                               Margin="0,0,10,0"/>
+                    <Button Content="−"
+                            Command="{Binding ZoomOutCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="16"
+                            FontWeight="Bold"
+                            ToolTip="縮小"
+                            AutomationProperties.Name="ズーム縮小"/>
+                    <ComboBox ItemsSource="{Binding ZoomLevels}"
+                              SelectedItem="{Binding ZoomLevel}"
+                              Width="80"
+                              Height="28"
+                              Margin="5,0"
+                              VerticalContentAlignment="Center"
+                              AutomationProperties.Name="ズーム倍率">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding StringFormat={}{0}%}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <Button Content="＋"
+                            Command="{Binding ZoomInCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="16"
+                            FontWeight="Bold"
+                            ToolTip="拡大"
+                            AutomationProperties.Name="ズーム拡大"/>
+                    <Button Content="100%"
+                            Command="{Binding ResetZoomCommand}"
+                            Height="28"
+                            Padding="10,0"
+                            Margin="10,0,0,0"
+                            ToolTip="100%にリセット"
+                            AutomationProperties.Name="ズームリセット"/>
+                </StackPanel>
+
+                <!-- ページナビゲーション -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,20,0">
+                    <TextBlock Text="ページ:"
+                               VerticalAlignment="Center"
+                               Margin="0,0,10,0"/>
+                    <Button Content="⏮"
+                            Command="{Binding FirstPageCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="12"
+                            ToolTip="最初のページ"
+                            AutomationProperties.Name="最初のページ"/>
+                    <Button Content="◀"
+                            Command="{Binding PreviousPageCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="12"
+                            Margin="2,0"
+                            ToolTip="前のページ"
+                            AutomationProperties.Name="前のページ"/>
+                    <Border Background="White"
+                            BorderBrush="#CCCCCC"
+                            BorderThickness="1"
+                            Padding="10,4"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="{Binding PageDisplayText}"
+                                   FontWeight="Bold"
+                                   AutomationProperties.LiveSetting="Polite"/>
+                    </Border>
+                    <Button Content="▶"
+                            Command="{Binding NextPageCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="12"
+                            Margin="2,0"
+                            ToolTip="次のページ"
+                            AutomationProperties.Name="次のページ"/>
+                    <Button Content="⏭"
+                            Command="{Binding LastPageCommand}"
+                            Width="30"
+                            Height="28"
+                            FontSize="12"
+                            ToolTip="最後のページ"
+                            AutomationProperties.Name="最後のページ"/>
+                </StackPanel>
+
+                <!-- 用紙設定 -->
+                <StackPanel Grid.Column="3" Orientation="Horizontal">
+                    <TextBlock Text="用紙方向:"
+                               VerticalAlignment="Center"
+                               Margin="0,0,10,0"/>
+                    <ComboBox ItemsSource="{Binding Orientations}"
+                              SelectedItem="{Binding SelectedOrientation}"
+                              Width="140"
+                              Height="28"
+                              VerticalContentAlignment="Center"
+                              AutomationProperties.Name="用紙方向">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock>
+                                    <TextBlock.Text>
+                                        <Binding Converter="{StaticResource OrientationConverter}"/>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <Button Content="印刷"
+                            Command="{Binding PrintCommand}"
+                            Height="28"
+                            Padding="20,0"
+                            Margin="15,0,0,0"
+                            Background="#2196F3"
+                            Foreground="White"
+                            FontWeight="Bold"
+                            ToolTip="印刷ダイアログを開く"
+                            AutomationProperties.Name="印刷を実行"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- プレビューエリア -->
+        <Border Grid.Row="1" Background="#666666" Padding="20">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto"
+                          PanningMode="Both">
+                <Border Background="White"
+                        BorderBrush="#333333"
+                        BorderThickness="1"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Top"
+                        Effect="{StaticResource DropShadowEffect}">
+                    <Border.Resources>
+                        <DropShadowEffect x:Key="DropShadowEffect"
+                                          BlurRadius="15"
+                                          ShadowDepth="5"
+                                          Opacity="0.4"/>
+                    </Border.Resources>
+                    <FlowDocumentScrollViewer x:Name="DocumentViewer"
+                                              Document="{Binding Document}"
+                                              VerticalScrollBarVisibility="Hidden"
+                                              HorizontalScrollBarVisibility="Hidden"
+                                              Zoom="{Binding ZoomLevel}"
+                                              IsToolBarVisible="False"
+                                              MinWidth="400"
+                                              MinHeight="500"
+                                              AutomationProperties.Name="ドキュメントプレビュー"/>
+                </Border>
+            </ScrollViewer>
+        </Border>
+
+        <!-- フッター -->
+        <Border Grid.Row="2" Background="#F5F5F5" Padding="15" BorderBrush="#CCCCCC" BorderThickness="0,1,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- ステータスメッセージ -->
+                <TextBlock Grid.Column="0"
+                           Text="{Binding StatusMessage}"
+                           Foreground="#1976D2"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           AutomationProperties.LiveSetting="Polite"/>
+
+                <!-- 閉じるボタン -->
+                <Button Grid.Column="1"
+                        Content="閉じる"
+                        Click="CloseButton_Click"
+                        Padding="20,8"
+                        MinWidth="100"
+                        IsCancel="True"
+                        AutomationProperties.Name="閉じる"
+                        ToolTip="ダイアログを閉じる (Escape)"/>
+            </Grid>
+        </Border>
+
+        <!-- 処理中オーバーレイ -->
+        <Border Grid.RowSpan="3"
+                Background="#80000000"
+                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
+                <TextBlock Text="{Binding BusyMessage}"
+                           Foreground="White"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           Margin="0,10,0,0"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml.cs
@@ -1,0 +1,30 @@
+using System.Windows;
+using ICCardManager.ViewModels;
+
+namespace ICCardManager.Views.Dialogs;
+
+/// <summary>
+/// 印刷プレビューダイアログ
+/// </summary>
+public partial class PrintPreviewDialog : Window
+{
+    /// <summary>
+    /// ViewModel
+    /// </summary>
+    public PrintPreviewViewModel ViewModel { get; }
+
+    public PrintPreviewDialog(PrintPreviewViewModel viewModel)
+    {
+        InitializeComponent();
+        ViewModel = viewModel;
+        DataContext = viewModel;
+    }
+
+    /// <summary>
+    /// 閉じるボタン
+    /// </summary>
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -190,6 +190,16 @@
                         AutomationProperties.Name="閉じる"
                         AutomationProperties.HelpText="ダイアログを閉じます"
                         ToolTip="ダイアログを閉じる (Escape)"/>
+                <Button Content="プレビュー"
+                        Command="{Binding PreviewSelectedCommand}"
+                        Padding="20,10"
+                        Margin="0,0,10,0"
+                        MinWidth="100"
+                        Background="#2196F3"
+                        Foreground="White"
+                        AutomationProperties.Name="印刷プレビュー"
+                        AutomationProperties.HelpText="選択したカードの帳票をプレビュー表示します"
+                        ToolTip="選択したカードの帳票をプレビュー"/>
                 <Button Content="作成"
                         Command="{Binding CreateReportCommand}"
                         Padding="20,10"

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -18,6 +18,7 @@ public class ReportViewModelTests
     private readonly Mock<ICardRepository> _cardRepositoryMock;
     private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
     private readonly ReportService _reportService;
+    private readonly PrintService _printService;
     private readonly ReportViewModel _viewModel;
 
     public ReportViewModelTests()
@@ -26,9 +27,11 @@ public class ReportViewModelTests
         _ledgerRepositoryMock = new Mock<ILedgerRepository>();
         // ReportServiceはコンクリートクラスのため、モックしたリポジトリで実インスタンスを作成
         _reportService = new ReportService(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object);
+        _printService = new PrintService(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object);
 
         _viewModel = new ReportViewModel(
             _reportService,
+            _printService,
             _cardRepositoryMock.Object);
     }
 


### PR DESCRIPTION
## Summary
- 帳票作成画面に印刷プレビュー機能を追加
- プレビュー画面でズーム（50%～200%）・ページ送り・用紙方向設定が可能
- プレビュー画面から直接印刷（プリンター選択ダイアログ）

## 追加したファイル
| ファイル | 説明 |
|----------|------|
| `PrintService.cs` | FlowDocument生成・印刷サービス |
| `PrintPreviewViewModel.cs` | プレビュー画面のViewModel |
| `PrintPreviewDialog.xaml/.cs` | プレビューダイアログ |
| `OrientationToDisplayNameConverter.cs` | 用紙方向の日本語表示変換 |

## 変更したファイル
| ファイル | 変更内容 |
|----------|----------|
| `ReportViewModel.cs` | `PreviewSelectedCommand`を追加 |
| `ReportDialog.xaml` | 「プレビュー」ボタンを追加 |
| `App.xaml.cs` | DIコンテナにPrintService/PrintPreviewViewModel/PrintPreviewDialogを登録 |
| `ReportViewModelTests.cs` | PrintService依存を追加 |

## 機能詳細

### プレビュー画面
- FlowDocumentを使用した帳票プレビュー表示
- ズーム: 50%, 75%, 100%, 125%, 150%, 200%から選択可能
- ページ送り: 先頭/前/次/末尾ページボタン
- 用紙方向: 横向き（A4横）/縦向き（A4縦）

### 印刷機能
- PrintDialogを使用したプリンター選択
- 用紙方向設定の反映

## スクリーンショット
（実行確認後に追加予定）

## Test plan
- [x] ビルドが成功すること
- [x] 既存テストが通ること（DbContextCleanupTestsの既存失敗2件を除く）
- [ ] 帳票作成画面で「プレビュー」ボタンが表示されること
- [ ] プレビュー画面が正しく表示されること
- [ ] ズーム機能が動作すること
- [ ] ページ送り機能が動作すること（複数ページの場合）
- [ ] 用紙方向変更が反映されること
- [ ] 印刷ボタンでプリンターダイアログが表示されること

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)