### PR TITLE
feat: カードリーダー接続状態の監視と再接続機能を追加 (Issue #22)

### DIFF
--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/ICardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/ICardReader.cs
@@ -3,6 +3,55 @@ using ICCardManager.Models;
 namespace ICCardManager.Infrastructure.CardReader;
 
 /// <summary>
+/// カードリーダーの接続状態
+/// </summary>
+public enum CardReaderConnectionState
+{
+    /// <summary>
+    /// 接続中
+    /// </summary>
+    Connected,
+
+    /// <summary>
+    /// 切断
+    /// </summary>
+    Disconnected,
+
+    /// <summary>
+    /// 再接続中
+    /// </summary>
+    Reconnecting
+}
+
+/// <summary>
+/// 接続状態変更イベントの引数
+/// </summary>
+public class ConnectionStateChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// 新しい接続状態
+    /// </summary>
+    public CardReaderConnectionState State { get; }
+
+    /// <summary>
+    /// メッセージ（エラー詳細など）
+    /// </summary>
+    public string? Message { get; }
+
+    /// <summary>
+    /// 再接続試行回数（再接続中の場合）
+    /// </summary>
+    public int RetryCount { get; }
+
+    public ConnectionStateChangedEventArgs(CardReaderConnectionState state, string? message = null, int retryCount = 0)
+    {
+        State = state;
+        Message = message;
+        RetryCount = retryCount;
+    }
+}
+
+/// <summary>
 /// カード読み取りイベントの引数
 /// </summary>
 public class CardReadEventArgs : EventArgs
@@ -34,6 +83,11 @@ public interface ICardReader : IDisposable
     event EventHandler<Exception>? Error;
 
     /// <summary>
+    /// 接続状態が変更された時に発生するイベント
+    /// </summary>
+    event EventHandler<ConnectionStateChangedEventArgs>? ConnectionStateChanged;
+
+    /// <summary>
     /// カード読み取りを開始
     /// </summary>
     Task StartReadingAsync();
@@ -49,6 +103,11 @@ public interface ICardReader : IDisposable
     bool IsReading { get; }
 
     /// <summary>
+    /// 現在の接続状態
+    /// </summary>
+    CardReaderConnectionState ConnectionState { get; }
+
+    /// <summary>
     /// カードから履歴を読み取る
     /// </summary>
     /// <param name="idm">カードのIDm</param>
@@ -61,4 +120,15 @@ public interface ICardReader : IDisposable
     /// <param name="idm">カードのIDm</param>
     /// <returns>残高</returns>
     Task<int?> ReadBalanceAsync(string idm);
+
+    /// <summary>
+    /// 接続状態を確認（ヘルスチェック）
+    /// </summary>
+    /// <returns>接続中の場合true</returns>
+    Task<bool> CheckConnectionAsync();
+
+    /// <summary>
+    /// 手動で再接続を試行
+    /// </summary>
+    Task ReconnectAsync();
 }

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
@@ -13,8 +13,10 @@ public class MockCardReader : ICardReader
 
     public event EventHandler<CardReadEventArgs>? CardRead;
     public event EventHandler<Exception>? Error;
+    public event EventHandler<ConnectionStateChangedEventArgs>? ConnectionStateChanged;
 
     public bool IsReading => _isReading;
+    public CardReaderConnectionState ConnectionState => CardReaderConnectionState.Connected;
 
     /// <summary>
     /// シミュレーション用のカードIDm
@@ -134,6 +136,21 @@ public class MockCardReader : ICardReader
     {
         // テスト用のダミー残高を返す
         return Task.FromResult<int?>(4980);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> CheckConnectionAsync()
+    {
+        // モックは常に接続済み
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc/>
+    public Task ReconnectAsync()
+    {
+        // モックでは再接続は不要（常に接続済み）
+        ConnectionStateChanged?.Invoke(this, new ConnectionStateChangedEventArgs(CardReaderConnectionState.Connected));
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
         xmlns:conv="clr-namespace:ICCardManager.Common"
+        xmlns:cardReader="clr-namespace:ICCardManager.Infrastructure.CardReader"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
         Title="交通系ICカード管理システム"
@@ -411,6 +412,76 @@
                     <Run Text="{Binding LentCards.Count, Mode=OneWay}"/>
                     <Run Text=" 枚"/>
                 </TextBlock>
+            </StatusBarItem>
+            <Separator/>
+            <!-- カードリーダー接続状態 -->
+            <StatusBarItem AutomationProperties.Name="カードリーダー接続状態">
+                <StackPanel Orientation="Horizontal">
+                    <!-- 接続状態アイコン -->
+                    <TextBlock x:Name="ConnectionIcon" VerticalAlignment="Center" Margin="0,0,5,0">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="🔗"/>
+                                <Setter Property="Foreground" Value="#4CAF50"/>
+                                <Setter Property="ToolTip" Value="カードリーダー接続中"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CardReaderConnectionState}" Value="{x:Static cardReader:CardReaderConnectionState.Disconnected}">
+                                        <Setter Property="Text" Value="🔌"/>
+                                        <Setter Property="Foreground" Value="#F44336"/>
+                                        <Setter Property="ToolTip" Value="カードリーダー切断"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding CardReaderConnectionState}" Value="{x:Static cardReader:CardReaderConnectionState.Reconnecting}">
+                                        <Setter Property="Text" Value="🔄"/>
+                                        <Setter Property="Foreground" Value="#FF9800"/>
+                                        <Setter Property="ToolTip" Value="再接続中..."/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <!-- 接続状態テキスト -->
+                    <TextBlock VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="リーダー: 接続中"/>
+                                <Setter Property="Foreground" Value="#4CAF50"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CardReaderConnectionState}" Value="{x:Static cardReader:CardReaderConnectionState.Disconnected}">
+                                        <Setter Property="Text" Value="リーダー: 切断"/>
+                                        <Setter Property="Foreground" Value="#F44336"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding CardReaderConnectionState}" Value="{x:Static cardReader:CardReaderConnectionState.Reconnecting}">
+                                        <Setter Property="Text">
+                                            <Setter.Value>
+                                                <Binding Path="CardReaderReconnectAttempts" StringFormat="リーダー: 再接続中 ({0}/10)"/>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Setter Property="Foreground" Value="#FF9800"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <!-- 手動再接続ボタン（切断時のみ表示） -->
+                    <Button Content="再接続"
+                            Command="{Binding ReconnectCardReaderAsyncCommand}"
+                            Margin="10,0,0,0"
+                            Padding="8,2"
+                            FontSize="11"
+                            AutomationProperties.Name="カードリーダーに再接続"
+                            ToolTip="カードリーダーへの接続を再試行します">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CardReaderConnectionState}" Value="{x:Static cardReader:CardReaderConnectionState.Disconnected}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                </StackPanel>
             </StatusBarItem>
         </StatusBar>
     </Grid>


### PR DESCRIPTION
## Summary

Issue #22 の実装として、カードリーダーの接続状態監視と自動再接続機能を追加しました。

### 変更内容

- **ICardReaderインターフェース拡張**
  - `CardReaderConnectionState`列挙型（Connected/Disconnected/Reconnecting）
  - `ConnectionStateChanged`イベント
  - `CheckConnectionAsync()`、`ReconnectAsync()`メソッド

- **PcScCardReader実装**
  - 10秒間隔のヘルスチェックタイマー
  - 3秒間隔/最大10回の自動再接続
  - エラー発生時の自動再接続開始

- **MainViewModel拡張**
  - 接続状態プロパティ（CardReaderConnectionState、CardReaderConnectionMessage）
  - `ReconnectCardReaderAsyncCommand`（手動再接続）
  - 警告メッセージの動的管理

- **MainWindow.xaml UI追加**
  - ステータスバーに接続状態インジケーター
  - 状態アイコン（🔗接続中/🔌切断/🔄再接続中）
  - 状態に応じた色表示（緑/赤/オレンジ）
  - 切断時の手動再接続ボタン

## Test plan

- [x] ビルド成功を確認
- [x] 全649テストが成功
- [ ] カードリーダー接続時：ステータスバーに「🔗 リーダー: 接続中」が緑で表示
- [ ] カードリーダー切断時：「🔌 リーダー: 切断」が赤で表示、再接続ボタン表示
- [ ] 再接続中：「🔄 リーダー: 再接続中 (n/10)」がオレンジで表示
- [ ] 再接続成功後：自動的に接続状態に復帰
- [ ] 手動再接続ボタンのクリックで再接続開始

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)