### PR TITLE
feat: バス停名入力のオートコンプリート機能 (Issue #28)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -79,4 +79,10 @@ public interface ILedgerRepository
     /// </summary>
     /// <returns>カードIDmをキーとした最新残高のディクショナリ</returns>
     Task<Dictionary<string, (int Balance, DateTime? LastUsageDate)>> GetAllLatestBalancesAsync();
+
+    /// <summary>
+    /// 過去に入力されたバス停名を使用頻度順で取得（オートコンプリート用）
+    /// </summary>
+    /// <returns>バス停名と使用回数のリスト（使用頻度順）</returns>
+    Task<IEnumerable<(string BusStops, int UsageCount)>> GetBusStopSuggestionsAsync();
 }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
@@ -7,12 +7,12 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:BusStopInputViewModel}"
         Title="バス停名入力"
-        Height="450"
-        Width="600"
+        Height="500"
+        Width="650"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         AutomationProperties.Name="バス停名入力ダイアログ"
-        AutomationProperties.HelpText="バス利用の乗車・降車バス停名を入力します。スキップして後で入力することもできます。">
+        AutomationProperties.HelpText="バス利用の乗車・降車バス停名を入力します。過去の入力履歴から候補が表示されます。">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
@@ -33,11 +33,14 @@
                            FontSize="{DynamicResource BaseFontSize}"
                            FontWeight="Bold"
                            Foreground="#E65100"/>
-                <TextBlock Text="バス停名は「乗車バス停～降車バス停」の形式で入力してください。例: 天神バスセンター～博多駅"
-                           FontSize="{DynamicResource SmallFontSize}"
+                <TextBlock FontSize="{DynamicResource SmallFontSize}"
                            Foreground="#795548"
                            Margin="0,5,0,0"
-                           TextWrapping="Wrap"/>
+                           TextWrapping="Wrap">
+                    <Run Text="バス停名は「乗車バス停～降車バス停」の形式で入力してください。"/>
+                    <LineBreak/>
+                    <Run Text="💡 入力中に過去の履歴から候補が表示されます。候補をクリックまたは↓↑キーで選択できます。"/>
+                </TextBlock>
             </StackPanel>
         </Border>
 
@@ -45,7 +48,8 @@
         <ListView Grid.Row="1"
                   ItemsSource="{Binding BusUsages}"
                   BorderThickness="1"
-                  BorderBrush="#DDDDDD">
+                  BorderBrush="#DDDDDD"
+                  ScrollViewer.CanContentScroll="False">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid Margin="10">
@@ -58,23 +62,75 @@
                         <!-- 日時 -->
                         <TextBlock Grid.Column="0"
                                    Text="{Binding UseDateDisplay}"
-                                   VerticalAlignment="Center"/>
+                                   VerticalAlignment="Center"
+                                   FontSize="{DynamicResource SmallFontSize}"/>
 
                         <!-- 金額 -->
                         <TextBlock Grid.Column="1"
                                    Text="{Binding AmountDisplay}"
                                    VerticalAlignment="Center"
                                    Foreground="OrangeRed"
-                                   FontWeight="Bold"/>
+                                   FontWeight="Bold"
+                                   FontSize="{DynamicResource SmallFontSize}"/>
 
-                        <!-- バス停名入力 -->
-                        <TextBox Grid.Column="2"
-                                 Text="{Binding BusStops, UpdateSourceTrigger=PropertyChanged}"
-                                 Padding="8"
-                                 VerticalAlignment="Center"
-                                 AutomationProperties.Name="バス停名"
-                                 AutomationProperties.HelpText="乗車バス停～降車バス停の形式で入力"
-                                 ToolTip="乗車バス停～降車バス停（例: 天神～博多駅）"/>
+                        <!-- バス停名入力（オートコンプリート付き） -->
+                        <Grid Grid.Column="2">
+                            <TextBox Text="{Binding BusStops, UpdateSourceTrigger=PropertyChanged}"
+                                     Padding="8"
+                                     VerticalAlignment="Center"
+                                     FontSize="{DynamicResource BaseFontSize}"
+                                     AutomationProperties.Name="バス停名"
+                                     AutomationProperties.HelpText="乗車バス停～降車バス停の形式で入力。過去の履歴から候補が表示されます。"
+                                     ToolTip="乗車バス停～降車バス停（例: 天神～博多駅）"/>
+
+                            <!-- サジェストポップアップ -->
+                            <Popup IsOpen="{Binding ShowSuggestions}"
+                                   PlacementTarget="{Binding RelativeSource={RelativeSource AncestorType=Grid}}"
+                                   Placement="Bottom"
+                                   StaysOpen="False"
+                                   AllowsTransparency="True"
+                                   PopupAnimation="Fade">
+                                <Border Background="White"
+                                        BorderBrush="#2196F3"
+                                        BorderThickness="1"
+                                        CornerRadius="4"
+                                        MaxHeight="200"
+                                        MinWidth="300">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="8" ShadowDepth="2" Opacity="0.3"/>
+                                    </Border.Effect>
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                        <ItemsControl ItemsSource="{Binding FilteredSuggestions}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border Padding="10,8"
+                                                            Cursor="Hand"
+                                                            Background="Transparent">
+                                                        <Border.Style>
+                                                            <Style TargetType="Border">
+                                                                <Style.Triggers>
+                                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                                        <Setter Property="Background" Value="#E3F2FD"/>
+                                                                    </Trigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Border.Style>
+                                                        <Border.InputBindings>
+                                                            <MouseBinding MouseAction="LeftClick"
+                                                                          Command="{Binding DataContext.SelectSuggestionCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                                          CommandParameter="{Binding}"/>
+                                                        </Border.InputBindings>
+                                                        <TextBlock Text="{Binding}"
+                                                                   FontSize="{DynamicResource BaseFontSize}"
+                                                                   Foreground="#333"/>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>
@@ -92,6 +148,7 @@
                    Text="{Binding StatusMessage}"
                    Foreground="#1976D2"
                    FontWeight="Bold"
+                   FontSize="{DynamicResource SmallFontSize}"
                    Margin="0,10,0,0"/>
 
         <!-- ボタン -->
@@ -104,6 +161,7 @@
                     Padding="15,10"
                     Margin="0,0,10,0"
                     IsCancel="True"
+                    FontSize="{DynamicResource BaseFontSize}"
                     AutomationProperties.Name="スキップ"
                     AutomationProperties.HelpText="バス停名を入力せずにダイアログを閉じます。後で入力できます。"
                     ToolTip="後で入力する場合はスキップ (Escape)"/>
@@ -113,6 +171,7 @@
                     Background="#4CAF50"
                     Foreground="White"
                     IsDefault="True"
+                    FontSize="{DynamicResource BaseFontSize}"
                     AutomationProperties.Name="バス停名を保存"
                     AutomationProperties.HelpText="入力したバス停名を保存します"
                     ToolTip="バス停名を保存 (Enter)"/>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml.cs
@@ -40,9 +40,18 @@ public partial class BusStopInputDialog : Window
     /// <summary>
     /// バス利用詳細を直接指定して初期化（返却時用）
     /// </summary>
+    public async Task InitializeWithDetailsAsync(Ledger ledger, IEnumerable<LedgerDetail> busDetails)
+    {
+        await _viewModel.InitializeWithDetailsAsync(ledger, busDetails);
+    }
+
+    /// <summary>
+    /// バス利用詳細を直接指定して初期化（返却時用・同期版 - 後方互換性のため）
+    /// </summary>
     public void InitializeWithDetails(Ledger ledger, IEnumerable<LedgerDetail> busDetails)
     {
-        _viewModel.InitializeWithDetails(ledger, busDetails);
+        // 非同期版を同期的に呼び出し（サジェスト読み込みを含む）
+        _ = _viewModel.InitializeWithDetailsAsync(ledger, busDetails);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- バス停名入力時に過去の入力履歴からサジェスト候補を表示する機能を追加
- 使用頻度順で候補を表示し、入力の手間を軽減
- 前方一致を優先、部分一致も対応

## 変更内容

### リポジトリ層 (`LedgerRepository`)
- `GetBusStopSuggestionsAsync()` メソッドを追加
- `ledger_detail` テーブルからバス停名を集計し、使用頻度順でソート
- ★マークや空文字は除外、上位100件を返却

### ViewModel層 (`BusStopInputViewModel`)
- `BusStopSuggestions` プロパティでサジェスト候補を保持
- `LoadBusStopSuggestionsAsync()` で非同期読み込み
- `BusStopInputItem` クラスにフィルタリングロジックを追加
  - 前方一致を5件まで優先
  - 次に部分一致を5件まで追加
  - 最大8件を表示

### View層 (`BusStopInputDialog.xaml`)
- WPF `Popup` コントロールでオートコンプリートUIを実装
- ドロップシャドウ付きのポップアップ
- マウスホバーでハイライト表示
- クリックまたはキーボード操作で選択可能

## テスト結果

- ビルド: ✅ 成功（0エラー）
- 単体テスト: ✅ 全662件パス

## スクリーンショット

（テキストボックスに入力開始すると、過去の履歴からマッチする候補がドロップダウンで表示されます）

## Test plan

- [ ] バス停名入力ダイアログを開き、テキストを入力するとサジェストが表示されることを確認
- [ ] サジェスト候補をクリックすると、テキストボックスに反映されることを確認
- [ ] 前方一致の候補が優先的に表示されることを確認
- [ ] 過去にバス利用履歴がない場合、サジェストが表示されないことを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)