### PR TITLE
fix: カード一覧の横幅を拡張して横スクロールを解消 (Issue #89)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -107,7 +107,7 @@
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="280"/>
+                <ColumnDefinition Width="320"/>
             </Grid.ColumnDefinitions>
 
             <!-- 中央エリア（ステータス表示） -->


### PR DESCRIPTION
## 概要

初期画面右側のカード一覧が狭すぎて、横スクロールしないと全体が見えない問題を修正しました。

Closes #89

## 問題の原因

右サイドバー（カード残高ダッシュボード）の幅が `280px` に固定されており、
以下の情報を表示するには不十分でした：

- カード種別 + 管理番号（例: "nimoca N-002"）
- 残高（例: "¥3,000"）
- 最終利用日（例: "最終: 2025/12/15"）
- 貸出状態（例: "📤 貸出中（山田太郎）"）

特に「貸出中（〇〇）」の表示が長い場合、横スクロールが必要になっていました。

## 修正内容

```xml
<!-- Before -->
<ColumnDefinition Width="280"/>

<!-- After -->
<ColumnDefinition Width="320"/>
```

| 項目 | Before | After |
|------|--------|-------|
| サイドバー幅 | 280px | 320px |
| メインエリア幅 | 720px | 680px |

### 幅の選定理由

- `320px` = カード情報の表示に必要な最小幅
- ウィンドウ幅 `1000px` に対して、メインエリア `680px` は十分な広さ
- 40px の拡張で横スクロールを解消

## テスト方法

```cmd
dotnet run --project src\ICCardManager
```

1. アプリケーションを起動
2. 右側のカード一覧を確認
3. 横スクロールなしで全ての情報が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)