### PR TITLE
fix: 対象カード一覧の不要な選択ハイライトを削除 (Issue #101)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -121,34 +121,48 @@
                           ToolTip="すべてのカードを選択または解除"/>
 
                 <!-- カード一覧 -->
-                <ListView Grid.Row="1"
-                          ItemsSource="{Binding Cards}"
-                          SelectionMode="Multiple"
-                          BorderThickness="1"
-                          BorderBrush="#DDDDDD">
-                    <ListView.ItemTemplate>
+                <!-- Note: チェックボックスで選択を管理するため、ListViewの選択機能は無効化 -->
+                <ItemsControl Grid.Row="1"
+                              ItemsSource="{Binding Cards}"
+                              BorderThickness="1"
+                              BorderBrush="#DDDDDD"
+                              Background="White">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.Template>
+                        <ControlTemplate TargetType="ItemsControl">
+                            <Border BorderThickness="{TemplateBinding BorderThickness}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Background="{TemplateBinding Background}">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter/>
+                                </ScrollViewer>
+                            </Border>
+                        </ControlTemplate>
+                    </ItemsControl.Template>
+                    <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
-                                      Margin="5">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding CardType}"
-                                               Width="100"
-                                               FontWeight="Bold"/>
-                                    <TextBlock Text="{Binding CardNumber}"
-                                               Width="100"/>
-                                    <TextBlock Text="{Binding Note}"
-                                               Foreground="Gray"/>
-                                </StackPanel>
-                            </CheckBox>
+                            <Border Padding="5" BorderThickness="0,0,0,1" BorderBrush="#EEEEEE">
+                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                          Margin="5">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{Binding CardType}"
+                                                   Width="100"
+                                                   FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding CardNumber}"
+                                                   Width="100"/>
+                                        <TextBlock Text="{Binding Note}"
+                                                   Foreground="Gray"/>
+                                    </StackPanel>
+                                </CheckBox>
+                            </Border>
                         </DataTemplate>
-                    </ListView.ItemTemplate>
-                    <ListView.ItemContainerStyle>
-                        <Style TargetType="ListViewItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                            <Setter Property="Padding" Value="5"/>
-                        </Style>
-                    </ListView.ItemContainerStyle>
-                </ListView>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </Grid>
         </GroupBox>
 


### PR DESCRIPTION
## 概要

Issue #101 に対応し、帳票作成画面の「対象カード」一覧で、チェックボックスとは無関係に表示されていた青い選択ハイライトを削除しました。

Closes #101

## 問題点

**スクリーンショット（修正前）**

カードをクリックすると、チェックボックスの状態とは関係なく青いハイライトが表示されていました。
これは `ListView` の組み込み選択機能が原因でした。

## 修正内容

### ReportDialog.xaml
- `ListView` を `ItemsControl` に変更
- `ItemsControl` は選択機能を持たないため、青いハイライトが表示されなくなりました
- スクロール機能は `ScrollViewer` で維持
- 各アイテムに薄いボーダー（`#EEEEEE`）を追加して視認性を向上

### 変更前後の比較

| 項目 | 変更前 (ListView) | 変更後 (ItemsControl) |
|------|-------------------|----------------------|
| 選択機能 | あり（青いハイライト） | なし |
| チェックボックス | 独立して動作 | 唯一の選択手段 |
| スクロール | 自動 | ScrollViewerで実装 |

## テスト結果

```
テストの実行に成功しました。
テストの合計数: 21
     成功: 21
```

## 技術的な詳細

### なぜ ListView ではなく ItemsControl を使用したか

1. **ListView/ListBoxの問題点**:
   - 組み込みの選択機能（`SelectionMode`）があり、クリックでアイテムが選択される
   - 選択されたアイテムは青くハイライトされる
   - この動作を完全に無効化するにはテンプレートの大幅な変更が必要

2. **ItemsControl の利点**:
   - アイテムの表示のみを担当し、選択機能を持たない
   - チェックボックスが唯一の選択手段となり、ユーザーの混乱を防げる
   - シンプルなテンプレートで実装可能

### ScrollViewer の追加

`ItemsControl` 単体ではスクロール機能がないため、`ControlTemplate` 内に `ScrollViewer` を配置してスクロール機能を提供しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)