### PR TITLE
feat: 履歴画面にページネーション機能を追加 (Issue #73)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -85,4 +85,20 @@ public interface ILedgerRepository
     /// </summary>
     /// <returns>バス停名と使用回数のリスト（使用頻度順）</returns>
     Task<IEnumerable<(string BusStops, int UsageCount)>> GetBusStopSuggestionsAsync();
+
+    /// <summary>
+    /// 指定期間の利用履歴をページング付きで取得
+    /// </summary>
+    /// <param name="cardIdm">ICカードIDm（nullの場合は全カード）</param>
+    /// <param name="fromDate">開始日</param>
+    /// <param name="toDate">終了日</param>
+    /// <param name="page">ページ番号（1から開始）</param>
+    /// <param name="pageSize">1ページあたりの件数</param>
+    /// <returns>履歴リストと総件数のタプル</returns>
+    Task<(IEnumerable<Ledger> Items, int TotalCount)> GetPagedAsync(
+        string? cardIdm,
+        DateTime fromDate,
+        DateTime toDate,
+        int page,
+        int pageSize);
 }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -230,17 +230,108 @@
 
         <!-- フッター -->
         <Grid Grid.Row="3" Margin="0,15,0,0">
-            <TextBlock Text="{Binding StatusMessage}"
-                       Foreground="Gray"
-                       VerticalAlignment="Center"
-                       AutomationProperties.LiveSetting="Polite"/>
-            <Button Content="閉じる"
-                    Click="CloseButton_Click"
-                    HorizontalAlignment="Right"
-                    Padding="20,8"
-                    IsCancel="True"
-                    AutomationProperties.Name="閉じる"
-                    ToolTip="ダイアログを閉じる (Escape)"/>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- ページネーション -->
+            <Border Grid.Row="0"
+                    Background="#F5F5F5"
+                    CornerRadius="4"
+                    Padding="10,8"
+                    Margin="0,0,0,10">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <!-- ナビゲーションボタン -->
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <Button Content="⏮"
+                                Command="{Binding GoToFirstPageCommand}"
+                                Padding="8,4"
+                                MinWidth="32"
+                                ToolTip="最初のページへ"
+                                AutomationProperties.Name="最初のページへ"/>
+                        <Button Content="◀"
+                                Command="{Binding GoToPrevPageCommand}"
+                                Padding="8,4"
+                                MinWidth="32"
+                                Margin="5,0,0,0"
+                                ToolTip="前のページへ"
+                                AutomationProperties.Name="前のページへ"/>
+
+                        <TextBlock Text="ページ"
+                                   VerticalAlignment="Center"
+                                   Margin="15,0,5,0"/>
+                        <Border Background="White"
+                                BorderBrush="#CCCCCC"
+                                BorderThickness="1"
+                                CornerRadius="2"
+                                Padding="10,4">
+                            <TextBlock Text="{Binding PageDisplay}"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center"/>
+                        </Border>
+
+                        <Button Content="▶"
+                                Command="{Binding GoToNextPageCommand}"
+                                Padding="8,4"
+                                MinWidth="32"
+                                Margin="15,0,0,0"
+                                ToolTip="次のページへ"
+                                AutomationProperties.Name="次のページへ"/>
+                        <Button Content="⏭"
+                                Command="{Binding GoToLastPageCommand}"
+                                Padding="8,4"
+                                MinWidth="32"
+                                Margin="5,0,0,0"
+                                ToolTip="最後のページへ"
+                                AutomationProperties.Name="最後のページへ"/>
+                    </StackPanel>
+
+                    <!-- 表示件数選択 -->
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="表示件数:"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"/>
+                        <ComboBox ItemsSource="{Binding PageSizeOptions}"
+                                  SelectedItem="{Binding SelectedPageSizeItem}"
+                                  DisplayMemberPath="DisplayName"
+                                  Width="80"
+                                  Padding="8,4"
+                                  ToolTip="1ページに表示する件数を選択"
+                                  AutomationProperties.Name="表示件数選択"/>
+
+                        <TextBlock Text="|"
+                                   Foreground="#CCCCCC"
+                                   Margin="15,0"
+                                   VerticalAlignment="Center"/>
+
+                        <TextBlock Text="{Binding TotalCount, StringFormat=全 {0:N0} 件}"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <!-- ステータスと閉じるボタン -->
+            <Grid Grid.Row="1">
+                <TextBlock Text="{Binding StatusMessage}"
+                           Foreground="Gray"
+                           VerticalAlignment="Center"
+                           AutomationProperties.LiveSetting="Polite"/>
+                <Button Content="閉じる"
+                        Click="CloseButton_Click"
+                        HorizontalAlignment="Right"
+                        Padding="20,8"
+                        IsCancel="True"
+                        AutomationProperties.Name="閉じる"
+                        ToolTip="ダイアログを閉じる (Escape)"/>
+            </Grid>
         </Grid>
 
         <!-- 処理中オーバーレイ -->


### PR DESCRIPTION
## Summary

- 履歴画面（HistoryDialog）に大量データ対応のためのページネーション機能を追加
- デフォルト50件/ページ（25/50/100/200から選択可能）
- ナビゲーション：最初・前・次・最後のページへ移動
- フィルタ（月選択）変更時は自動的にページ1にリセット

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `ILedgerRepository.cs` | `GetPagedAsync`メソッドのインターフェース追加 |
| `LedgerRepository.cs` | SQL LIMIT/OFFSET による実装 |
| `HistoryViewModel.cs` | ページネーションプロパティ・コマンド追加 |
| `HistoryDialog.xaml` | ページネーションUI追加 |
| `LedgerRepositoryTests.cs` | GetPagedAsync テスト8件追加 |
| `HistoryViewModelTests.cs` | ページネーションテスト20件追加 |

## 実装詳細

### サーバーサイドページング
```sql
SELECT ... FROM ledger
WHERE ...
ORDER BY date DESC, id DESC
LIMIT @pageSize OFFSET @offset
```

### UI コンポーネント
```
[⏮] [◀]  ページ [1 / 10]  [▶] [⏭]    表示件数: [50件▼]  |  全 500 件
```

## Test plan

- [x] ビルドが成功すること
- [x] 全737件のテストがパスすること
- [x] LedgerRepository.GetPagedAsync のテスト（ページング動作）
- [x] HistoryViewModel のページナビゲーションテスト
- [x] フィルタ変更時のページリセットテスト

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)