### PR TITLE
fix: StaffManageDialogのコマンドバインディングを修正 (Issue #34)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -93,7 +93,7 @@
                             AutomationProperties.HelpText="選択した職員の情報を編集します"
                             ToolTip="選択した職員を編集"/>
                     <Button Content="削除"
-                            Command="{Binding DeleteCommand}"
+                            Command="{Binding DeleteAsyncCommand}"
                             IsEnabled="{Binding SelectedStaff, Converter={StaticResource BoolToVisibilityConverter}}"
                             Padding="15,8"
                             Margin="0,0,0,5"
@@ -246,7 +246,7 @@
                             Padding="15,8"
                             Margin="0,0,10,0"/>
                     <Button Content="保存"
-                            Command="{Binding SaveCommand}"
+                            Command="{Binding SaveAsyncCommand}"
                             Padding="15,8"
                             Background="#2196F3"
                             Foreground="White"/>


### PR DESCRIPTION
## Summary

Issue #34 の実装として、StaffManageDialog のコマンドバインディングを確認・修正しました。

### 確認結果

| ボタン | XAMLのバインディング | ViewModelメソッド | 状態 |
|--------|---------------------|------------------|------|
| 新規登録 | `StartNewStaffCommand` | `StartNewStaff()` | ✅ 正しい |
| 編集 | `StartEditCommand` | `StartEdit()` | ✅ 正しい |
| 削除 | `DeleteCommand` | `DeleteAsync()` | ❌ **修正** |
| シミュレート | `SimulateCardReadCommand` | `SimulateCardRead()` | ✅ 正しい |
| キャンセル | `CancelEditCommand` | `CancelEdit()` | ✅ 正しい |
| 保存 | `SaveCommand` | `SaveAsync()` | ❌ **修正** |

### 修正内容

#### 1. 削除ボタン (96行目)

```diff
- Command="{Binding DeleteCommand}"
+ Command="{Binding DeleteAsyncCommand}"
```

#### 2. 保存ボタン (249行目)

```diff
- Command="{Binding SaveCommand}"
+ Command="{Binding SaveAsyncCommand}"
```

### 原因

`[RelayCommand]` 属性付きの非同期メソッド（`SaveAsync()`, `DeleteAsync()`）は、CommunityToolkit.Mvvm により `*AsyncCommand` という名前でコマンドが生成されます。

## Test plan

- [ ] 職員管理画面で新規登録ができる
- [ ] 職員管理画面で既存職員の編集・保存ができる
- [ ] 職員管理画面で職員の削除ができる
- [ ] ビルドが成功する

## 受け入れ条件

- [x] 全コマンドバインディングが確認されている
- [x] 問題があれば修正されている

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)