### PR TITLE
refactor: 例外ハンドリングの改善と統一 (Issue #80)

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/Exceptions/CardReaderException.cs
+++ b/ICCardManager/src/ICCardManager/Common/Exceptions/CardReaderException.cs
@@ -38,9 +38,11 @@ public class CardReaderException : AppException
     /// <summary>
     /// カード履歴読み取り失敗
     /// </summary>
-    public static CardReaderException HistoryReadFailed(Exception? innerException = null)
+    public static CardReaderException HistoryReadFailed(string? detail = null, Exception? innerException = null)
     {
-        const string message = "Failed to read card history";
+        var message = string.IsNullOrEmpty(detail)
+            ? "Failed to read card history"
+            : $"Failed to read card history: {detail}";
         const string userMessage = "カードの利用履歴を読み取れませんでした。";
         const string errorCode = "CR003";
 
@@ -52,9 +54,11 @@ public class CardReaderException : AppException
     /// <summary>
     /// カード残高読み取り失敗
     /// </summary>
-    public static CardReaderException BalanceReadFailed(Exception? innerException = null)
+    public static CardReaderException BalanceReadFailed(string? detail = null, Exception? innerException = null)
     {
-        const string message = "Failed to read card balance";
+        var message = string.IsNullOrEmpty(detail)
+            ? "Failed to read card balance"
+            : $"Failed to read card balance: {detail}";
         const string userMessage = "カードの残高を読み取れませんでした。";
         const string errorCode = "CR004";
 
@@ -71,6 +75,64 @@ public class CardReaderException : AppException
         const string message = "Card reader communication timeout";
         const string userMessage = "カードリーダーとの通信がタイムアウトしました。再度お試しください。";
         const string errorCode = "CR005";
+
+        return innerException != null
+            ? new CardReaderException(message, userMessage, errorCode, innerException)
+            : new CardReaderException(message, userMessage, errorCode);
+    }
+
+    /// <summary>
+    /// スマートカードサービスが起動していない
+    /// </summary>
+    public static CardReaderException ServiceNotAvailable(Exception? innerException = null)
+    {
+        const string message = "Smart card service is not running";
+        const string userMessage = "スマートカードサービスが起動していません。Windowsの設定を確認してください。";
+        const string errorCode = "CR006";
+
+        return innerException != null
+            ? new CardReaderException(message, userMessage, errorCode, innerException)
+            : new CardReaderException(message, userMessage, errorCode);
+    }
+
+    /// <summary>
+    /// 監視エラー（モニター例外）
+    /// </summary>
+    public static CardReaderException MonitorError(string? detail = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(detail)
+            ? "Card reader monitor error"
+            : $"Card reader monitor error: {detail}";
+        const string userMessage = "カードリーダーの監視中にエラーが発生しました。接続を確認してください。";
+        const string errorCode = "CR007";
+
+        return innerException != null
+            ? new CardReaderException(message, userMessage, errorCode, innerException)
+            : new CardReaderException(message, userMessage, errorCode);
+    }
+
+    /// <summary>
+    /// 再接続失敗
+    /// </summary>
+    public static CardReaderException ReconnectFailed(int attemptCount, Exception? innerException = null)
+    {
+        var message = $"Failed to reconnect to card reader after {attemptCount} attempts";
+        var userMessage = $"カードリーダーへの再接続に失敗しました（{attemptCount}回試行）。接続を確認して手動で再接続してください。";
+        const string errorCode = "CR008";
+
+        return innerException != null
+            ? new CardReaderException(message, userMessage, errorCode, innerException)
+            : new CardReaderException(message, userMessage, errorCode);
+    }
+
+    /// <summary>
+    /// カード取り外し（読み取り中にカードが離された）
+    /// </summary>
+    public static CardReaderException CardRemoved(Exception? innerException = null)
+    {
+        const string message = "Card was removed during read operation";
+        const string userMessage = "カードの読み取り中にカードが離されました。カードをリーダーに置いたままお待ちください。";
+        const string errorCode = "CR009";
 
         return innerException != null
             ? new CardReaderException(message, userMessage, errorCode, innerException)

--- a/ICCardManager/src/ICCardManager/Common/Exceptions/FileOperationException.cs
+++ b/ICCardManager/src/ICCardManager/Common/Exceptions/FileOperationException.cs
@@ -1,0 +1,136 @@
+namespace ICCardManager.Common.Exceptions;
+
+/// <summary>
+/// ファイル操作関連の例外
+/// </summary>
+public class FileOperationException : AppException
+{
+    /// <summary>
+    /// 操作対象のファイルパス
+    /// </summary>
+    public string? FilePath { get; }
+
+    /// <summary>
+    /// ファイルが見つからない
+    /// </summary>
+    public static FileOperationException FileNotFound(string filePath, Exception? innerException = null)
+    {
+        var message = $"File not found: {filePath}";
+        const string userMessage = "指定されたファイルが見つかりません。";
+        const string errorCode = "FILE001";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// ファイル読み込み失敗
+    /// </summary>
+    public static FileOperationException ReadFailed(string? filePath = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(filePath)
+            ? "Failed to read file"
+            : $"Failed to read file: {filePath}";
+        const string userMessage = "ファイルの読み込みに失敗しました。ファイルが他のアプリケーションで使用されていないか確認してください。";
+        const string errorCode = "FILE002";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// ファイル書き込み失敗
+    /// </summary>
+    public static FileOperationException WriteFailed(string? filePath = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(filePath)
+            ? "Failed to write file"
+            : $"Failed to write file: {filePath}";
+        const string userMessage = "ファイルの書き込みに失敗しました。書き込み先フォルダへのアクセス権限を確認してください。";
+        const string errorCode = "FILE003";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// ファイルアクセス権限なし
+    /// </summary>
+    public static FileOperationException AccessDenied(string? filePath = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(filePath)
+            ? "File access denied"
+            : $"File access denied: {filePath}";
+        const string userMessage = "ファイルへのアクセス権限がありません。管理者に連絡してください。";
+        const string errorCode = "FILE004";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// ファイルが使用中
+    /// </summary>
+    public static FileOperationException FileInUse(string? filePath = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(filePath)
+            ? "File is in use by another process"
+            : $"File is in use by another process: {filePath}";
+        const string userMessage = "ファイルが他のアプリケーションで使用中です。ファイルを閉じてから再度お試しください。";
+        const string errorCode = "FILE005";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// 無効なファイル形式
+    /// </summary>
+    public static FileOperationException InvalidFormat(string? filePath = null, string? expectedFormat = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(filePath)
+            ? "Invalid file format"
+            : $"Invalid file format: {filePath}";
+        var userMessage = string.IsNullOrEmpty(expectedFormat)
+            ? "ファイル形式が正しくありません。"
+            : $"ファイル形式が正しくありません。{expectedFormat}形式のファイルを選択してください。";
+        const string errorCode = "FILE006";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, filePath, innerException)
+            : new FileOperationException(message, userMessage, errorCode, filePath);
+    }
+
+    /// <summary>
+    /// ディレクトリ作成失敗
+    /// </summary>
+    public static FileOperationException DirectoryCreationFailed(string? path = null, Exception? innerException = null)
+    {
+        var message = string.IsNullOrEmpty(path)
+            ? "Failed to create directory"
+            : $"Failed to create directory: {path}";
+        const string userMessage = "フォルダの作成に失敗しました。書き込み権限を確認してください。";
+        const string errorCode = "FILE007";
+
+        return innerException != null
+            ? new FileOperationException(message, userMessage, errorCode, path, innerException)
+            : new FileOperationException(message, userMessage, errorCode, path);
+    }
+
+    private FileOperationException(string message, string userFriendlyMessage, string errorCode, string? filePath)
+        : base(message, userFriendlyMessage, errorCode)
+    {
+        FilePath = filePath;
+    }
+
+    private FileOperationException(string message, string userFriendlyMessage, string errorCode, string? filePath, Exception innerException)
+        : base(message, userFriendlyMessage, errorCode, innerException)
+    {
+        FilePath = filePath;
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -1,6 +1,8 @@
 using System.IO;
+using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using ICCardManager.Common.Exceptions;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Infrastructure.Caching;
@@ -330,7 +332,12 @@ public class CsvImportService
                     importedCount = 0;
                 }
             }
-            catch
+            catch (SqliteException ex)
+            {
+                transaction.Rollback();
+                throw DatabaseException.QueryFailed("CSV import transaction", ex);
+            }
+            catch (Exception)
             {
                 transaction.Rollback();
                 throw;
@@ -345,12 +352,48 @@ public class CsvImportService
                 Errors = errors
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportResult
             {
                 Success = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (DatabaseException ex)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = ex.UserFriendlyMessage,
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }
@@ -533,7 +576,12 @@ public class CsvImportService
                     importedCount = 0;
                 }
             }
-            catch
+            catch (SqliteException ex)
+            {
+                transaction.Rollback();
+                throw DatabaseException.QueryFailed("CSV import transaction", ex);
+            }
+            catch (Exception)
             {
                 transaction.Rollback();
                 throw;
@@ -548,12 +596,48 @@ public class CsvImportService
                 Errors = errors
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportResult
             {
                 Success = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (DatabaseException ex)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = ex.UserFriendlyMessage,
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }
@@ -700,12 +784,39 @@ public class CsvImportService
                 Items = items
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportPreviewResult
             {
                 IsValid = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }
@@ -841,12 +952,39 @@ public class CsvImportService
                 Items = items
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportPreviewResult
             {
                 IsValid = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }
@@ -1089,12 +1227,39 @@ public class CsvImportService
                 Errors = errors
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportResult
             {
                 Success = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }
@@ -1240,12 +1405,39 @@ public class CsvImportService
                 Items = items
             };
         }
-        catch (Exception ex)
+        catch (FileNotFoundException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "指定されたファイルが見つかりません。",
+                Errors = errors
+            };
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = "ファイルへのアクセス権限がありません。",
+                Errors = errors
+            };
+        }
+        catch (IOException ex)
         {
             return new CsvImportPreviewResult
             {
                 IsValid = false,
                 ErrorMessage = $"ファイルの読み込みエラー: {ex.Message}",
+                Errors = errors
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CsvImportPreviewResult
+            {
+                IsValid = false,
+                ErrorMessage = $"予期しないエラーが発生しました: {ex.Message}",
                 Errors = errors
             };
         }

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderIntegrationTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderIntegrationTests.cs
@@ -390,7 +390,6 @@ public class DefaultPcScProviderIntegrationTests : IDisposable
         {
             _skipReason = $"スマートカードサービスが利用できません: {ex.Message}";
             _output.WriteLine($"[SKIP] {_skipReason}");
-            _serviceAvailable = false;
             return false;
         }
     }

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using ICCardManager.Common.Exceptions;
 using ICCardManager.Infrastructure.CardReader;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -90,7 +91,7 @@ public class PcScCardReaderTests : IDisposable
         var reader = CreateReader();
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(() => reader.StartReadingAsync());
+        await Assert.ThrowsAsync<CardReaderException>(() => reader.StartReadingAsync());
         // 例外がスローされた後、Disconnected状態になっていることを確認
         reader.ConnectionState.Should().Be(CardReaderConnectionState.Disconnected);
     }
@@ -107,7 +108,7 @@ public class PcScCardReaderTests : IDisposable
         var reader = CreateReader();
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(() => reader.StartReadingAsync());
+        await Assert.ThrowsAsync<CardReaderException>(() => reader.StartReadingAsync());
         reader.ConnectionState.Should().Be(CardReaderConnectionState.Disconnected);
     }
 


### PR DESCRIPTION
## 概要
Issue #80 で要求された例外ハンドリングの改善を実装しました。

## 変更内容

### 🎯 目的
- 汎用的な `catch (Exception)` を具体的な例外型に置き換え
- カスタム例外クラスを拡張して詳細なエラー情報を提供
- 例外チェーン（InnerException）の保持によるデバッグ性の向上

### 📁 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `CardReaderException.cs` | `HistoryReadFailed`, `BalanceReadFailed` にdetailパラメータ追加 |
| `FileOperationException.cs` | **新規作成** - ファイル操作エラー用のカスタム例外 |
| `BackupService.cs` | 具体的な例外ハンドリング（UnauthorizedAccess, IOException, SecurityException） |
| `CsvImportService.cs` | FileNotFound, UnauthorizedAccess 等の個別ハンドリング |
| `PcScCardReader.cs` | PCSCException のエラーコード別処理、CardReaderException への統一 |
| `ReportService.cs` | ディレクトリ作成エラー、アクセス権エラーの詳細化 |

### 🔧 主な改善点

1. **例外の具体化**
   - `UnauthorizedAccessException` → アクセス権限エラーを明示
   - `IOException` → I/Oエラーを明示
   - `SecurityException` → セキュリティエラーを明示
   - `FileNotFoundException` → ファイル未検出を明示

2. **カスタム例外の活用**
   - `CardReaderException`: カードリーダー関連のエラーを体系的に管理
   - `FileOperationException`: ファイル操作エラーを体系的に管理
   - `DatabaseException`: DB関連エラーのラップ

3. **ログの改善**
   - エラーログに詳細なコンテキスト情報（パス、ソース等）を追加
   - 例外チェーンを保持して根本原因の追跡を容易に

### ✅ テスト
- 全32件のPcScCardReaderテストが成功
- テストも `CardReaderException` を期待するように更新

### 📝 注意事項
- `OperationLogRepositoryTests` の2件のテスト失敗は本PR以前からの既存問題であり、本変更とは無関係です

## Test Plan
- [x] ビルド成功
- [x] PcScCardReaderTests 全32件成功
- [x] 主要な例外パターンのテストがパス

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)