### PR TITLE
feat: テンプレートパス解決の堅牢性向上 (Issue #21)

### DIFF
--- a/ICCardManager/src/ICCardManager/ICCardManager.csproj
+++ b/ICCardManager/src/ICCardManager/ICCardManager.csproj
@@ -71,6 +71,10 @@
     <EmbeddedResource Include="Resources\StationCode.csv">
       <LogicalName>ICCardManager.Resources.StationCode.csv</LogicalName>
     </EmbeddedResource>
+    <!-- 埋め込みリソース（物品出納簿テンプレート）- フォールバック用 -->
+    <EmbeddedResource Include="Resources\Templates\物品出納簿テンプレート.xlsx">
+      <LogicalName>ICCardManager.Resources.Templates.物品出納簿テンプレート.xlsx</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/ICCardManager/src/ICCardManager/Services/TemplateResolver.cs
+++ b/ICCardManager/src/ICCardManager/Services/TemplateResolver.cs
@@ -1,0 +1,221 @@
+using System.IO;
+using System.Reflection;
+
+namespace ICCardManager.Services;
+
+/// <summary>
+/// Excelテンプレートファイルのパス解決を行うヘルパークラス
+/// </summary>
+/// <remarks>
+/// Single-file publish環境でも正しくテンプレートを取得できるよう、
+/// 複数のパス解決方法をフォールバックで試行します。
+/// </remarks>
+public static class TemplateResolver
+{
+    /// <summary>
+    /// 物品出納簿テンプレートの相対パス
+    /// </summary>
+    private const string TemplateRelativePath = "Resources/Templates/物品出納簿テンプレート.xlsx";
+
+    /// <summary>
+    /// 埋め込みリソース名
+    /// </summary>
+    private const string EmbeddedResourceName = "ICCardManager.Resources.Templates.物品出納簿テンプレート.xlsx";
+
+    /// <summary>
+    /// 一時ファイルのプレフィックス
+    /// </summary>
+    private const string TempFilePrefix = "ICCardManager_Template_";
+
+    /// <summary>
+    /// 物品出納簿テンプレートのパスを解決
+    /// </summary>
+    /// <returns>テンプレートファイルのパス</returns>
+    /// <exception cref="TemplateNotFoundException">テンプレートが見つからない場合</exception>
+    public static string ResolveTemplatePath()
+    {
+        var searchedPaths = new List<string>();
+
+        // 1. AppContext.BaseDirectory からの相対パス（推奨）
+        var baseDirPath = Path.Combine(AppContext.BaseDirectory, TemplateRelativePath);
+        searchedPaths.Add(baseDirPath);
+        if (File.Exists(baseDirPath))
+        {
+            return baseDirPath;
+        }
+
+        // 2. AppDomain.CurrentDomain.BaseDirectory からの相対パス
+        var domainBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, TemplateRelativePath);
+        if (domainBasePath != baseDirPath)
+        {
+            searchedPaths.Add(domainBasePath);
+            if (File.Exists(domainBasePath))
+            {
+                return domainBasePath;
+            }
+        }
+
+        // 3. 実行アセンブリの場所からの相対パス
+        var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+        if (!string.IsNullOrEmpty(assemblyLocation))
+        {
+            var assemblyDir = Path.GetDirectoryName(assemblyLocation);
+            if (!string.IsNullOrEmpty(assemblyDir))
+            {
+                var assemblyPath = Path.Combine(assemblyDir, TemplateRelativePath);
+                if (assemblyPath != baseDirPath && assemblyPath != domainBasePath)
+                {
+                    searchedPaths.Add(assemblyPath);
+                    if (File.Exists(assemblyPath))
+                    {
+                        return assemblyPath;
+                    }
+                }
+            }
+        }
+
+        // 4. 実行ファイルの場所からの相対パス（Single-file publish対応）
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrEmpty(processPath))
+        {
+            var processDir = Path.GetDirectoryName(processPath);
+            if (!string.IsNullOrEmpty(processDir))
+            {
+                var processBasePath = Path.Combine(processDir, TemplateRelativePath);
+                if (!searchedPaths.Contains(processBasePath))
+                {
+                    searchedPaths.Add(processBasePath);
+                    if (File.Exists(processBasePath))
+                    {
+                        return processBasePath;
+                    }
+                }
+            }
+        }
+
+        // 5. 埋め込みリソースから一時ファイルに展開
+        var tempPath = ExtractEmbeddedTemplate();
+        if (tempPath != null)
+        {
+            return tempPath;
+        }
+
+        // どの方法でも見つからない場合は例外をスロー
+        throw new TemplateNotFoundException(
+            "物品出納簿テンプレート",
+            searchedPaths,
+            "テンプレートファイルが見つかりません。アプリケーションを再インストールしてください。");
+    }
+
+    /// <summary>
+    /// 埋め込みリソースからテンプレートを一時ファイルに展開
+    /// </summary>
+    /// <returns>一時ファイルのパス。展開に失敗した場合はnull</returns>
+    private static string? ExtractEmbeddedTemplate()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        using var stream = assembly.GetManifestResourceStream(EmbeddedResourceName);
+        if (stream == null)
+        {
+            return null;
+        }
+
+        // 一時ディレクトリに展開
+        var tempDir = Path.Combine(Path.GetTempPath(), "ICCardManager");
+        Directory.CreateDirectory(tempDir);
+
+        var tempPath = Path.Combine(tempDir, $"{TempFilePrefix}{Guid.NewGuid():N}.xlsx");
+
+        using var fileStream = File.Create(tempPath);
+        stream.CopyTo(fileStream);
+
+        return tempPath;
+    }
+
+    /// <summary>
+    /// テンプレートファイルが存在するかチェック
+    /// </summary>
+    /// <returns>存在する場合true</returns>
+    public static bool TemplateExists()
+    {
+        try
+        {
+            ResolveTemplatePath();
+            return true;
+        }
+        catch (TemplateNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 一時展開されたテンプレートファイルをクリーンアップ
+    /// </summary>
+    public static void CleanupTempFiles()
+    {
+        try
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "ICCardManager");
+            if (Directory.Exists(tempDir))
+            {
+                var files = Directory.GetFiles(tempDir, $"{TempFilePrefix}*.xlsx");
+                foreach (var file in files)
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch
+                    {
+                        // 削除失敗は無視（使用中の可能性あり）
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // クリーンアップ失敗は無視
+        }
+    }
+}
+
+/// <summary>
+/// テンプレートファイルが見つからない場合の例外
+/// </summary>
+public class TemplateNotFoundException : Exception
+{
+    /// <summary>
+    /// テンプレート名
+    /// </summary>
+    public string TemplateName { get; }
+
+    /// <summary>
+    /// 検索したパスの一覧
+    /// </summary>
+    public IReadOnlyList<string> SearchedPaths { get; }
+
+    public TemplateNotFoundException(string templateName, IEnumerable<string> searchedPaths, string message)
+        : base(message)
+    {
+        TemplateName = templateName;
+        SearchedPaths = searchedPaths.ToList().AsReadOnly();
+    }
+
+    public TemplateNotFoundException(string templateName, IEnumerable<string> searchedPaths, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        TemplateName = templateName;
+        SearchedPaths = searchedPaths.ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// 検索したパスを含む詳細メッセージを取得
+    /// </summary>
+    public string GetDetailedMessage()
+    {
+        var paths = string.Join("\n  - ", SearchedPaths);
+        return $"{Message}\n\n検索したパス:\n  - {paths}";
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
@@ -129,7 +129,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
         File.Exists(outputPath).Should().BeTrue();
 
         // Excelファイルの内容を検証
@@ -197,7 +197,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -256,7 +256,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -316,7 +316,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -376,7 +376,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -424,7 +424,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -480,11 +480,12 @@ public class ReportServiceTests : IDisposable
                 new[] { cardIdm1, cardIdm2 }, year, month, outputFolder);
 
             // Assert
-            result.Should().HaveCount(2);
-            result.Should().Contain(f => f.Contains("はやかけん_001"));
-            result.Should().Contain(f => f.Contains("nimoca_002"));
+            result.AllSuccess.Should().BeTrue();
+            result.SuccessfulFiles.Should().HaveCount(2);
+            result.SuccessfulFiles.Should().Contain(f => f.Contains("はやかけん_001"));
+            result.SuccessfulFiles.Should().Contain(f => f.Contains("nimoca_002"));
 
-            foreach (var filePath in result)
+            foreach (var filePath in result.SuccessfulFiles)
             {
                 File.Exists(filePath).Should().BeTrue();
             }
@@ -527,7 +528,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
         File.Exists(outputPath).Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
@@ -541,10 +542,10 @@ public class ReportServiceTests : IDisposable
     }
 
     /// <summary>
-    /// TC009: 存在しないカードIDmの場合はfalseを返す
+    /// TC009: 存在しないカードIDmの場合は失敗結果を返す
     /// </summary>
     [Fact]
-    public async Task CreateMonthlyReportAsync_WithNonExistentCard_ShouldReturnFalse()
+    public async Task CreateMonthlyReportAsync_WithNonExistentCard_ShouldReturnFailureResult()
     {
         // Arrange
         var cardIdm = "FFFFFFFFFFFFFFFF";
@@ -560,12 +561,13 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeFalse();
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
         File.Exists(outputPath).Should().BeFalse();
     }
 
     /// <summary>
-    /// TC010: 複数カード一括作成で存在しないカードはスキップされる
+    /// TC010: 複数カード一括作成で存在しないカードは失敗として記録される
     /// </summary>
     [Fact]
     public async Task CreateMonthlyReportsAsync_WithNonExistentCard_ShouldSkipInvalidCard()
@@ -600,8 +602,10 @@ public class ReportServiceTests : IDisposable
                 new[] { validCardIdm, invalidCardIdm }, year, month, outputFolder);
 
             // Assert
-            result.Should().HaveCount(1);
-            result.First().Should().Contain("はやかけん_001");
+            result.SuccessCount.Should().Be(1);
+            result.FailureCount.Should().Be(1);
+            result.SuccessfulFiles.Should().HaveCount(1);
+            result.SuccessfulFiles.First().Should().Contain("はやかけん_001");
         }
         finally
         {
@@ -641,7 +645,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -688,7 +692,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -739,7 +743,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();
@@ -792,7 +796,7 @@ public class ReportServiceTests : IDisposable
         var result = await _reportService.CreateMonthlyReportAsync(cardIdm, year, month, outputPath);
 
         // Assert
-        result.Should().BeTrue();
+        result.Success.Should().BeTrue();
 
         using var workbook = new XLWorkbook(outputPath);
         var worksheet = workbook.Worksheets.First();


### PR DESCRIPTION
## Summary

Issue #21 の実装です。Single-file publish環境を含む様々なデプロイ環境でExcelテンプレートファイルを正しく解決できるよう、パス解決ロジックを改善しました。

### 主な変更点

- **TemplateResolverクラスの新規作成**
  - 5段階のフォールバックパス解決戦略
  - 詳細な診断情報を含むTemplateNotFoundException
  - 一時ファイルのクリーンアップ機能

- **ReportServiceのエラーハンドリング改善**
  - `ReportGenerationResult`クラスで詳細なエラー情報を提供
  - `BatchReportGenerationResult`クラスでバッチ処理の結果を管理
  - ユーザーフレンドリーなエラーメッセージ

- **csproj設定**
  - テンプレートを埋め込みリソースとして追加（最終フォールバック用）

### パス解決戦略

1. `AppContext.BaseDirectory`（.NET Core+推奨）
2. `AppDomain.CurrentDomain.BaseDirectory`
3. `Assembly.GetExecutingAssembly().Location`
4. `Environment.ProcessPath`（Single-file publish対応）
5. 埋め込みリソースからの一時ファイル展開

## Test plan

- [x] 全テストが成功（649件パス）
- [x] ReportServiceTestsが新しいAPIに対応
- [x] ビルドが正常に完了

## Files Changed

| ファイル | 変更内容 |
|----------|----------|
| `Services/TemplateResolver.cs` | 新規作成 - テンプレートパス解決ロジック |
| `Services/ReportService.cs` | 結果型の追加、エラーハンドリング改善 |
| `ViewModels/ReportViewModel.cs` | 新しいAPIへの対応 |
| `ICCardManager.csproj` | 埋め込みリソース設定 |
| `ReportServiceTests.cs` | 新しいAPIへのテスト更新 |

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)