### PR TITLE
fix: カード管理・職員管理の保存/削除ボタンが機能しない問題を修正 (Issue #144)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -290,7 +290,7 @@
                             Padding="15,8"
                             Margin="0,0,10,0"/>
                     <Button Content="保存"
-                            Command="{Binding SaveAsyncCommand}"
+                            Command="{Binding SaveCommand}"
                             Padding="15,8"
                             Background="#2196F3"
                             Foreground="White"/>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -93,7 +93,7 @@
                             AutomationProperties.HelpText="選択した職員の情報を編集します"
                             ToolTip="選択した職員を編集"/>
                     <Button Content="削除"
-                            Command="{Binding DeleteAsyncCommand}"
+                            Command="{Binding DeleteCommand}"
                             IsEnabled="{Binding SelectedStaff, Converter={StaticResource BoolToVisibilityConverter}}"
                             Padding="15,8"
                             Margin="0,0,0,5"
@@ -246,7 +246,7 @@
                             Padding="15,8"
                             Margin="0,0,10,0"/>
                     <Button Content="保存"
-                            Command="{Binding SaveAsyncCommand}"
+                            Command="{Binding SaveCommand}"
                             Padding="15,8"
                             Background="#2196F3"
                             Foreground="White"/>


### PR DESCRIPTION
## Summary

- カード管理ダイアログの「保存」ボタンが機能しない問題を修正
- 職員管理ダイアログの「保存」「削除」ボタンも同様の問題があったため併せて修正

## 原因

Issue #142, #143 と同様の問題。CommunityToolkit.Mvvmの`[RelayCommand]`属性は、`async Task`メソッドからコマンドを生成する際に「Async」サフィックスを削除します。

| メソッド名 | 生成されるコマンド名 | XAMLでのバインド（修正前） |
|-----------|---------------------|---------------------------|
| `SaveAsync()` | `SaveCommand` | `SaveAsyncCommand` ❌ |
| `DeleteAsync()` | `DeleteCommand` | `DeleteAsyncCommand` ❌ |

## 修正内容

### CardManageDialog.xaml
```diff
- Command="{Binding SaveAsyncCommand}"
+ Command="{Binding SaveCommand}"
```

### StaffManageDialog.xaml
```diff
- Command="{Binding DeleteAsyncCommand}"
+ Command="{Binding DeleteCommand}"

- Command="{Binding SaveAsyncCommand}"
+ Command="{Binding SaveCommand}"
```

## Test plan

- [x] ビルドが成功することを確認
- [x] カード管理ダイアログで「保存」ボタンが機能することを確認
- [x] 職員管理ダイアログで「保存」ボタンが機能することを確認
- [x] 職員管理ダイアログで「削除」ボタンが機能することを確認

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)