### PR TITLE
fix: カード管理・再接続ボタンが機能しない問題を修正 (Issue #142)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -26,7 +26,7 @@
         <KeyBinding Key="Escape" Command="{Binding CancelCommand}"/>
         <KeyBinding Key="F1" Command="{Binding OpenSettingsCommand}"/>
         <KeyBinding Key="F2" Command="{Binding OpenReportCommand}"/>
-        <KeyBinding Key="F3" Command="{Binding OpenCardManageAsyncCommand}"/>
+        <KeyBinding Key="F3" Command="{Binding OpenCardManageCommand}"/>
         <KeyBinding Key="F4" Command="{Binding OpenStaffManageCommand}"/>
         <KeyBinding Key="F5" Command="{Binding OpenDataExportImportCommand}"/>
         <KeyBinding Key="F6" Command="{Binding OpenOperationLogCommand}"/>
@@ -76,7 +76,7 @@
                             AutomationProperties.HelpText="物品出納簿を作成します。ショートカット: F2"
                             ToolTip="帳票を開く (F2)"/>
                     <Button Content="カード管理 (F3)" Margin="5,0" Padding="10,5"
-                            Command="{Binding OpenCardManageAsyncCommand}"
+                            Command="{Binding OpenCardManageCommand}"
                             TabIndex="3"
                             AutomationProperties.Name="カード管理ダイアログを開く"
                             AutomationProperties.HelpText="ICカードの登録・編集を行います。ショートカット: F3"
@@ -464,7 +464,7 @@
                     </TextBlock>
                     <!-- 手動再接続ボタン（切断時のみ表示） -->
                     <Button Content="再接続"
-                            Command="{Binding ReconnectCardReaderAsyncCommand}"
+                            Command="{Binding ReconnectCardReaderCommand}"
                             Margin="10,0,0,0"
                             Padding="8,2"
                             FontSize="11"


### PR DESCRIPTION
## Summary

- 「カード管理」ボタンと「再接続」ボタンが機能しない問題を修正

## 原因

CommunityToolkit.Mvvmの`[RelayCommand]`属性は、`async Task`メソッドからコマンドを生成する際に「Async」サフィックスを削除します。

| メソッド名 | 生成されるコマンド名 | XAMLでのバインド（修正前） |
|-----------|---------------------|---------------------------|
| `OpenCardManageAsync()` | `OpenCardManageCommand` | `OpenCardManageAsyncCommand` ❌ |
| `ReconnectCardReaderAsync()` | `ReconnectCardReaderCommand` | `ReconnectCardReaderAsyncCommand` ❌ |

存在しないコマンド名にバインドしていたため、ボタンが機能していませんでした。

## 修正内容

MainWindow.xaml のコマンドバインディングを修正：

```diff
- Command="{Binding OpenCardManageAsyncCommand}"
+ Command="{Binding OpenCardManageCommand}"

- Command="{Binding ReconnectCardReaderAsyncCommand}"
+ Command="{Binding ReconnectCardReaderCommand}"
```

## Test plan

- [x] ビルドが成功することを確認
- [x] 「カード管理 (F3)」ボタンをクリックしてダイアログが開くことを確認
- [x] F3キーを押してダイアログが開くことを確認
- [x] カードリーダー切断時に「再接続」ボタンが機能することを確認

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)