### PR TITLE
security: BackupServiceにパス検証を追加 (Issue #71)

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/PathValidator.cs
+++ b/ICCardManager/src/ICCardManager/Common/PathValidator.cs
@@ -1,0 +1,246 @@
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace ICCardManager.Common;
+
+/// <summary>
+/// ファイルパスの検証を行うユーティリティクラス
+/// </summary>
+public static partial class PathValidator
+{
+    /// <summary>
+    /// Windows のパス最大長
+    /// </summary>
+    private const int MaxPathLength = 260;
+
+    /// <summary>
+    /// パス検証結果
+    /// </summary>
+    public class ValidationResult
+    {
+        /// <summary>
+        /// 検証が成功したかどうか
+        /// </summary>
+        public bool IsValid { get; init; }
+
+        /// <summary>
+        /// エラーメッセージ（失敗時のみ）
+        /// </summary>
+        public string? ErrorMessage { get; init; }
+
+        /// <summary>
+        /// 成功結果を作成
+        /// </summary>
+        public static ValidationResult Success() => new() { IsValid = true };
+
+        /// <summary>
+        /// 失敗結果を作成
+        /// </summary>
+        public static ValidationResult Failure(string errorMessage) => new()
+        {
+            IsValid = false,
+            ErrorMessage = errorMessage
+        };
+    }
+
+    /// <summary>
+    /// バックアップパスとして有効かどうかを検証
+    /// </summary>
+    /// <param name="path">検証するパス</param>
+    /// <returns>検証結果</returns>
+    public static ValidationResult ValidateBackupPath(string? path)
+    {
+        // 1. null または空でないこと
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return ValidationResult.Failure("バックアップパスが指定されていません");
+        }
+
+        // 2. パス長チェック
+        if (path.Length > MaxPathLength)
+        {
+            return ValidationResult.Failure($"パスが長すぎます（最大{MaxPathLength}文字）");
+        }
+
+        // 3. 不正な文字を含まないこと
+        var invalidChars = Path.GetInvalidPathChars();
+        if (path.IndexOfAny(invalidChars) >= 0)
+        {
+            return ValidationResult.Failure("パスに使用できない文字が含まれています");
+        }
+
+        // 4. UNCパスでないこと（オフライン環境のため）
+        if (IsUncPath(path))
+        {
+            return ValidationResult.Failure("ネットワークパス（UNCパス）は使用できません");
+        }
+
+        // 5. 絶対パスであること
+        if (!Path.IsPathRooted(path))
+        {
+            return ValidationResult.Failure("絶対パスを指定してください");
+        }
+
+        // 6. パストラバーサルを含まないこと
+        if (ContainsPathTraversal(path))
+        {
+            return ValidationResult.Failure("パスに不正な文字列（..）が含まれています");
+        }
+
+        // 7. ドライブが存在すること（Windowsの場合）
+        if (OperatingSystem.IsWindows())
+        {
+            var root = Path.GetPathRoot(path);
+            if (!string.IsNullOrEmpty(root))
+            {
+                var driveInfo = new DriveInfo(root);
+                if (!driveInfo.IsReady)
+                {
+                    return ValidationResult.Failure($"ドライブ {root} が利用できません");
+                }
+            }
+        }
+
+        // 8. 書き込み可能かチェック（ディレクトリが存在する場合）
+        var writeCheckResult = CheckWritePermission(path);
+        if (!writeCheckResult.IsValid)
+        {
+            return writeCheckResult;
+        }
+
+        return ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// UNCパスかどうかを判定
+    /// </summary>
+    private static bool IsUncPath(string path)
+    {
+        // UNCパス: \\server\share または //server/share
+        return path.StartsWith(@"\\") || path.StartsWith("//");
+    }
+
+    /// <summary>
+    /// パストラバーサルを含むかどうかを判定
+    /// </summary>
+    private static bool ContainsPathTraversal(string path)
+    {
+        // 正規化されたパスと元のパスを比較
+        try
+        {
+            var fullPath = Path.GetFullPath(path);
+            var normalizedInput = Path.GetFullPath(path);
+
+            // ".." を含むパスは正規化後に異なるパスになる可能性がある
+            // 明示的に ".." の存在をチェック
+            if (path.Contains(".."))
+            {
+                return true;
+            }
+
+            return false;
+        }
+        catch
+        {
+            // パスの解析に失敗した場合は不正とみなす
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// 書き込み権限をチェック
+    /// </summary>
+    private static ValidationResult CheckWritePermission(string path)
+    {
+        try
+        {
+            // ディレクトリが存在する場合のみチェック
+            if (Directory.Exists(path))
+            {
+                // テストファイルを書き込んでみる
+                var testFile = Path.Combine(path, $".write_test_{Guid.NewGuid():N}");
+                try
+                {
+                    File.WriteAllText(testFile, "test");
+                    File.Delete(testFile);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return ValidationResult.Failure("指定されたフォルダへの書き込み権限がありません");
+                }
+                catch (IOException ex)
+                {
+                    return ValidationResult.Failure($"フォルダへのアクセスエラー: {ex.Message}");
+                }
+            }
+            else
+            {
+                // ディレクトリが存在しない場合は、親ディレクトリの書き込み権限をチェック
+                var parentDir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(parentDir) && Directory.Exists(parentDir))
+                {
+                    var testFile = Path.Combine(parentDir, $".write_test_{Guid.NewGuid():N}");
+                    try
+                    {
+                        File.WriteAllText(testFile, "test");
+                        File.Delete(testFile);
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        return ValidationResult.Failure("指定されたフォルダの親ディレクトリへの書き込み権限がありません");
+                    }
+                    catch (IOException)
+                    {
+                        // 親ディレクトリへのアクセスエラーは警告程度で通過させる
+                    }
+                }
+            }
+
+            return ValidationResult.Success();
+        }
+        catch
+        {
+            // 権限チェックに失敗した場合は通過させる（実際の書き込み時にエラーになる）
+            return ValidationResult.Success();
+        }
+    }
+
+    /// <summary>
+    /// パスを正規化（安全な形式に変換）
+    /// </summary>
+    /// <param name="path">正規化するパス</param>
+    /// <returns>正規化されたパス（不正なパスの場合はnull）</returns>
+    public static string? NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            // 末尾のスペースやピリオドを除去
+            path = path.TrimEnd(' ', '.');
+
+            // パスを正規化
+            var fullPath = Path.GetFullPath(path);
+
+            return fullPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// デフォルトのバックアップパスを取得
+    /// </summary>
+    public static string GetDefaultBackupPath()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "ICCardManager",
+            "backup");
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Common/PathValidatorTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/PathValidatorTests.cs
@@ -1,0 +1,470 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using ICCardManager.Common;
+using Xunit;
+
+namespace ICCardManager.Tests.Common;
+
+/// <summary>
+/// PathValidatorの単体テスト
+/// </summary>
+public class PathValidatorTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public PathValidatorTests()
+    {
+        // テスト用の一時ディレクトリを作成
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"PathValidatorTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    public void Dispose()
+    {
+        // テスト用ディレクトリを削除
+        try
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // クリーンアップ失敗は無視
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    #region ValidateBackupPath - Null/Empty テスト
+
+    /// <summary>
+    /// nullパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_NullPath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(null);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("指定されていません");
+    }
+
+    /// <summary>
+    /// 空文字列が拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_EmptyPath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(string.Empty);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("指定されていません");
+    }
+
+    /// <summary>
+    /// 空白のみのパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_WhitespacePath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath("   ");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("指定されていません");
+    }
+
+    #endregion
+
+    #region ValidateBackupPath - パス長テスト
+
+    /// <summary>
+    /// 長すぎるパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathTooLong_ReturnsInvalid()
+    {
+        // Arrange
+        var longPath = @"C:\" + new string('a', 300);
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(longPath);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("長すぎます");
+    }
+
+    /// <summary>
+    /// 260文字ちょうどのパスは許容されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathAt260Chars_IsValid()
+    {
+        // Arrange - 260文字ちょうどのパスを作成
+        // C:\ = 3文字、残り257文字
+        var path = @"C:\" + new string('a', 257);
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(path);
+
+        // Assert - パストラバーサルやUNCでなければ長さは OK
+        // ドライブが存在しない可能性があるのでそのエラーは無視
+        if (!result.IsValid)
+        {
+            result.ErrorMessage.Should().NotContain("長すぎます");
+        }
+    }
+
+    #endregion
+
+    #region ValidateBackupPath - UNCパステスト
+
+    /// <summary>
+    /// UNCパス（\\server\share形式）が拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_UncPath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(@"\\server\share\backup");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("ネットワークパス");
+    }
+
+    /// <summary>
+    /// UNCパス（//server/share形式）が拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_UncPathWithForwardSlash_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath("//server/share/backup");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("ネットワークパス");
+    }
+
+    #endregion
+
+    #region ValidateBackupPath - 相対パステスト
+
+    /// <summary>
+    /// 相対パスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_RelativePath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath("backup/folder");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("絶対パス");
+    }
+
+    /// <summary>
+    /// ドット開始の相対パスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_DotRelativePath_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath("./backup");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("絶対パス");
+    }
+
+    #endregion
+
+    #region ValidateBackupPath - パストラバーサルテスト
+
+    /// <summary>
+    /// パストラバーサル（..）を含むパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathTraversal_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(@"C:\backup\..\Windows\System32");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("..");
+    }
+
+    /// <summary>
+    /// 中間に..を含むパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathTraversalInMiddle_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(@"C:\Users\test\..\admin\backup");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("..");
+    }
+
+    /// <summary>
+    /// 末尾に..を含むパスが拒否されることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathTraversalAtEnd_ReturnsInvalid()
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(@"C:\Users\test\..");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("..");
+    }
+
+    #endregion
+
+    #region ValidateBackupPath - 有効なパステスト
+
+    /// <summary>
+    /// 有効な絶対パスが受け入れられることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_ValidAbsolutePath_ReturnsValid()
+    {
+        // Arrange - 実在するディレクトリを使用
+        var validPath = _testDirectory;
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(validPath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 存在しないが有効な形式のパスが受け入れられることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_ValidPathNotExists_ReturnsValid()
+    {
+        // Arrange - 存在しないが有効なパス
+        var validPath = Path.Combine(_testDirectory, "new_folder");
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(validPath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// ネストしたパスが受け入れられることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_NestedPath_ReturnsValid()
+    {
+        // Arrange
+        var nestedPath = Path.Combine(_testDirectory, "level1", "level2", "level3");
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(nestedPath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region NormalizePath テスト
+
+    /// <summary>
+    /// nullが返されることを確認
+    /// </summary>
+    [Fact]
+    public void NormalizePath_NullInput_ReturnsNull()
+    {
+        // Act
+        var result = PathValidator.NormalizePath(null);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 空文字列が返されることを確認
+    /// </summary>
+    [Fact]
+    public void NormalizePath_EmptyInput_ReturnsNull()
+    {
+        // Act
+        var result = PathValidator.NormalizePath(string.Empty);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 末尾のスペースが除去されることを確認
+    /// </summary>
+    [Fact]
+    public void NormalizePath_TrailingSpaces_TrimsSpaces()
+    {
+        // Arrange
+        var pathWithSpaces = _testDirectory + "   ";
+
+        // Act
+        var result = PathValidator.NormalizePath(pathWithSpaces);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().NotEndWith(" ");
+    }
+
+    /// <summary>
+    /// パスが正規化されることを確認
+    /// </summary>
+    [Fact]
+    public void NormalizePath_ValidPath_ReturnsFullPath()
+    {
+        // Arrange
+        var inputPath = _testDirectory;
+
+        // Act
+        var result = PathValidator.NormalizePath(inputPath);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(Path.GetFullPath(inputPath));
+    }
+
+    #endregion
+
+    #region GetDefaultBackupPath テスト
+
+    /// <summary>
+    /// デフォルトパスがLocalApplicationData内であることを確認
+    /// </summary>
+    [Fact]
+    public void GetDefaultBackupPath_ReturnsLocalAppDataPath()
+    {
+        // Act
+        var result = PathValidator.GetDefaultBackupPath();
+
+        // Assert
+        result.Should().Contain("ICCardManager");
+        result.Should().Contain("backup");
+        result.Should().StartWith(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+    }
+
+    /// <summary>
+    /// デフォルトパスが絶対パスであることを確認
+    /// </summary>
+    [Fact]
+    public void GetDefaultBackupPath_ReturnsAbsolutePath()
+    {
+        // Act
+        var result = PathValidator.GetDefaultBackupPath();
+
+        // Assert
+        Path.IsPathRooted(result).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region 境界値テスト
+
+    /// <summary>
+    /// 不正な文字を含むパスが拒否されることを確認（プラットフォーム依存）
+    /// </summary>
+    [Theory]
+    [InlineData("C:\\backup<test")]
+    [InlineData("C:\\backup>test")]
+    [InlineData("C:\\backup|test")]
+    [InlineData("C:\\backup\"test")]
+    public void ValidateBackupPath_InvalidCharacters_ReturnsInvalid(string invalidPath)
+    {
+        // Act
+        var result = PathValidator.ValidateBackupPath(invalidPath);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region エッジケーステスト
+
+    /// <summary>
+    /// ドライブルートパスの検証を確認
+    /// Note: ドライブルートは書き込み権限がない可能性があるため、
+    /// パス形式として有効かどうかをチェック
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_DriveRoot_ChecksPathFormat()
+    {
+        // Arrange - 存在するドライブのルートを使用
+        var driveRoot = Path.GetPathRoot(_testDirectory);
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(driveRoot);
+
+        // Assert
+        // ドライブルートは有効なパス形式だが、書き込み権限がない場合は失敗する可能性がある
+        // パストラバーサルやUNCパスなどの致命的なエラーではないことを確認
+        if (!result.IsValid)
+        {
+            // 書き込み権限関連のエラーは許容
+            result.ErrorMessage.Should().NotContain("ネットワークパス");
+            result.ErrorMessage.Should().NotContain("..");
+            result.ErrorMessage.Should().NotContain("絶対パス");
+        }
+    }
+
+    /// <summary>
+    /// 日本語を含むパスが有効であることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_JapanesePath_IsValid()
+    {
+        // Arrange
+        var japanesePath = Path.Combine(_testDirectory, "バックアップ", "フォルダ");
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(japanesePath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// スペースを含むパスが有効であることを確認
+    /// </summary>
+    [Fact]
+    public void ValidateBackupPath_PathWithSpaces_IsValid()
+    {
+        // Arrange
+        var pathWithSpaces = Path.Combine(_testDirectory, "backup folder", "sub folder");
+
+        // Act
+        var result = PathValidator.ValidateBackupPath(pathWithSpaces);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/BackupServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/BackupServiceTests.cs
@@ -4,6 +4,7 @@ using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
 using ICCardManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -43,7 +44,10 @@ public class BackupServiceTests : IDisposable
         _settingsRepositoryMock.Setup(x => x.GetAppSettingsAsync())
             .ReturnsAsync(new AppSettings { BackupPath = _backupDirectory });
 
-        _service = new BackupService(_dbContext, _settingsRepositoryMock.Object);
+        _service = new BackupService(
+            _dbContext,
+            _settingsRepositoryMock.Object,
+            NullLogger<BackupService>.Instance);
     }
 
     public void Dispose()
@@ -292,7 +296,10 @@ public class BackupServiceTests : IDisposable
 
         // DbContextを作成して即座に破棄（接続を開かずにパスだけ設定）
         var restoreDbContext = new DbContext(restoreTargetPath);
-        var restoreService = new BackupService(restoreDbContext, _settingsRepositoryMock.Object);
+        var restoreService = new BackupService(
+            restoreDbContext,
+            _settingsRepositoryMock.Object,
+            NullLogger<BackupService>.Instance);
         restoreDbContext.Dispose(); // 接続を開く前に破棄
 
         // Act
@@ -337,7 +344,10 @@ public class BackupServiceTests : IDisposable
 
         // DbContextを作成して即座に破棄
         var restoreDbContext = new DbContext(restoreTargetPath);
-        var restoreService = new BackupService(restoreDbContext, _settingsRepositoryMock.Object);
+        var restoreService = new BackupService(
+            restoreDbContext,
+            _settingsRepositoryMock.Object,
+            NullLogger<BackupService>.Instance);
         restoreDbContext.Dispose();
 
         // Act
@@ -366,7 +376,10 @@ public class BackupServiceTests : IDisposable
         lockedStream.WriteByte(0);
 
         var restoreDbContext = new DbContext(restoreTargetPath);
-        var testService = new BackupService(restoreDbContext, _settingsRepositoryMock.Object);
+        var testService = new BackupService(
+            restoreDbContext,
+            _settingsRepositoryMock.Object,
+            NullLogger<BackupService>.Instance);
         restoreDbContext.Dispose();
 
         // Act
@@ -395,7 +408,10 @@ public class BackupServiceTests : IDisposable
         File.WriteAllText(restoreTargetPath, "different content that should be overwritten");
 
         var restoreDbContext = new DbContext(restoreTargetPath);
-        var restoreService = new BackupService(restoreDbContext, _settingsRepositoryMock.Object);
+        var restoreService = new BackupService(
+            restoreDbContext,
+            _settingsRepositoryMock.Object,
+            NullLogger<BackupService>.Instance);
         restoreDbContext.Dispose();
 
         // Act


### PR DESCRIPTION
## Summary

- パストラバーサル攻撃を防止するため、PathValidatorクラスを実装
- BackupServiceとSettingsViewModelでパス検証を適用
- 無効なパス指定時はデフォルトパスにフォールバック

## 変更内容

### 新規ファイル
| ファイル | 説明 |
|----------|------|
| `Common/PathValidator.cs` | パス検証ユーティリティクラス |
| `PathValidatorTests.cs` | 単体テスト（28ケース） |

### 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `BackupService.cs` | パス検証・ILogger追加 |
| `SettingsViewModel.cs` | 設定保存時のパス検証 |
| `BackupServiceTests.cs` | ILogger依存に対応 |

## パス検証項目

| チェック項目 | 実装 |
|--------------|------|
| null/空文字チェック | ✅ |
| 絶対パス確認 | ✅ |
| パストラバーサル（`..`） | ✅ 拒否 |
| UNCパス（`\\server\share`） | ✅ 拒否 |
| パス長260文字制限 | ✅ |
| ドライブ存在確認 | ✅ |
| 書き込み権限チェック | ✅ |

## セキュリティ対策

### Before（脆弱なコード）
```csharp
var backupPath = settings.BackupPath;  // ユーザー入力
Directory.CreateDirectory(backupPath);  // 検証なしで使用
```

### After（安全なコード）
```csharp
var validationResult = PathValidator.ValidateBackupPath(backupPath);
if (!validationResult.IsValid)
{
    _logger.LogWarning("バックアップパスが無効: {Error}", validationResult.ErrorMessage);
    backupPath = PathValidator.GetDefaultBackupPath();  // フォールバック
}
```

## Test plan

- [x] ビルド成功（0警告、0エラー）
- [x] 全690テスト合格
- [x] パストラバーサル（`..`）を含むパスが拒否される
- [x] UNCパスが拒否される
- [x] 相対パスが拒否される
- [x] 無効なパス指定時にデフォルトパスにフォールバック

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>