### PR TITLE
fix: 「すべて選択」チェックボックスと個別カード選択の連動を修正 (Issue #99)

### DIFF
--- a/ICCardManager/src/ICCardManager/Dtos/CardDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/CardDto.cs
@@ -1,11 +1,18 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace ICCardManager.Dtos;
 
 /// <summary>
 /// カード情報DTO
 /// ViewModelで使用するカード情報の表示用オブジェクト
 /// </summary>
-public class CardDto
+public partial class CardDto : ObservableObject
 {
+    /// <summary>
+    /// 選択状態（帳票作成画面等で使用）
+    /// </summary>
+    [ObservableProperty]
+    private bool _isSelected;
     /// <summary>
     /// カードIDm（16進数16文字）
     /// </summary>

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -381,6 +381,119 @@ public class ReportViewModelTests
 
     #endregion
 
+    #region 個別チェックボックス連動テスト
+
+    /// <summary>
+    /// 個別のカードのIsSelectedを変更するとSelectedCardsが更新されること
+    /// </summary>
+    [Fact]
+    public async Task CardIsSelected_WhenChangedToFalse_ShouldRemoveFromSelectedCards()
+    {
+        // Arrange
+        var cards = new List<IcCard>
+        {
+            new() { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" },
+            new() { CardIdm = "02", CardType = "はやかけん", CardNumber = "H-001" }
+        };
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(cards);
+        await _viewModel.LoadCardsAsync();
+
+        var targetCard = _viewModel.Cards[0];
+        _viewModel.SelectedCards.Should().HaveCount(2);
+
+        // Act - 個別チェックボックスをOFFにする（UIの動作をシミュレート）
+        targetCard.IsSelected = false;
+
+        // Assert
+        _viewModel.SelectedCards.Should().HaveCount(1);
+        _viewModel.SelectedCards.Should().NotContain(targetCard);
+        _viewModel.IsAllSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 個別のカードのIsSelectedを変更してすべて選択状態になるとIsAllSelectedがtrueになること
+    /// </summary>
+    [Fact]
+    public async Task CardIsSelected_WhenAllSelected_ShouldSetIsAllSelectedToTrue()
+    {
+        // Arrange
+        var cards = new List<IcCard>
+        {
+            new() { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" },
+            new() { CardIdm = "02", CardType = "はやかけん", CardNumber = "H-001" }
+        };
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(cards);
+        await _viewModel.LoadCardsAsync();
+
+        // 全解除
+        _viewModel.IsAllSelected = false;
+        _viewModel.SelectedCards.Should().BeEmpty();
+
+        // Act - 個別に全カードを選択
+        foreach (var card in _viewModel.Cards)
+        {
+            card.IsSelected = true;
+        }
+
+        // Assert
+        _viewModel.SelectedCards.Should().HaveCount(2);
+        _viewModel.IsAllSelected.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// すべて選択チェックボックスをONにすると各カードのIsSelectedもtrueになること
+    /// </summary>
+    [Fact]
+    public async Task IsAllSelected_WhenSetToTrue_ShouldSetAllCardsIsSelectedToTrue()
+    {
+        // Arrange
+        var cards = new List<IcCard>
+        {
+            new() { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" },
+            new() { CardIdm = "02", CardType = "はやかけん", CardNumber = "H-001" }
+        };
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(cards);
+        await _viewModel.LoadCardsAsync();
+
+        // 全解除
+        _viewModel.IsAllSelected = false;
+        _viewModel.Cards.All(c => !c.IsSelected).Should().BeTrue();
+
+        // Act
+        _viewModel.IsAllSelected = true;
+
+        // Assert
+        _viewModel.Cards.All(c => c.IsSelected).Should().BeTrue();
+        _viewModel.SelectedCards.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// すべて選択チェックボックスをOFFにすると各カードのIsSelectedもfalseになること
+    /// </summary>
+    [Fact]
+    public async Task IsAllSelected_WhenSetToFalse_ShouldSetAllCardsIsSelectedToFalse()
+    {
+        // Arrange
+        var cards = new List<IcCard>
+        {
+            new() { CardIdm = "01", CardType = "nimoca", CardNumber = "N-001" },
+            new() { CardIdm = "02", CardType = "はやかけん", CardNumber = "H-001" }
+        };
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(cards);
+        await _viewModel.LoadCardsAsync();
+
+        _viewModel.Cards.All(c => c.IsSelected).Should().BeTrue();
+
+        // Act
+        _viewModel.IsAllSelected = false;
+
+        // Assert
+        _viewModel.Cards.All(c => !c.IsSelected).Should().BeTrue();
+        _viewModel.SelectedCards.Should().BeEmpty();
+    }
+
+    #endregion
+
     #region InitializeAsyncテスト
 
     /// <summary>


### PR DESCRIPTION
## 概要

Issue #99 に対応し、帳票作成画面の「対象カード」セクションで「すべて選択」チェックボックスが正しく動作するように修正しました。

Closes #99

## 問題点

1. **CardDtoにIsSelectedプロパティが存在しなかった**
   - XAML: `{Binding IsSelected, Mode=TwoWay}` でバインドしていた
   - しかし `CardDto` クラスには `IsSelected` プロパティがなく、バインドが機能していなかった

2. **SelectedCardsコレクションとUIの不整合**
   - ViewModelは `SelectedCards` コレクションを管理
   - UIは個々のカードの `IsSelected` を表示
   - この2つが同期されていなかった

## 修正内容

### CardDto.cs
- `ObservableObject` を継承し、`INotifyPropertyChanged` をサポート
- `[ObservableProperty]` で `IsSelected` プロパティを追加

### ReportViewModel.cs
- `PropertyChanged` イベントを購読して `IsSelected` 変更を監視
- `SelectAllCards()`: 各カードの `IsSelected = true` を設定
- `DeselectAllCards()`: 各カードの `IsSelected = false` を設定
- バルク操作中のイベント発火を防止する `_isBulkUpdating` フラグを追加
- 無限ループ防止用の `_isUpdatingFromCardSelection` フラグを追加

### テスト追加 (4件)
- `CardIsSelected_WhenChangedToFalse_ShouldRemoveFromSelectedCards`
- `CardIsSelected_WhenAllSelected_ShouldSetIsAllSelectedToTrue`
- `IsAllSelected_WhenSetToTrue_ShouldSetAllCardsIsSelectedToTrue`
- `IsAllSelected_WhenSetToFalse_ShouldSetAllCardsIsSelectedToFalse`

## テスト結果

```
テストの実行に成功しました。
テストの合計数: 21
     成功: 21
```

## 技術的な詳細

### 状態同期の仕組み

```
┌─────────────────────────────────────────────────────────────┐
│  「すべて選択」チェックボックス                                 │
│  IsAllSelected = true/false                                  │
│       ↓                                                      │
│  OnIsAllSelectedChanged()                                    │
│       ↓                                                      │
│  SelectAllCards() / DeselectAllCards()                       │
│       ↓                                                      │
│  各CardDto.IsSelected = true/false                           │
│       ↓                                                      │
│  UI上の個別チェックボックスが更新される                         │
└─────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────┐
│  個別チェックボックスをクリック                                │
│  CardDto.IsSelected が変更される                             │
│       ↓                                                      │
│  OnCardPropertyChanged()                                     │
│       ↓                                                      │
│  SelectedCards コレクションを更新                             │
│       ↓                                                      │
│  IsAllSelected を再計算（全選択ならtrue）                     │
└─────────────────────────────────────────────────────────────┘
```

### 無限ループ防止

- `_isBulkUpdating`: SelectAllCards/DeselectAllCards実行中は `OnCardPropertyChanged` をスキップ
- `_isUpdatingFromCardSelection`: 個別選択からの `IsAllSelected` 更新時は `OnIsAllSelectedChanged` をスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)