### PR TITLE
fix: LIKE句のワイルドカードエスケープとDBファイルアクセス権限設定 (Issue #134)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/OperationLogRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/OperationLogRepository.cs
@@ -240,14 +240,16 @@ public class OperationLogRepository : IOperationLogRepository
 
         if (!string.IsNullOrEmpty(criteria.TargetId))
         {
-            conditions.Add("target_id LIKE @targetId");
-            parameters["@targetId"] = $"%{criteria.TargetId}%";
+            var escapedId = EscapeLikeWildcards(criteria.TargetId);
+            conditions.Add("target_id LIKE @targetId ESCAPE '\\'");
+            parameters["@targetId"] = $"%{escapedId}%";
         }
 
         if (!string.IsNullOrEmpty(criteria.OperatorName))
         {
-            conditions.Add("operator_name LIKE @operatorName");
-            parameters["@operatorName"] = $"%{criteria.OperatorName}%";
+            var escapedName = EscapeLikeWildcards(criteria.OperatorName);
+            conditions.Add("operator_name LIKE @operatorName ESCAPE '\\'");
+            parameters["@operatorName"] = $"%{escapedName}%";
         }
 
         var whereClause = conditions.Count > 0
@@ -255,6 +257,19 @@ public class OperationLogRepository : IOperationLogRepository
             : "";
 
         return (whereClause, parameters);
+    }
+
+    /// <summary>
+    /// LIKE句で使用する文字列からワイルドカード文字をエスケープ
+    /// </summary>
+    /// <param name="value">エスケープする文字列</param>
+    /// <returns>エスケープ済み文字列</returns>
+    private static string EscapeLikeWildcards(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")  // バックスラッシュを先にエスケープ
+            .Replace("%", "\\%")    // %をエスケープ
+            .Replace("_", "\\_");   // _をエスケープ
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- LIKE句でのワイルドカード文字（%、_）をエスケープし、意図しない検索結果を防止
- データベースファイルのアクセス権限を現在のユーザーのみに制限

## 変更内容

### 1. LIKE句のワイルドカードエスケープ (OperationLogRepository.cs)

| 変更箇所 | 内容 |
|----------|------|
| `EscapeLikeWildcards()` | ワイルドカード文字をエスケープするヘルパーメソッドを追加 |
| `BuildWhereClause()` | TargetIdとOperatorNameの検索で`ESCAPE '\'`句を使用 |

**エスケープ対象文字:**
- `\` → `\\`
- `%` → `\%`
- `_` → `\_`

### 2. DBファイルのアクセス権限制限 (DbContext.cs)

| 変更箇所 | 内容 |
|----------|------|
| `RestrictDatabaseFilePermissions()` | アクセス権限を制限するメソッドを追加 |
| `InitializeDatabase()` | 初期化時にアクセス権限を設定 |

**権限設定:**
- 継承を無効化
- 既存のアクセスルールをすべて削除
- 現在のユーザーにのみフルコントロール権限を付与

## Test plan
- [ ] ワイルドカード文字（%、_）を含む検索キーワードで操作ログを検索
- [ ] 検索結果が意図通りの件数であることを確認
- [ ] アプリケーション起動後、DBファイルのアクセス権限を確認（エクスプローラー→プロパティ→セキュリティ）
- [ ] 現在のユーザーのみがアクセス権を持っていることを確認

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)