### PR TITLE
feat: DEBUGビルド時のテストデータ自動登録を改善 (Issue #25)

### DIFF
--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
@@ -23,10 +23,12 @@ public class MockCardReader : ICardReader
     /// </summary>
     public List<string> MockCards { get; } = new()
     {
-        "07FE112233445566", // はやかけん
-        "05FE112233445567", // nimoca
-        "06FE112233445568", // SUGOCA
-        "01FE112233445569", // Suica
+        "07FE112233445566", // はやかけん H-001
+        "05FE112233445567", // nimoca N-001
+        "06FE112233445568", // SUGOCA S-001
+        "01FE112233445569", // Suica Su-001
+        "07FE112233445570", // はやかけん H-002
+        "05FE112233445571", // nimoca N-002
     };
 
     /// <summary>
@@ -34,10 +36,22 @@ public class MockCardReader : ICardReader
     /// </summary>
     public List<string> MockStaffCards { get; } = new()
     {
-        "FFFF000000000001",
-        "FFFF000000000002",
-        "FFFF000000000003",
+        "FFFF000000000001", // 山田太郎
+        "FFFF000000000002", // 鈴木花子
+        "FFFF000000000003", // 佐藤一郎
+        "FFFF000000000004", // 田中美咲
+        "FFFF000000000005", // 伊藤健二
     };
+
+    /// <summary>
+    /// カスタム履歴データ生成の設定
+    /// </summary>
+    public MockHistorySettings HistorySettings { get; set; } = new();
+
+    /// <summary>
+    /// 現在の残高設定
+    /// </summary>
+    public int MockBalance { get; set; } = 4980;
 
     /// <inheritdoc/>
     public Task StartReadingAsync()
@@ -83,59 +97,140 @@ public class MockCardReader : ICardReader
     /// <inheritdoc/>
     public Task<IEnumerable<LedgerDetail>> ReadHistoryAsync(string idm)
     {
-        // テスト用のダミー履歴データを返す
-        var details = new List<LedgerDetail>
+        // カスタム履歴データがあればそれを使用
+        if (HistorySettings.CustomHistory.TryGetValue(idm, out var customHistory))
         {
-            new LedgerDetail
-            {
-                UseDate = DateTime.Now.AddDays(-1),
-                EntryStation = "博多",
-                ExitStation = "天神",
-                Amount = 260,
-                Balance = 5240,
-                IsCharge = false,
-                IsBus = false
-            },
-            new LedgerDetail
-            {
-                UseDate = DateTime.Now.AddDays(-1),
-                EntryStation = "天神",
-                ExitStation = "博多",
-                Amount = 260,
-                Balance = 4980,
-                IsCharge = false,
-                IsBus = false
-            },
-            new LedgerDetail
-            {
-                UseDate = DateTime.Now.AddDays(-2),
-                EntryStation = null,
-                ExitStation = null,
-                Amount = 230,
-                Balance = 5500,
-                IsCharge = false,
-                IsBus = true
-            },
-            new LedgerDetail
-            {
-                UseDate = DateTime.Now.AddDays(-3),
-                EntryStation = null,
-                ExitStation = null,
-                Amount = 3000,
-                Balance = 5730,
-                IsCharge = true,
-                IsBus = false
-            }
-        };
+            return Task.FromResult<IEnumerable<LedgerDetail>>(customHistory);
+        }
 
+        // 設定に基づいて履歴データを生成
+        var details = GenerateMockHistory(HistorySettings.Days, HistorySettings.IncludeBus, HistorySettings.IncludeCharge);
         return Task.FromResult<IEnumerable<LedgerDetail>>(details);
+    }
+
+    /// <summary>
+    /// モック履歴データを生成
+    /// </summary>
+    private List<LedgerDetail> GenerateMockHistory(int days, bool includeBus, bool includeCharge)
+    {
+        var details = new List<LedgerDetail>();
+        var random = new Random(MockBalance); // 残高をシードにして再現性を確保
+        var balance = MockBalance + 1000; // 履歴の残高は現在より高い状態から開始
+
+        // 福岡周辺の駅名
+        string[] stations = { "博多", "天神", "薬院", "大橋", "春日", "二日市", "福岡空港", "貝塚", "香椎" };
+
+        for (int i = 0; i < days; i++)
+        {
+            var date = DateTime.Now.AddDays(-(i + 1));
+
+            // チャージを含める場合、最初にチャージを追加
+            if (includeCharge && i == days - 1)
+            {
+                details.Add(new LedgerDetail
+                {
+                    UseDate = date,
+                    EntryStation = null,
+                    ExitStation = null,
+                    Amount = 3000,
+                    Balance = balance,
+                    IsCharge = true,
+                    IsBus = false
+                });
+                balance -= 3000;
+            }
+
+            // 鉄道利用
+            var fromIdx = random.Next(stations.Length);
+            var toIdx = (fromIdx + random.Next(1, 4)) % stations.Length;
+            var fare = 200 + random.Next(8) * 30;
+
+            details.Add(new LedgerDetail
+            {
+                UseDate = date,
+                EntryStation = stations[fromIdx],
+                ExitStation = stations[toIdx],
+                Amount = fare,
+                Balance = balance,
+                IsCharge = false,
+                IsBus = false
+            });
+            balance -= fare;
+
+            // バス利用を含める場合
+            if (includeBus && i % 2 == 0)
+            {
+                var busFare = 200 + random.Next(3) * 30;
+                details.Add(new LedgerDetail
+                {
+                    UseDate = date,
+                    EntryStation = null,
+                    ExitStation = null,
+                    Amount = busFare,
+                    Balance = balance,
+                    IsCharge = false,
+                    IsBus = true
+                });
+                balance -= busFare;
+            }
+        }
+
+        return details;
     }
 
     /// <inheritdoc/>
     public Task<int?> ReadBalanceAsync(string idm)
     {
-        // テスト用のダミー残高を返す
-        return Task.FromResult<int?>(4980);
+        // カスタム残高があればそれを使用
+        if (HistorySettings.CustomBalances.TryGetValue(idm, out var customBalance))
+        {
+            return Task.FromResult<int?>(customBalance);
+        }
+
+        return Task.FromResult<int?>(MockBalance);
+    }
+
+    /// <summary>
+    /// 任意のIDmでカード読み取りをシミュレート
+    /// </summary>
+    /// <param name="idm">シミュレートするIDm（登録済みでなくてもOK）</param>
+    /// <param name="systemCode">システムコード（省略可）</param>
+    public void SimulateAnyCardRead(string idm, string? systemCode = null)
+    {
+        if (_isReading)
+        {
+            CardRead?.Invoke(this, new CardReadEventArgs
+            {
+                Idm = idm,
+                SystemCode = systemCode ?? "0003"
+            });
+            System.Diagnostics.Debug.WriteLine($"[MockReader] カード読み取りシミュレート: {idm}");
+        }
+    }
+
+    /// <summary>
+    /// 特定カードの履歴データを設定
+    /// </summary>
+    public void SetCustomHistory(string idm, List<LedgerDetail> history)
+    {
+        HistorySettings.CustomHistory[idm] = history;
+    }
+
+    /// <summary>
+    /// 特定カードの残高を設定
+    /// </summary>
+    public void SetCustomBalance(string idm, int balance)
+    {
+        HistorySettings.CustomBalances[idm] = balance;
+    }
+
+    /// <summary>
+    /// カスタム設定をリセット
+    /// </summary>
+    public void ResetCustomSettings()
+    {
+        HistorySettings = new MockHistorySettings();
+        MockBalance = 4980;
     }
 
     /// <inheritdoc/>
@@ -172,4 +267,35 @@ public class MockCardReader : ICardReader
             _disposed = true;
         }
     }
+}
+
+/// <summary>
+/// モック履歴データ生成の設定
+/// </summary>
+public class MockHistorySettings
+{
+    /// <summary>
+    /// 生成する履歴の日数（デフォルト: 3日）
+    /// </summary>
+    public int Days { get; set; } = 3;
+
+    /// <summary>
+    /// バス利用を含めるか
+    /// </summary>
+    public bool IncludeBus { get; set; } = true;
+
+    /// <summary>
+    /// チャージを含めるか
+    /// </summary>
+    public bool IncludeCharge { get; set; } = true;
+
+    /// <summary>
+    /// カードIDmごとのカスタム履歴データ
+    /// </summary>
+    public Dictionary<string, List<LedgerDetail>> CustomHistory { get; } = new();
+
+    /// <summary>
+    /// カードIDmごとのカスタム残高
+    /// </summary>
+    public Dictionary<string, int> CustomBalances { get; } = new();
 }


### PR DESCRIPTION
## Summary
- DEBUGビルド時のテストデータを充実化（職員5名・カード6枚）
- デバッグ機能を強化（リセット・任意シミュレート・履歴生成）
- MockCardReaderに設定可能な履歴生成機能を追加

## 変更内容

### 新規ファイル: DebugDataService.cs

| 機能 | 説明 |
|------|------|
| テストデータ定義 | 職員5名・カード6枚を一元管理 |
| RegisterAllTestDataAsync() | 全テストデータを登録 |
| RegisterSampleHistoryAsync() | 過去30日分のサンプル履歴を生成 |
| ResetTestDataAsync() | テストデータを削除して再登録 |
| GenerateHistoryAsync() | 任意カードに履歴データを生成 |
| GetAllTestIdms() | テストデータ一覧を取得 |

### MockCardReader.cs の改善

| 機能 | 説明 |
|------|------|
| MockHistorySettings | 履歴生成の設定（日数・バス含有・チャージ含有） |
| SetCustomHistory() | 特定カードのカスタム履歴を設定 |
| SetCustomBalance() | 特定カードのカスタム残高を設定 |
| SimulateAnyCardRead() | 任意のIDmで読み取りをシミュレート |
| ResetCustomSettings() | カスタム設定をリセット |

### App.xaml.cs の改善

| 機能 | 説明 |
|------|------|
| DebugDataService登録 | DIコンテナにサービスを追加 |
| ResetTestDataAsync() | テストデータリセットのヘルパー |
| GenerateHistoryAsync() | 履歴生成のヘルパー |
| GetTestDataList() | テストデータ一覧取得のヘルパー |

## テストデータ一覧

### 職員（5名）

| IDm | 名前 | 番号 |
|-----|------|------|
| FFFF000000000001 | 山田太郎 | 001 |
| FFFF000000000002 | 鈴木花子 | 002 |
| FFFF000000000003 | 佐藤一郎 | 003 |
| FFFF000000000004 | 田中美咲 | 004 |
| FFFF000000000005 | 伊藤健二 | 005 |

### カード（6枚）

| IDm | 種別 | 番号 |
|-----|------|------|
| 07FE112233445566 | はやかけん | H-001 |
| 05FE112233445567 | nimoca | N-001 |
| 06FE112233445568 | SUGOCA | S-001 |
| 01FE112233445569 | Suica | Su-001 |
| 07FE112233445570 | はやかけん | H-002 |
| 05FE112233445571 | nimoca | N-002 |

## サンプル履歴データ

- 過去30日分（平日のみ、30%の確率で利用）
- 鉄道利用（博多・天神・薬院等の福岡周辺駅）
- バス利用（20%の確率で追加）
- チャージ（残高が1000円未満の場合）

## Test plan
- [x] ビルド成功
- [x] 全662テスト成功
- [x] DEBUGビルドでテストデータが登録されることを確認

## 関連Issue
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)