### PR TITLE
feat: ウィンドウ位置・サイズの記憶機能を追加 (Issue #27)

### DIFF
--- a/ICCardManager/src/ICCardManager/Models/AppSettings.cs
+++ b/ICCardManager/src/ICCardManager/Models/AppSettings.cs
@@ -25,6 +25,47 @@ public class AppSettings
     /// 最終VACUUM実行日
     /// </summary>
     public DateTime? LastVacuumDate { get; set; }
+
+    /// <summary>
+    /// メインウィンドウの位置・サイズ設定
+    /// </summary>
+    public WindowSettings MainWindowSettings { get; set; } = new();
+}
+
+/// <summary>
+/// ウィンドウの位置・サイズ設定
+/// </summary>
+public class WindowSettings
+{
+    /// <summary>
+    /// ウィンドウ左端のX座標
+    /// </summary>
+    public double? Left { get; set; }
+
+    /// <summary>
+    /// ウィンドウ上端のY座標
+    /// </summary>
+    public double? Top { get; set; }
+
+    /// <summary>
+    /// ウィンドウ幅
+    /// </summary>
+    public double? Width { get; set; }
+
+    /// <summary>
+    /// ウィンドウ高さ
+    /// </summary>
+    public double? Height { get; set; }
+
+    /// <summary>
+    /// 最大化状態かどうか
+    /// </summary>
+    public bool IsMaximized { get; set; }
+
+    /// <summary>
+    /// 有効な設定かどうか（一度でも保存されているか）
+    /// </summary>
+    public bool HasValidSettings => Left.HasValue && Top.HasValue && Width.HasValue && Height.HasValue;
 }
 
 /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
@@ -1,4 +1,7 @@
 using System.Windows;
+using System.Windows.Interop;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views;
@@ -9,20 +12,194 @@ namespace ICCardManager.Views;
 public partial class MainWindow : Window
 {
     private readonly MainViewModel _viewModel;
+    private readonly ISettingsRepository _settingsRepository;
 
-    public MainWindow(MainViewModel viewModel)
+    public MainWindow(MainViewModel viewModel, ISettingsRepository settingsRepository)
     {
         InitializeComponent();
 
         _viewModel = viewModel;
+        _settingsRepository = settingsRepository;
         DataContext = _viewModel;
 
         Loaded += MainWindow_Loaded;
+        Closing += MainWindow_Closing;
     }
 
     private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
+        // ウィンドウ位置・サイズを復元
+        await RestoreWindowPositionAsync();
+
         // 初期化を実行
         await _viewModel.InitializeAsync();
+    }
+
+    private async void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        // ウィンドウ位置・サイズを保存
+        await SaveWindowPositionAsync();
+    }
+
+    /// <summary>
+    /// ウィンドウ位置・サイズを保存
+    /// </summary>
+    private async Task SaveWindowPositionAsync()
+    {
+        try
+        {
+            var settings = await _settingsRepository.GetAppSettingsAsync();
+
+            // 最大化状態を保存
+            settings.MainWindowSettings.IsMaximized = WindowState == WindowState.Maximized;
+
+            // 通常状態の位置・サイズを保存（最大化中でもRestoreBoundsから取得可能）
+            if (WindowState == WindowState.Maximized)
+            {
+                // 最大化中は RestoreBounds から通常時のサイズを取得
+                settings.MainWindowSettings.Left = RestoreBounds.Left;
+                settings.MainWindowSettings.Top = RestoreBounds.Top;
+                settings.MainWindowSettings.Width = RestoreBounds.Width;
+                settings.MainWindowSettings.Height = RestoreBounds.Height;
+            }
+            else
+            {
+                settings.MainWindowSettings.Left = Left;
+                settings.MainWindowSettings.Top = Top;
+                settings.MainWindowSettings.Width = Width;
+                settings.MainWindowSettings.Height = Height;
+            }
+
+            await _settingsRepository.SaveAppSettingsAsync(settings);
+            System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置を保存: Left={settings.MainWindowSettings.Left}, Top={settings.MainWindowSettings.Top}, Width={settings.MainWindowSettings.Width}, Height={settings.MainWindowSettings.Height}, Maximized={settings.MainWindowSettings.IsMaximized}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置の保存に失敗: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// ウィンドウ位置・サイズを復元
+    /// </summary>
+    private async Task RestoreWindowPositionAsync()
+    {
+        try
+        {
+            var settings = await _settingsRepository.GetAppSettingsAsync();
+            var windowSettings = settings.MainWindowSettings;
+
+            if (!windowSettings.HasValidSettings)
+            {
+                System.Diagnostics.Debug.WriteLine("[MainWindow] 保存されたウィンドウ位置がありません。デフォルトを使用します。");
+                return;
+            }
+
+            // 位置・サイズを復元
+            var left = windowSettings.Left!.Value;
+            var top = windowSettings.Top!.Value;
+            var width = windowSettings.Width!.Value;
+            var height = windowSettings.Height!.Value;
+
+            // 画面外補正
+            var correctedBounds = EnsureWindowIsVisible(left, top, width, height);
+            left = correctedBounds.Left;
+            top = correctedBounds.Top;
+            width = correctedBounds.Width;
+            height = correctedBounds.Height;
+
+            // ウィンドウに適用
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Left = left;
+            Top = top;
+            Width = width;
+            Height = height;
+
+            // 最大化状態を復元
+            if (windowSettings.IsMaximized)
+            {
+                WindowState = WindowState.Maximized;
+            }
+
+            System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置を復元: Left={left}, Top={top}, Width={width}, Height={height}, Maximized={windowSettings.IsMaximized}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置の復元に失敗: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// ウィンドウが画面内に収まるように補正
+    /// </summary>
+    /// <param name="left">左端座標</param>
+    /// <param name="top">上端座標</param>
+    /// <param name="width">幅</param>
+    /// <param name="height">高さ</param>
+    /// <returns>補正後の座標・サイズ</returns>
+    private static (double Left, double Top, double Width, double Height) EnsureWindowIsVisible(
+        double left, double top, double width, double height)
+    {
+        // 仮想スクリーン領域（全モニターを含む）を取得
+        var virtualLeft = SystemParameters.VirtualScreenLeft;
+        var virtualTop = SystemParameters.VirtualScreenTop;
+        var virtualWidth = SystemParameters.VirtualScreenWidth;
+        var virtualHeight = SystemParameters.VirtualScreenHeight;
+
+        // ウィンドウの中心点が仮想スクリーン内にあるかチェック
+        var centerX = left + width / 2;
+        var centerY = top + height / 2;
+
+        var isVisible = centerX >= virtualLeft &&
+                        centerX <= virtualLeft + virtualWidth &&
+                        centerY >= virtualTop &&
+                        centerY <= virtualTop + virtualHeight;
+
+        if (isVisible)
+        {
+            // ウィンドウが見える位置にあれば、そのまま返す
+            // ただし、ウィンドウが画面端からはみ出している場合は調整
+            if (left < virtualLeft)
+            {
+                left = virtualLeft;
+            }
+            if (top < virtualTop)
+            {
+                top = virtualTop;
+            }
+            if (left + width > virtualLeft + virtualWidth)
+            {
+                left = virtualLeft + virtualWidth - width;
+            }
+            if (top + height > virtualTop + virtualHeight)
+            {
+                top = virtualTop + virtualHeight - height;
+            }
+
+            return (left, top, width, height);
+        }
+
+        // 画面外の場合、プライマリモニターの中央に配置
+        var primaryWidth = SystemParameters.PrimaryScreenWidth;
+        var primaryHeight = SystemParameters.PrimaryScreenHeight;
+        var workAreaWidth = SystemParameters.WorkArea.Width;
+        var workAreaHeight = SystemParameters.WorkArea.Height;
+
+        // ウィンドウサイズがモニターより大きい場合は調整
+        if (width > workAreaWidth)
+        {
+            width = workAreaWidth * 0.9;
+        }
+        if (height > workAreaHeight)
+        {
+            height = workAreaHeight * 0.9;
+        }
+
+        // 作業領域の中央に配置
+        left = (workAreaWidth - width) / 2;
+        top = (workAreaHeight - height) / 2;
+
+        System.Diagnostics.Debug.WriteLine($"[MainWindow] 画面外補正を適用: Left={left}, Top={top}");
+        return (left, top, width, height);
     }
 }


### PR DESCRIPTION
## Summary

- メインウィンドウの位置・サイズを記憶し、次回起動時に復元する機能を実装
- 最大化状態の保存・復元に対応
- マルチモニター環境での画面外補正に対応

## 変更内容

### Models/AppSettings.cs
- `WindowSettings`クラスを新規追加
  - `Left`, `Top`, `Width`, `Height`: ウィンドウの位置・サイズ
  - `IsMaximized`: 最大化状態
  - `HasValidSettings`: 有効な設定があるかのチェックプロパティ
- `AppSettings.MainWindowSettings`プロパティを追加

### Data/Repositories/SettingsRepository.cs
- ウィンドウ設定用のキー定数を追加
  - `window_left`, `window_top`, `window_width`, `window_height`, `window_maximized`
- `GetWindowSettingsFromDbAsync()`: DBからウィンドウ設定を取得
- `SaveWindowSettingsToDbAsync()`: ウィンドウ設定をDBに保存

### Views/MainWindow.xaml.cs
- `ISettingsRepository`をコンストラクタ注入
- `SaveWindowPositionAsync()`: アプリ終了時にウィンドウ位置を保存
  - 最大化中は`RestoreBounds`から通常時のサイズを取得
- `RestoreWindowPositionAsync()`: 起動時にウィンドウ位置を復元
- `EnsureWindowIsVisible()`: 画面外補正ロジック
  - 仮想スクリーン（全モニター）を考慮
  - ウィンドウ中心が画面外の場合、プライマリモニター中央に配置
  - ウィンドウサイズが画面より大きい場合は調整

## 技術的なポイント

### RestoreBoundsの活用
```csharp
if (WindowState == WindowState.Maximized)
{
    // 最大化中は RestoreBounds から通常時のサイズを取得
    settings.MainWindowSettings.Left = RestoreBounds.Left;
    settings.MainWindowSettings.Top = RestoreBounds.Top;
    // ...
}
```
WPFの`RestoreBounds`プロパティは、最大化・最小化状態でも通常時のウィンドウ位置・サイズを保持しています。

### マルチモニター対応
```csharp
var virtualLeft = SystemParameters.VirtualScreenLeft;
var virtualTop = SystemParameters.VirtualScreenTop;
var virtualWidth = SystemParameters.VirtualScreenWidth;
var virtualHeight = SystemParameters.VirtualScreenHeight;
```
`SystemParameters.VirtualScreen*`は全モニターを含む仮想スクリーン領域を提供します。

## Test plan

- [x] ビルドが成功すること
- [x] 全662件のテストがパスすること
- [ ] ウィンドウを移動・リサイズして終了後、再起動で位置・サイズが復元されること
- [ ] 最大化して終了後、再起動で最大化状態が復元されること
- [ ] セカンダリモニターに移動して終了後、再起動で同じモニターに表示されること
- [ ] 切断されたモニター上の位置で保存されていた場合、プライマリモニター中央に表示されること

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)