### PR TITLE
fix: Run.TextバインディングにMode=OneWayを追加して起動時エラーを修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -151,7 +151,7 @@
                                AutomationProperties.Name="残り時間"
                                AutomationProperties.LiveSetting="Polite">
                         <Run Text="残り "/>
-                        <Run Text="{Binding RemainingSeconds}"/>
+                        <Run Text="{Binding RemainingSeconds, Mode=OneWay}"/>
                         <Run Text=" 秒"/>
                     </TextBlock>
                 </StackPanel>
@@ -272,9 +272,9 @@
                                         <TextBlock Grid.Column="1" Grid.Row="0"
                                                    FontWeight="Bold"
                                                    FontSize="{DynamicResource SmallFontSize}">
-                                            <Run Text="{Binding CardType}"/>
+                                            <Run Text="{Binding CardType, Mode=OneWay}"/>
                                             <Run Text=" "/>
-                                            <Run Text="{Binding CardNumber}"/>
+                                            <Run Text="{Binding CardNumber, Mode=OneWay}"/>
                                         </TextBlock>
 
                                         <!-- 残高 -->
@@ -300,7 +300,7 @@
                                                     Orientation="Horizontal">
                                             <TextBlock FontSize="10" Foreground="Gray">
                                                 <Run Text="最終: "/>
-                                                <Run Text="{Binding LastUsageDateDisplay}"/>
+                                                <Run Text="{Binding LastUsageDateDisplay, Mode=OneWay}"/>
                                             </TextBlock>
                                             <TextBlock FontSize="10" Margin="10,0,0,0">
                                                 <TextBlock.Style>
@@ -313,9 +313,9 @@
                                                         </Style.Triggers>
                                                     </Style>
                                                 </TextBlock.Style>
-                                                <Run Text="{Binding LentStatusIcon}"/>
+                                                <Run Text="{Binding LentStatusIcon, Mode=OneWay}"/>
                                                 <Run Text=" "/>
-                                                <Run Text="{Binding LentInfoDisplay}"/>
+                                                <Run Text="{Binding LentInfoDisplay, Mode=OneWay}"/>
                                             </TextBlock>
                                         </StackPanel>
                                     </Grid>
@@ -394,7 +394,7 @@
             <StatusBarItem>
                 <TextBlock>
                     <Run Text="状態: "/>
-                    <Run Text="{Binding CurrentState}"/>
+                    <Run Text="{Binding CurrentState, Mode=OneWay}"/>
                 </TextBlock>
             </StatusBarItem>
             <Separator/>


### PR DESCRIPTION
## 概要

アプリケーション起動時に `XamlParseException` (SYS999エラー) が発生し、起動できない問題を修正しました。

## 問題の原因

WPFの `<Run Text="{Binding Property}"/>` のデフォルトバインディングモードは **TwoWay** です。
そのため、読み取り専用プロパティ（計算プロパティや `init` アクセサ）にバインドすると例外が発生します。

```
XamlParseException: TwoWay または OneWayToSource バインドは、
型 'ICCardManager.Dtos.CardBalanceDashboardItem' の読み取り専用プロパティ 
'LastUsageDateDisplay' では動作できません。
```

## 修正内容

`MainWindow.xaml` の以下のバインディングに `Mode=OneWay` を追加:

| プロパティ | 理由 |
|-----------|------|
| `RemainingSeconds` | ViewModelプロパティ（書き込み不要） |
| `CardType` | `init` アクセサ（初期化後読み取り専用） |
| `CardNumber` | `init` アクセサ（初期化後読み取り専用） |
| `LastUsageDateDisplay` | 計算プロパティ（`=>` で定義） |
| `LentStatusIcon` | 計算プロパティ |
| `LentInfoDisplay` | 計算プロパティ |
| `CurrentState` | ViewModelプロパティ（書き込み不要） |

## テスト方法

```cmd
dotnet run --project src\ICCardManager
```

アプリケーションが正常に起動することを確認してください。

## 技術的な補足

WPFの `Run.Text` プロパティは `FrameworkPropertyMetadataOptions.BindsTwoWayByDefault` が設定されているため、
明示的に `Mode=OneWay` を指定しないとTwoWayバインディングになります。
View→ViewModel方向のみのデータフローでは、常に `Mode=OneWay` を指定することがベストプラクティスです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)