### PR TITLE
feat: 職員証タッチのスキップオプション (Issue #29)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
@@ -25,6 +25,10 @@ public class SettingsRepository : ISettingsRepository
     public const string KeyWindowHeight = "window_height";
     public const string KeyWindowMaximized = "window_maximized";
 
+    // 職員証スキップ設定キー
+    public const string KeySkipStaffTouch = "skip_staff_touch";
+    public const string KeyDefaultStaffIdm = "default_staff_idm";
+
     public SettingsRepository(DbContext dbContext, ICacheService cacheService)
     {
         _dbContext = dbContext;
@@ -103,6 +107,13 @@ public class SettingsRepository : ISettingsRepository
         // ウィンドウ設定
         settings.MainWindowSettings = await GetWindowSettingsFromDbAsync();
 
+        // 職員証スキップ設定
+        var skipStaffTouch = await GetAsync(KeySkipStaffTouch);
+        settings.SkipStaffTouch = skipStaffTouch?.ToLowerInvariant() == "true";
+
+        var defaultStaffIdm = await GetAsync(KeyDefaultStaffIdm);
+        settings.DefaultStaffIdm = string.IsNullOrEmpty(defaultStaffIdm) ? null : defaultStaffIdm;
+
         return settings;
     }
 
@@ -159,6 +170,10 @@ public class SettingsRepository : ISettingsRepository
 
         // ウィンドウ設定を保存
         success &= await SaveWindowSettingsToDbAsync(settings.MainWindowSettings);
+
+        // 職員証スキップ設定を保存
+        success &= await SetAsync(KeySkipStaffTouch, settings.SkipStaffTouch.ToString().ToLowerInvariant());
+        success &= await SetAsync(KeyDefaultStaffIdm, settings.DefaultStaffIdm);
 
         // 設定保存後にキャッシュを無効化
         _cacheService.Invalidate(CacheKeys.AppSettings);

--- a/ICCardManager/src/ICCardManager/Models/AppSettings.cs
+++ b/ICCardManager/src/ICCardManager/Models/AppSettings.cs
@@ -30,6 +30,16 @@ public class AppSettings
     /// メインウィンドウの位置・サイズ設定
     /// </summary>
     public WindowSettings MainWindowSettings { get; set; } = new();
+
+    /// <summary>
+    /// 職員証タッチをスキップするかどうか
+    /// </summary>
+    public bool SkipStaffTouch { get; set; } = false;
+
+    /// <summary>
+    /// デフォルト職員のIDm（スキップ時に使用）
+    /// </summary>
+    public string? DefaultStaffIdm { get; set; }
 }
 
 /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:SettingsViewModel}"
         Title="設定"
-        Height="450"
+        Height="650"
         Width="550"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
@@ -103,6 +103,58 @@
                                    FontSize="{DynamicResource SmallFontSize}"
                                    Foreground="Gray"
                                    Margin="0,5,0,0"/>
+                    </StackPanel>
+                </GroupBox>
+
+                <!-- 操作設定 -->
+                <GroupBox Header="操作設定" Margin="0,0,0,20" Padding="15">
+                    <StackPanel>
+                        <CheckBox IsChecked="{Binding SkipStaffTouch}"
+                                  Content="職員証タッチをスキップする"
+                                  FontWeight="Bold"
+                                  AutomationProperties.Name="職員証タッチスキップ"
+                                  AutomationProperties.HelpText="有効にすると、ICカードのみで貸出・返却ができます"
+                                  ToolTip="少人数環境向け：職員証をタッチせずにICカードのみで操作可能にします"/>
+
+                        <StackPanel Margin="0,15,0,0"
+                                    IsEnabled="{Binding SkipStaffTouch}">
+                            <TextBlock Text="デフォルト職員"
+                                       FontWeight="Bold"
+                                       Margin="0,0,0,10"/>
+                            <ComboBox ItemsSource="{Binding StaffList}"
+                                      SelectedItem="{Binding SelectedDefaultStaff}"
+                                      DisplayMemberPath="Name"
+                                      Padding="8"
+                                      Width="250"
+                                      HorizontalAlignment="Left"
+                                      AutomationProperties.Name="デフォルト職員選択"
+                                      AutomationProperties.HelpText="スキップ時に操作者として記録される職員を選択します"
+                                      ToolTip="操作者として記録される職員を選択"/>
+                            <TextBlock Text="※ スキップ時、この職員が操作者として記録されます"
+                                       FontSize="{DynamicResource SmallFontSize}"
+                                       Foreground="Gray"
+                                       Margin="0,5,0,0"/>
+                        </StackPanel>
+
+                        <!-- セキュリティ警告 -->
+                        <Border Background="#FFF3E0"
+                                BorderBrush="#FF9800"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                Padding="10"
+                                Margin="0,15,0,0"
+                                Visibility="{Binding SkipStaffTouch, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <StackPanel>
+                                <TextBlock Text="⚠️ セキュリティに関する注意"
+                                           FontWeight="Bold"
+                                           Foreground="#E65100"/>
+                                <TextBlock Text="この機能を有効にすると、誰でもICカードをタッチするだけで貸出・返却が可能になります。限られた職員のみが使用する環境でのみご利用ください。"
+                                           TextWrapping="Wrap"
+                                           FontSize="{DynamicResource SmallFontSize}"
+                                           Foreground="#795548"
+                                           Margin="0,5,0,0"/>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </GroupBox>
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
@@ -14,19 +15,25 @@ namespace ICCardManager.Tests.ViewModels;
 public class SettingsViewModelTests
 {
     private readonly Mock<ISettingsRepository> _settingsRepositoryMock;
+    private readonly Mock<IStaffRepository> _staffRepositoryMock;
     private readonly Mock<IValidationService> _validationServiceMock;
     private readonly SettingsViewModel _viewModel;
 
     public SettingsViewModelTests()
     {
         _settingsRepositoryMock = new Mock<ISettingsRepository>();
+        _staffRepositoryMock = new Mock<IStaffRepository>();
         _validationServiceMock = new Mock<IValidationService>();
 
         // バリデーションはデフォルトで成功を返す
         _validationServiceMock.Setup(v => v.ValidateWarningBalance(It.IsAny<int>())).Returns(ValidationResult.Success());
 
+        // 空の職員リストを返す
+        _staffRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Staff>());
+
         _viewModel = new SettingsViewModel(
             _settingsRepositoryMock.Object,
+            _staffRepositoryMock.Object,
             _validationServiceMock.Object);
     }
 


### PR DESCRIPTION
## Summary

- 少人数環境向けに、職員証タッチをスキップするオプションを追加
- デフォルト職員を設定することで、ICカードのみで貸出・返却が可能に
- セキュリティ上の注意喚起を設定画面に表示

## 変更内容

### 設定画面 (`SettingsDialog.xaml`)

| 項目 | 内容 |
|------|------|
| 「職員証タッチをスキップする」チェックボックス | スキップモードの有効/無効 |
| 「デフォルト職員」ドロップダウン | 操作者として記録される職員 |
| セキュリティ警告 | オレンジ背景で注意喚起を表示 |

### メイン画面の動作変更

| 状態 | 通常モード | スキップモード |
|------|-----------|---------------|
| 初期状態 | 職員証タッチ待ち | ICカードタッチ待ち |
| 表示メッセージ | 「職員証をタッチしてください」 | 「ICカードをタッチしてください（操作者: ○○）」 |
| 処理完了後 | 職員証タッチ待ちに戻る | ICカードタッチ待ちに戻る |

### 実装詳細

- `AppSettings.cs`: `SkipStaffTouch`, `DefaultStaffIdm` プロパティ追加
- `SettingsRepository.cs`: 新設定の保存・読込
- `SettingsViewModel.cs`: 職員一覧読込、バリデーション追加
- `MainViewModel.cs`: スキップモードのロジック実装

## テスト結果

- ビルド: ✅ 成功（0エラー）
- 単体テスト: ✅ 全662件パス

## スクリーンショット

（設定画面に「操作設定」セクションが追加され、職員証スキップのオプションと警告メッセージが表示されます）

## Test plan

- [ ] 設定画面で「職員証タッチをスキップする」をチェック
- [ ] デフォルト職員を選択して保存
- [ ] メイン画面がICカードタッチ待ち状態から開始することを確認
- [ ] ICカードをタッチして貸出/返却が正常に動作することを確認
- [ ] デフォルト職員が操作者として記録されることを確認
- [ ] スキップを無効にして、通常モードに戻ることを確認
- [ ] デフォルト職員未選択でスキップ有効化を試みるとエラーになることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)