### PR TITLE
test: 駅コードから履歴文字列への変換の単体テストを追加 (Issue #129)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Services/StationCodeToSummaryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/StationCodeToSummaryTests.cs
@@ -132,16 +132,16 @@ public class StationCodeToSummaryTests
     /// </summary>
     private static string GetCardTypeName(CardType? cardType) => cardType switch
     {
-        Common.CardType.Hayakaken => "はやかけん",
-        Common.CardType.Suica => "Suica",
-        Common.CardType.PASMO => "PASMO",
-        Common.CardType.ICOCA => "ICOCA",
-        Common.CardType.SUGOCA => "SUGOCA",
-        Common.CardType.Nimoca => "nimoca",
-        Common.CardType.Kitaca => "Kitaca",
-        Common.CardType.TOICA => "TOICA",
-        Common.CardType.Manaca => "manaca",
-        Common.CardType.PiTaPa => "PiTaPa",
+        CardType.Hayakaken => "はやかけん",
+        CardType.Suica => "Suica",
+        CardType.PASMO => "PASMO",
+        CardType.ICOCA => "ICOCA",
+        CardType.SUGOCA => "SUGOCA",
+        CardType.Nimoca => "nimoca",
+        CardType.Kitaca => "Kitaca",
+        CardType.TOICA => "TOICA",
+        CardType.Manaca => "manaca",
+        CardType.PiTaPa => "PiTaPa",
         _ => "不明"
     };
 


### PR DESCRIPTION
## Summary

- ICカードから読み取った駅コードを物品出納簿の摘要欄文字列に変換するエンドツーエンドテストを追加
- `StationMasterService`による駅コード→駅名変換と`SummaryGenerator`による駅名→摘要文字列生成の統合テスト
- 実運用シナリオを網羅的にカバー

## テスト対象

### 福岡市地下鉄（はやかけん）
- 空港線 単純片道（天神→博多）
- 空港線 往復（天神⇔博多）
- 箱崎線 単純片道（中洲川端→貝塚）
- 七隈線 単純片道（天神南→六本松）
- 空港線→箱崎線 乗継

### JR九州（鹿児島本線）
- 単純片道（博多→吉塚）
- 往復（博多⇔二日市）

### 関東エリア（Suica）
- JR山手線 単純片道（品川→渋谷）
- JR山手線 往復（新宿⇔池袋）
- JR東海道本線 単純片道（東京→横浜）

### 出張シナリオ
- はやかけんで東京出張（九州カードで関東エリア利用）
- Suicaで福岡出張（関東カードで九州エリア利用）

### 複数日・複合利用
- GenerateByDate: 2日間の通勤記録
- GenerateByDate: 鉄道とバスの複合利用
- GenerateByDate: 利用とチャージの混在

### エッジケース
- 未登録駅コードのフォールバック形式
- 同一駅での乗降
- 3区間連続利用（乗継2回）

## Test plan

- [x] `dotnet test --filter "StationCodeToSummaryTests"` でテストが通ること
- [ ] テスト出力を確認し、駅コード変換が正しく行われていること

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)