### PR TITLE
feat: トースト通知ウィンドウを追加 (Issue #91)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -148,6 +148,7 @@ public partial class App : Application
         services.AddSingleton<OperationLogger>();
         services.AddSingleton<CsvExportService>();
         services.AddSingleton<CsvImportService>();
+        services.AddSingleton<IToastNotificationService, ToastNotificationService>();
 
         // Infrastructure層
 #if DEBUG

--- a/ICCardManager/src/ICCardManager/Services/IToastNotificationService.cs
+++ b/ICCardManager/src/ICCardManager/Services/IToastNotificationService.cs
@@ -1,0 +1,49 @@
+namespace ICCardManager.Services;
+
+/// <summary>
+/// トースト通知サービスのインターフェース
+/// </summary>
+/// <remarks>
+/// 画面右上に表示されるフォーカスを奪わない通知を管理するサービス。
+/// 貸出・返却時の通知をメインウィンドウとは別ウィンドウで表示し、
+/// 職員の操作を妨げないようにする。
+/// </remarks>
+public interface IToastNotificationService
+{
+    /// <summary>
+    /// 貸出通知を表示
+    /// </summary>
+    /// <param name="cardType">カード種別（例: "はやかけん"）</param>
+    /// <param name="cardNumber">カード番号（例: "H-001"）</param>
+    void ShowLendNotification(string cardType, string cardNumber);
+
+    /// <summary>
+    /// 返却通知を表示
+    /// </summary>
+    /// <param name="cardType">カード種別</param>
+    /// <param name="cardNumber">カード番号</param>
+    /// <param name="balance">残額</param>
+    /// <param name="isLowBalance">残額警告フラグ</param>
+    void ShowReturnNotification(string cardType, string cardNumber, int balance, bool isLowBalance = false);
+
+    /// <summary>
+    /// 情報通知を表示
+    /// </summary>
+    /// <param name="title">タイトル</param>
+    /// <param name="message">メッセージ</param>
+    void ShowInfo(string title, string message);
+
+    /// <summary>
+    /// 警告通知を表示
+    /// </summary>
+    /// <param name="title">タイトル</param>
+    /// <param name="message">メッセージ</param>
+    void ShowWarning(string title, string message);
+
+    /// <summary>
+    /// エラー通知を表示
+    /// </summary>
+    /// <param name="title">タイトル</param>
+    /// <param name="message">メッセージ</param>
+    void ShowError(string title, string message);
+}

--- a/ICCardManager/src/ICCardManager/Services/ToastNotificationService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ToastNotificationService.cs
@@ -1,0 +1,55 @@
+using ICCardManager.Views;
+
+namespace ICCardManager.Services;
+
+/// <summary>
+/// トースト通知サービスの実装
+/// </summary>
+/// <remarks>
+/// ToastNotificationWindowを使用して画面右上に通知を表示する。
+/// フォーカスを奪わないため、職員の操作を妨げない。
+/// </remarks>
+public class ToastNotificationService : IToastNotificationService
+{
+    /// <summary>
+    /// 貸出通知を表示
+    /// </summary>
+    public void ShowLendNotification(string cardType, string cardNumber)
+    {
+        var cardInfo = $"{cardType} {cardNumber}";
+        ToastNotificationWindow.ShowLend(cardInfo);
+    }
+
+    /// <summary>
+    /// 返却通知を表示
+    /// </summary>
+    public void ShowReturnNotification(string cardType, string cardNumber, int balance, bool isLowBalance = false)
+    {
+        var cardInfo = $"{cardType} {cardNumber}";
+        ToastNotificationWindow.ShowReturn(cardInfo, balance, isLowBalance);
+    }
+
+    /// <summary>
+    /// 情報通知を表示
+    /// </summary>
+    public void ShowInfo(string title, string message)
+    {
+        ToastNotificationWindow.Show(ToastType.Info, title, message);
+    }
+
+    /// <summary>
+    /// 警告通知を表示
+    /// </summary>
+    public void ShowWarning(string title, string message)
+    {
+        ToastNotificationWindow.Show(ToastType.Warning, title, message);
+    }
+
+    /// <summary>
+    /// エラー通知を表示
+    /// </summary>
+    public void ShowError(string title, string message)
+    {
+        ToastNotificationWindow.Show(ToastType.Error, title, message);
+    }
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -73,6 +73,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly ISettingsRepository _settingsRepository;
     private readonly LendingService _lendingService;
     private readonly CardTypeDetector _cardTypeDetector;
+    private readonly IToastNotificationService _toastNotificationService;
 
     private DispatcherTimer? _timeoutTimer;
     private string? _currentStaffIdm;
@@ -178,7 +179,8 @@ public partial class MainViewModel : ViewModelBase
         ILedgerRepository ledgerRepository,
         ISettingsRepository settingsRepository,
         LendingService lendingService,
-        CardTypeDetector cardTypeDetector)
+        CardTypeDetector cardTypeDetector,
+        IToastNotificationService toastNotificationService)
     {
         _cardReader = cardReader;
         _soundPlayer = soundPlayer;
@@ -188,6 +190,7 @@ public partial class MainViewModel : ViewModelBase
         _settingsRepository = settingsRepository;
         _lendingService = lendingService;
         _cardTypeDetector = cardTypeDetector;
+        _toastNotificationService = toastNotificationService;
 
         // イベント登録
         _cardReader.CardRead += OnCardRead;
@@ -530,8 +533,13 @@ public partial class MainViewModel : ViewModelBase
         if (result.Success)
         {
             _soundPlayer.Play(SoundType.Lend);
+
+            // トースト通知を表示（画面右上、フォーカスを奪わない）
+            _toastNotificationService.ShowLendNotification(card.CardType, card.CardNumber);
+
+            // メイン画面のステータスも更新（アクセシビリティ対応）
             SetState(AppState.WaitingForStaffCard,
-                $"🚃→ いってらっしゃい！\n{card.CardType} {card.CardNumber}",
+                $"🚃→ 貸出完了\n{card.CardType} {card.CardNumber}",
                 "#FFE0B2"); // 薄いオレンジ
 
             await RefreshLentCardsAsync();
@@ -568,7 +576,11 @@ public partial class MainViewModel : ViewModelBase
         {
             _soundPlayer.Play(SoundType.Return);
 
-            var message = $"🏠← おかえりなさい！\n{card.CardType} {card.CardNumber}\n残額: {result.Balance:N0}円";
+            // トースト通知を表示（画面右上、フォーカスを奪わない）
+            _toastNotificationService.ShowReturnNotification(card.CardType, card.CardNumber, result.Balance, result.IsLowBalance);
+
+            // メイン画面のステータスも更新（アクセシビリティ対応）
+            var message = $"🏠← 返却完了\n{card.CardType} {card.CardNumber}\n残額: {result.Balance:N0}円";
             if (result.IsLowBalance)
             {
                 message += "\n⚠️ 残額が少なくなっています";

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
@@ -1,0 +1,79 @@
+<Window x:Class="ICCardManager.Views.ToastNotificationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="通知"
+        Width="360"
+        Height="Auto"
+        SizeToContent="Height"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        Topmost="True"
+        ShowInTaskbar="False"
+        ShowActivated="False"
+        ResizeMode="NoResize"
+        AutomationProperties.Name="通知ウィンドウ"
+        AutomationProperties.LiveSetting="Assertive">
+
+    <Window.Resources>
+        <!-- フェードイン・アウトアニメーション -->
+        <Storyboard x:Key="FadeInAnimation">
+            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                             From="0" To="1" Duration="0:0:0.3"/>
+        </Storyboard>
+        <Storyboard x:Key="FadeOutAnimation">
+            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                             From="1" To="0" Duration="0:0:0.3"/>
+        </Storyboard>
+    </Window.Resources>
+
+    <Border x:Name="ToastBorder"
+            CornerRadius="12"
+            Margin="10"
+            Padding="20,15"
+            BorderThickness="2">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="15" ShadowDepth="3" Opacity="0.4"/>
+        </Border.Effect>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- アイコン -->
+            <TextBlock x:Name="IconText"
+                       Grid.Column="0"
+                       FontSize="48"
+                       VerticalAlignment="Center"
+                       Margin="0,0,15,0"
+                       AutomationProperties.Name="通知アイコン"/>
+
+            <!-- メッセージ -->
+            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                <TextBlock x:Name="TitleText"
+                           FontSize="22"
+                           FontWeight="Bold"
+                           TextWrapping="Wrap"
+                           AutomationProperties.Name="通知タイトル"/>
+                <TextBlock x:Name="MessageText"
+                           FontSize="14"
+                           Margin="0,5,0,0"
+                           TextWrapping="Wrap"
+                           Opacity="0.8"
+                           AutomationProperties.Name="通知メッセージ"/>
+                <TextBlock x:Name="SubMessageText"
+                           FontSize="12"
+                           Margin="0,5,0,0"
+                           TextWrapping="Wrap"
+                           Opacity="0.6"
+                           Visibility="Collapsed"
+                           AutomationProperties.Name="追加メッセージ"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
@@ -1,0 +1,223 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
+
+namespace ICCardManager.Views;
+
+/// <summary>
+/// トースト通知の種類
+/// </summary>
+public enum ToastType
+{
+    /// <summary>
+    /// 貸出（いってらっしゃい）
+    /// </summary>
+    Lend,
+
+    /// <summary>
+    /// 返却（おかえりなさい）
+    /// </summary>
+    Return,
+
+    /// <summary>
+    /// 情報
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// 警告
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// エラー
+    /// </summary>
+    Error
+}
+
+/// <summary>
+/// トースト通知ウィンドウ
+/// </summary>
+/// <remarks>
+/// 画面右上に表示されるフォーカスを奪わない通知ウィンドウ。
+/// 貸出・返却時の「いってらっしゃい！」「おかえりなさい！」メッセージを
+/// メインウィンドウとは別に表示し、職員の操作を妨げないようにする。
+/// </remarks>
+public partial class ToastNotificationWindow : Window
+{
+    private readonly DispatcherTimer _autoCloseTimer;
+    private const int DefaultDisplayDurationMs = 3000;
+
+    public ToastNotificationWindow()
+    {
+        InitializeComponent();
+
+        // 自動クローズタイマー
+        _autoCloseTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(DefaultDisplayDurationMs)
+        };
+        _autoCloseTimer.Tick += OnAutoCloseTimerTick;
+
+        // 画面右上に配置
+        Loaded += OnLoaded;
+    }
+
+    /// <summary>
+    /// ウィンドウ読み込み時に画面右上に配置
+    /// </summary>
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        PositionToTopRight();
+        StartFadeInAnimation();
+        _autoCloseTimer.Start();
+    }
+
+    /// <summary>
+    /// 画面右上に配置
+    /// </summary>
+    private void PositionToTopRight()
+    {
+        var workArea = SystemParameters.WorkArea;
+        Left = workArea.Right - ActualWidth - 20;
+        Top = workArea.Top + 20;
+    }
+
+    /// <summary>
+    /// フェードインアニメーション開始
+    /// </summary>
+    private void StartFadeInAnimation()
+    {
+        var storyboard = (Storyboard)FindResource("FadeInAnimation");
+        storyboard.Begin(this);
+    }
+
+    /// <summary>
+    /// フェードアウトして閉じる
+    /// </summary>
+    private void FadeOutAndClose()
+    {
+        var storyboard = (Storyboard)FindResource("FadeOutAnimation");
+        storyboard.Completed += (s, e) => Close();
+        storyboard.Begin(this);
+    }
+
+    /// <summary>
+    /// 自動クローズタイマーのTick
+    /// </summary>
+    private void OnAutoCloseTimerTick(object? sender, EventArgs e)
+    {
+        _autoCloseTimer.Stop();
+        FadeOutAndClose();
+    }
+
+    /// <summary>
+    /// 貸出通知を表示
+    /// </summary>
+    /// <param name="cardInfo">カード情報（例: "はやかけん H-001"）</param>
+    public static void ShowLend(string cardInfo)
+    {
+        Show(ToastType.Lend, "いってらっしゃい！", cardInfo);
+    }
+
+    /// <summary>
+    /// 返却通知を表示
+    /// </summary>
+    /// <param name="cardInfo">カード情報（例: "はやかけん H-001"）</param>
+    /// <param name="balance">残額</param>
+    /// <param name="isLowBalance">残額警告フラグ</param>
+    public static void ShowReturn(string cardInfo, int balance, bool isLowBalance = false)
+    {
+        var subMessage = isLowBalance ? "⚠️ 残額が少なくなっています" : null;
+        Show(ToastType.Return, "おかえりなさい！", cardInfo, $"残額: {balance:N0}円", subMessage);
+    }
+
+    /// <summary>
+    /// 通知を表示
+    /// </summary>
+    /// <param name="type">通知種類</param>
+    /// <param name="title">タイトル</param>
+    /// <param name="message">メッセージ</param>
+    /// <param name="additionalInfo">追加情報</param>
+    /// <param name="subMessage">サブメッセージ</param>
+    public static void Show(ToastType type, string title, string message, string? additionalInfo = null, string? subMessage = null)
+    {
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            var toast = new ToastNotificationWindow();
+            toast.ApplyStyle(type);
+            toast.TitleText.Text = title;
+            toast.MessageText.Text = message;
+
+            if (!string.IsNullOrEmpty(additionalInfo))
+            {
+                toast.MessageText.Text = $"{message}\n{additionalInfo}";
+            }
+
+            if (!string.IsNullOrEmpty(subMessage))
+            {
+                toast.SubMessageText.Text = subMessage;
+                toast.SubMessageText.Visibility = Visibility.Visible;
+            }
+
+            toast.Show();
+        });
+    }
+
+    /// <summary>
+    /// 通知種類に応じたスタイルを適用
+    /// </summary>
+    private void ApplyStyle(ToastType type)
+    {
+        switch (type)
+        {
+            case ToastType.Lend:
+                // 貸出: 暖色系オレンジ（アクセシビリティ対応）
+                IconText.Text = "🚃";
+                ToastBorder.Background = new SolidColorBrush(Color.FromRgb(255, 243, 224)); // #FFF3E0
+                ToastBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(255, 152, 0));  // #FF9800
+                TitleText.Foreground = new SolidColorBrush(Color.FromRgb(230, 81, 0));     // #E65100
+                MessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));    // #424242
+                SubMessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                break;
+
+            case ToastType.Return:
+                // 返却: 寒色系青（アクセシビリティ対応）
+                IconText.Text = "🏠";
+                ToastBorder.Background = new SolidColorBrush(Color.FromRgb(227, 242, 253)); // #E3F2FD
+                ToastBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(33, 150, 243)); // #2196F3
+                TitleText.Foreground = new SolidColorBrush(Color.FromRgb(13, 71, 161));    // #0D47A1
+                MessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));    // #424242
+                SubMessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                break;
+
+            case ToastType.Info:
+                IconText.Text = "ℹ️";
+                ToastBorder.Background = new SolidColorBrush(Color.FromRgb(227, 242, 253)); // #E3F2FD
+                ToastBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(33, 150, 243)); // #2196F3
+                TitleText.Foreground = new SolidColorBrush(Color.FromRgb(13, 71, 161));    // #0D47A1
+                MessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                SubMessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                break;
+
+            case ToastType.Warning:
+                IconText.Text = "⚠️";
+                ToastBorder.Background = new SolidColorBrush(Color.FromRgb(255, 243, 224)); // #FFF3E0
+                ToastBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(255, 152, 0));  // #FF9800
+                TitleText.Foreground = new SolidColorBrush(Color.FromRgb(230, 81, 0));     // #E65100
+                MessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                SubMessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                break;
+
+            case ToastType.Error:
+                IconText.Text = "❌";
+                ToastBorder.Background = new SolidColorBrush(Color.FromRgb(255, 235, 238)); // #FFEBEE
+                ToastBorder.BorderBrush = new SolidColorBrush(Color.FromRgb(244, 67, 54));  // #F44336
+                TitleText.Foreground = new SolidColorBrush(Color.FromRgb(183, 28, 28));    // #B71C1C
+                MessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                SubMessageText.Foreground = new SolidColorBrush(Color.FromRgb(66, 66, 66));
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- 貸出・返却時の「いってらっしゃい！」「おかえりなさい！」メッセージを画面右上のトースト通知として表示
- メインウィンドウのフォーカスを奪わないため、職員の操作を妨げない
- 3秒後に自動でフェードアウトして消去

## 変更内容

### 新規ファイル
- `Views/ToastNotificationWindow.xaml` / `.xaml.cs` - トースト通知ウィンドウ
  - 画面右上に表示 (`SystemParameters.WorkArea` を使用)
  - フォーカスを奪わない (`ShowActivated="False"`)
  - フェードイン/フェードアウトアニメーション
  - 貸出: 暖色系オレンジ（🚃アイコン）
  - 返却: 寒色系青（🏠アイコン）+ 残額表示 + 残額警告
- `Services/IToastNotificationService.cs` / `ToastNotificationService.cs` - DIサービス

### 変更ファイル
- `App.xaml.cs` - `IToastNotificationService` をDIコンテナに登録
- `ViewModels/MainViewModel.cs` - 貸出・返却処理でトースト通知を表示

## アクセシビリティ対応

| 要素 | 対応内容 |
|------|----------|
| 色覚多様性 | 貸出（暖色オレンジ）と返却（寒色青）で色相差を明確に |
| 多重表現 | 色・アイコン・テキストの3要素で状態を伝達 |
| 音 | 従来通り貸出音・返却音を再生 |
| メイン画面 | トースト表示と同時に、メイン画面のステータスも更新 |

## Test plan

- [x] デバッグ実行してアプリが起動することを確認
- [x] デバッグボタンで職員証→ICカードをシミュレート
- [x] 貸出時に画面右上に「いってらっしゃい！」トーストが表示されること
- [x] 返却時に画面右上に「おかえりなさい！」トーストが表示されること
- [x] トーストがフォーカスを奪わないこと（別のアプリにフォーカスがあっても切り替わらない）
- [x] トーストが3秒後に自動で消えること
- [ ] 残額警告時にサブメッセージが表示されること

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)