### PR TITLE
fix: デバッグ出力およびログ出力における機密情報露出を修正 (Issue #133)

### DIFF
--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
@@ -345,7 +345,9 @@ public class PcScCardReader : ICardReader
                 {
                     // バイト10-11が残高（リトルエンディアン）
                     var balance = historyData[10] + (historyData[11] << 8);
+#if DEBUG
                     System.Diagnostics.Debug.WriteLine($"残高読み取り: {balance}円");
+#endif
                     return balance;
                 }
 
@@ -391,7 +393,9 @@ public class PcScCardReader : ICardReader
                 return;
             }
 
+#if DEBUG
             System.Diagnostics.Debug.WriteLine($"IDm読み取り成功: {idm}");
+#endif
 
             // 同一カードの連続読み取りを防止
             var now = DateTime.Now;
@@ -914,9 +918,11 @@ public class PcScCardReader : ICardReader
                 }
             }
 
+#if DEBUG
             System.Diagnostics.Debug.WriteLine(
                 $"履歴: 日付={useDate:yyyy/MM/dd}, 入場={entryStationCode:X4}, 出場={exitStationCode:X4}, " +
                 $"残高={balance}, 金額={amount}, チャージ={isCharge}, バス={isBus}");
+#endif
 
             return new LedgerDetail
             {

--- a/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
@@ -233,7 +233,7 @@ public class OperationLogger
         return JsonSerializer.Serialize(obj, new JsonSerializerOptions
         {
             WriteIndented = false,
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(System.Text.Unicode.UnicodeRanges.All)
         });
     }
 }


### PR DESCRIPTION
## Summary

- PcScCardReader.cs の機密情報を含むデバッグ出力を `#if DEBUG` で囲み、Releaseビルドで露出しないように修正
- OperationLogger.cs の `UnsafeRelaxedJsonEscaping` を安全な `JavaScriptEncoder.Create(UnicodeRanges.All)` に変更

## 変更ファイル

### PcScCardReader.cs
| 行番号 | 修正内容 |
|--------|----------|
| 348-350 | 残高情報のデバッグ出力を `#if DEBUG` で囲む |
| 396-398 | IDm読み取り成功のデバッグ出力を `#if DEBUG` で囲む |
| 921-925 | 履歴データのデバッグ出力を `#if DEBUG` で囲む |

### OperationLogger.cs
| 行番号 | 修正内容 |
|--------|----------|
| 236 | `UnsafeRelaxedJsonEscaping` → `JavaScriptEncoder.Create(UnicodeRanges.All)` |

## セキュリティ改善

1. **Releaseビルドでの機密情報保護**: IDm、残高、利用履歴などの機密情報がReleaseビルドのデバッグ出力に露出しなくなる
2. **JSONエスケープの安全性向上**: HTMLインジェクションに使用される可能性のある文字（<, >, & 等）が適切にエスケープされる

## Test plan

- [x] ビルドが成功することを確認
- [ ] Releaseビルドでデバッグ出力に機密情報が含まれないことを確認
- [ ] 操作ログが正常に記録されることを確認

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)