### PR TITLE
feat: カード残高ダッシュボード表示機能を追加 (Issue #20)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -67,4 +67,16 @@ public interface ILedgerRepository
     /// <param name="cardIdm">ICカードIDm</param>
     /// <param name="fiscalYear">年度</param>
     Task<int?> GetCarryoverBalanceAsync(string cardIdm, int fiscalYear);
+
+    /// <summary>
+    /// 指定カードの最新利用履歴を取得
+    /// </summary>
+    /// <param name="cardIdm">ICカードIDm</param>
+    Task<Ledger?> GetLatestLedgerAsync(string cardIdm);
+
+    /// <summary>
+    /// 全カードの最新残高情報を一括取得（ダッシュボード用）
+    /// </summary>
+    /// <returns>カードIDmをキーとした最新残高のディクショナリ</returns>
+    Task<Dictionary<string, (int Balance, DateTime? LastUsageDate)>> GetAllLatestBalancesAsync();
 }

--- a/ICCardManager/src/ICCardManager/Dtos/CardBalanceDashboardItem.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/CardBalanceDashboardItem.cs
@@ -1,0 +1,94 @@
+namespace ICCardManager.Dtos;
+
+/// <summary>
+/// カード残高ダッシュボード表示用DTO
+/// メイン画面でカードの残高状況を一覧表示するために使用
+/// </summary>
+public class CardBalanceDashboardItem
+{
+    /// <summary>
+    /// カードIDm（16進数16文字）
+    /// </summary>
+    public string CardIdm { get; init; } = string.Empty;
+
+    /// <summary>
+    /// カード種別（はやかけん/nimoca/SUGOCA等）
+    /// </summary>
+    public string CardType { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 管理番号
+    /// </summary>
+    public string CardNumber { get; init; } = string.Empty;
+
+    /// <summary>
+    /// 現在残高（円）
+    /// </summary>
+    public int CurrentBalance { get; init; }
+
+    /// <summary>
+    /// 残高警告フラグ（残高が閾値以下の場合true）
+    /// </summary>
+    public bool IsBalanceWarning { get; init; }
+
+    /// <summary>
+    /// 最終利用日
+    /// </summary>
+    public DateTime? LastUsageDate { get; init; }
+
+    /// <summary>
+    /// 貸出状態（true: 貸出中）
+    /// </summary>
+    public bool IsLent { get; init; }
+
+    /// <summary>
+    /// 貸出者名（貸出中の場合）
+    /// </summary>
+    public string? LentStaffName { get; init; }
+
+    #region 表示用プロパティ
+
+    /// <summary>
+    /// 表示用: カード名（種別 + 番号）
+    /// </summary>
+    public string DisplayName => $"{CardType} {CardNumber}";
+
+    /// <summary>
+    /// 表示用: 残高（円単位、3桁区切り）
+    /// </summary>
+    public string BalanceDisplay => $"¥{CurrentBalance:N0}";
+
+    /// <summary>
+    /// 表示用: 警告アイコン（⚠）
+    /// </summary>
+    public string WarningIcon => IsBalanceWarning ? "⚠" : "";
+
+    /// <summary>
+    /// 表示用: 貸出状態アイコン
+    /// </summary>
+    public string LentStatusIcon => IsLent ? "📤" : "📥";
+
+    /// <summary>
+    /// 表示用: 貸出状態テキスト
+    /// </summary>
+    public string LentStatusDisplay => IsLent ? "貸出中" : "在庫";
+
+    /// <summary>
+    /// 表示用: 貸出情報（貸出中の場合は貸出者名を表示）
+    /// </summary>
+    public string LentInfoDisplay => IsLent && !string.IsNullOrEmpty(LentStaffName)
+        ? $"貸出中（{LentStaffName}）"
+        : LentStatusDisplay;
+
+    /// <summary>
+    /// 表示用: 最終利用日
+    /// </summary>
+    public string LastUsageDateDisplay => LastUsageDate?.ToString("yyyy/MM/dd") ?? "-";
+
+    /// <summary>
+    /// 表示用: 行の背景色（警告時は薄い赤）
+    /// </summary>
+    public string RowBackgroundColor => IsBalanceWarning ? "#FFEBEE" : "Transparent";
+
+    #endregion
+}

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -25,7 +25,7 @@
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}"/>
         <KeyBinding Key="F1" Command="{Binding OpenSettingsCommand}"/>
         <KeyBinding Key="F2" Command="{Binding OpenReportCommand}"/>
-        <KeyBinding Key="F3" Command="{Binding OpenCardManageCommand}"/>
+        <KeyBinding Key="F3" Command="{Binding OpenCardManageAsyncCommand}"/>
         <KeyBinding Key="F4" Command="{Binding OpenStaffManageCommand}"/>
         <KeyBinding Key="F5" Command="{Binding OpenDataExportImportCommand}"/>
         <KeyBinding Key="F6" Command="{Binding OpenOperationLogCommand}"/>
@@ -75,7 +75,7 @@
                             AutomationProperties.HelpText="物品出納簿を作成します。ショートカット: F2"
                             ToolTip="帳票を開く (F2)"/>
                     <Button Content="カード管理 (F3)" Margin="5,0" Padding="10,5"
-                            Command="{Binding OpenCardManageCommand}"
+                            Command="{Binding OpenCardManageAsyncCommand}"
                             TabIndex="3"
                             AutomationProperties.Name="カード管理ダイアログを開く"
                             AutomationProperties.HelpText="ICカードの登録・編集を行います。ショートカット: F3"
@@ -156,54 +156,183 @@
                 </StackPanel>
             </Border>
 
-            <!-- 右サイドバー（貸出中カード一覧・警告） -->
+            <!-- 右サイドバー（カード残高ダッシュボード） -->
             <Border Grid.Column="1" Background="#F5F5F5" Padding="15">
                 <Grid>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <!-- 貸出中カード -->
-                    <TextBlock Grid.Row="0"
-                               Text="貸出中のカード"
-                               FontSize="{DynamicResource BaseFontSize}"
-                               FontWeight="Bold"
-                               Margin="0,0,0,10"/>
+                    <!-- ダッシュボードヘッダー -->
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                        <TextBlock Text="💳 カード残高"
+                                   FontSize="{DynamicResource BaseFontSize}"
+                                   FontWeight="Bold"
+                                   VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding CardBalanceDashboard.Count, StringFormat=' ({0}枚)'}"
+                                   FontSize="{DynamicResource SmallFontSize}"
+                                   Foreground="Gray"
+                                   VerticalAlignment="Center"
+                                   Margin="5,0,0,0"/>
+                    </StackPanel>
 
-                    <ListView Grid.Row="1"
-                              ItemsSource="{Binding LentCards}"
+                    <!-- ソート選択 -->
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+                        <TextBlock Text="並び順:"
+                                   FontSize="{DynamicResource SmallFontSize}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,5,0"/>
+                        <ComboBox SelectedValue="{Binding DashboardSortOrder}"
+                                  SelectedValuePath="Tag"
+                                  FontSize="{DynamicResource SmallFontSize}"
+                                  Width="130"
+                                  AutomationProperties.Name="ダッシュボードの並び順"
+                                  ToolTip="カード一覧の並び順を変更">
+                            <ComboBoxItem Content="残高（少ない順）" Tag="{x:Static vm:DashboardSortOrder.BalanceAscending}"/>
+                            <ComboBoxItem Content="残高（多い順）" Tag="{x:Static vm:DashboardSortOrder.BalanceDescending}"/>
+                            <ComboBoxItem Content="カード名順" Tag="{x:Static vm:DashboardSortOrder.CardName}"/>
+                            <ComboBoxItem Content="最終利用日順" Tag="{x:Static vm:DashboardSortOrder.LastUsageDate}"/>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <!-- カード残高一覧 -->
+                    <ListView Grid.Row="2"
+                              ItemsSource="{Binding CardBalanceDashboard}"
+                              SelectedItem="{Binding SelectedDashboardItem}"
                               BorderThickness="0"
-                              Background="Transparent">
+                              Background="Transparent"
+                              AutomationProperties.Name="カード残高一覧"
+                              AutomationProperties.HelpText="カードをクリックすると履歴を表示します">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0,2"/>
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="ListViewItem">
+                                            <ContentPresenter/>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.ItemTemplate>
                             <DataTemplate>
-                                <Border Background="White" CornerRadius="4"
-                                        Margin="0,2" Padding="10,8">
-                                    <StackPanel>
-                                        <TextBlock FontWeight="Bold">
+                                <Border CornerRadius="4"
+                                        Padding="10,8"
+                                        Cursor="Hand"
+                                        Background="{Binding RowBackgroundColor}">
+                                    <Border.InputBindings>
+                                        <MouseBinding MouseAction="LeftClick"
+                                                      Command="{Binding DataContext.OpenCardHistoryFromDashboardCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                                      CommandParameter="{Binding}"/>
+                                    </Border.InputBindings>
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="White"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsBalanceWarning}" Value="True">
+                                                    <Setter Property="Background" Value="#FFEBEE"/>
+                                                </DataTrigger>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="BorderBrush" Value="#2196F3"/>
+                                                    <Setter Property="BorderThickness" Value="1"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <!-- 警告アイコン -->
+                                        <TextBlock Grid.Column="0" Grid.RowSpan="2"
+                                                   Text="{Binding WarningIcon}"
+                                                   FontSize="{DynamicResource LargeFontSize}"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,8,0"
+                                                   Foreground="#F44336"
+                                                   ToolTip="残高警告"
+                                                   Visibility="{Binding IsBalanceWarning, Converter={StaticResource BoolToVisibilityConverter}}"/>
+
+                                        <!-- カード名 -->
+                                        <TextBlock Grid.Column="1" Grid.Row="0"
+                                                   FontWeight="Bold"
+                                                   FontSize="{DynamicResource SmallFontSize}">
                                             <Run Text="{Binding CardType}"/>
                                             <Run Text=" "/>
                                             <Run Text="{Binding CardNumber}"/>
                                         </TextBlock>
-                                        <TextBlock FontSize="{DynamicResource SmallFontSize}" Foreground="Gray"
-                                                   Text="{Binding LastLentAt, StringFormat='{}{0:M/d H:mm}～'}"/>
-                                    </StackPanel>
+
+                                        <!-- 残高 -->
+                                        <TextBlock Grid.Column="2" Grid.Row="0"
+                                                   Text="{Binding BalanceDisplay}"
+                                                   FontWeight="Bold"
+                                                   FontSize="{DynamicResource SmallFontSize}"
+                                                   HorizontalAlignment="Right">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground" Value="#424242"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsBalanceWarning}" Value="True">
+                                                            <Setter Property="Foreground" Value="#F44336"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+
+                                        <!-- 最終利用日 + 貸出状態 -->
+                                        <StackPanel Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
+                                                    Orientation="Horizontal">
+                                            <TextBlock FontSize="10" Foreground="Gray">
+                                                <Run Text="最終: "/>
+                                                <Run Text="{Binding LastUsageDateDisplay}"/>
+                                            </TextBlock>
+                                            <TextBlock FontSize="10" Margin="10,0,0,0">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="#4CAF50"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsLent}" Value="True">
+                                                                <Setter Property="Foreground" Value="#FF9800"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                                <Run Text="{Binding LentStatusIcon}"/>
+                                                <Run Text=" "/>
+                                                <Run Text="{Binding LentInfoDisplay}"/>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Grid>
                                 </Border>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
 
                     <!-- 警告エリア -->
-                    <TextBlock Grid.Row="2"
-                               Text="警告"
+                    <TextBlock Grid.Row="3"
+                               Text="⚠ システム警告"
                                FontSize="{DynamicResource BaseFontSize}"
                                FontWeight="Bold"
                                Margin="0,15,0,10"
+                               Foreground="#F44336"
                                Visibility="{Binding WarningMessages.Count, Converter={StaticResource IntToVisibilityConverter}, Mode=OneWay}"/>
 
-                    <ItemsControl Grid.Row="3"
+                    <ItemsControl Grid.Row="4"
                                   ItemsSource="{Binding WarningMessages}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -265,6 +394,14 @@
                 <TextBlock>
                     <Run Text="状態: "/>
                     <Run Text="{Binding CurrentState}"/>
+                </TextBlock>
+            </StatusBarItem>
+            <Separator/>
+            <StatusBarItem>
+                <TextBlock>
+                    <Run Text="登録カード: "/>
+                    <Run Text="{Binding CardBalanceDashboard.Count, Mode=OneWay}"/>
+                    <Run Text=" 枚"/>
                 </TextBlock>
             </StatusBarItem>
             <Separator/>


### PR DESCRIPTION
## Summary

メイン画面の右サイドバーにカード残高ダッシュボードを追加しました。

- カード種別・管理番号、現在残高、警告アイコン、最終利用日、貸出状態を一覧表示
- 残高によるソート機能（昇順/降順）、カード名順、最終利用日順のソート
- 残高警告閾値以下のカードは赤背景で強調表示
- カードをクリックすると履歴画面に遷移

## 変更内容

### データ層
| ファイル | 変更内容 |
|----------|----------|
| `ILedgerRepository.cs` | `GetLatestLedgerAsync`, `GetAllLatestBalancesAsync` メソッド追加 |
| `LedgerRepository.cs` | 上記メソッドの実装（効率的な1クエリで全カードの最新残高を取得） |

### DTO
| ファイル | 変更内容 |
|----------|----------|
| `CardBalanceDashboardItem.cs` | 新規作成（ダッシュボード表示用DTO） |

### ViewModel
| ファイル | 変更内容 |
|----------|----------|
| `MainViewModel.cs` | ダッシュボード関連プロパティ・コマンド追加、ソート機能実装 |

### UI
| ファイル | 変更内容 |
|----------|----------|
| `MainWindow.xaml` | 右サイドバーをダッシュボードUIに変更、ステータスバー更新 |

## 技術的ポイント

- **効率的なDB取得**: `GetAllLatestBalancesAsync`は1クエリで全カードの最新残高を取得（N+1問題を回避）
- **リアルタイム更新**: 貸出・返却後に自動でダッシュボードを更新
- **MVVMパターン**: DTOを使用してView/ViewModelを疎結合に保持
- **アクセシビリティ**: AutomationProperties、ToolTipを適切に設定

## Test plan

- [x] ビルドが成功すること
- [x] 既存の649テストが全て通過すること
- [ ] メイン画面右サイドバーにカード残高一覧が表示されること
- [ ] ソート選択を変更すると一覧が再ソートされること
- [ ] 残高警告閾値以下のカードが赤背景で表示されること
- [ ] カードをクリックすると履歴画面が開くこと
- [ ] 貸出・返却後にダッシュボードが更新されること

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)