### PR TITLE
fix: 非同期処理のデッドロック危険を修正 (Issue #135)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -195,7 +195,8 @@ public partial class App : Application
 
 #if DEBUG
         // デバッグ時はテストデータを登録
-        RegisterTestDataAsync().Wait();
+        // Task.Runで別スレッドに移動し、UIスレッドのデッドロックを防止
+        Task.Run(() => RegisterTestDataAsync()).GetAwaiter().GetResult();
 #endif
 
         // 保存済み設定を適用
@@ -213,7 +214,8 @@ public partial class App : Application
         try
         {
             var settingsRepository = ServiceProvider.GetRequiredService<ISettingsRepository>();
-            var settings = settingsRepository.GetAppSettingsAsync().Result;
+            // 同期版メソッドを使用してデッドロックを防止
+            var settings = settingsRepository.GetAppSettings();
 
             // 文字サイズを適用
             ApplyFontSize(settings.FontSize);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/ISettingsRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ISettingsRepository.cs
@@ -26,6 +26,15 @@ public interface ISettingsRepository
     Task<AppSettings> GetAppSettingsAsync();
 
     /// <summary>
+    /// 全設定をAppSettingsオブジェクトとして取得（同期版）
+    /// </summary>
+    /// <remarks>
+    /// アプリケーション起動時など、非同期が使用できない場面で使用。
+    /// 通常はGetAppSettingsAsync()を使用すること。
+    /// </remarks>
+    AppSettings GetAppSettings();
+
+    /// <summary>
     /// AppSettingsオブジェクトを保存
     /// </summary>
     Task<bool> SaveAppSettingsAsync(AppSettings settings);

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -468,8 +468,9 @@ public partial class MainViewModel : ViewModelBase
 
         await Task.WhenAll(staffTask, cardTask);
 
-        var staff = staffTask.Result;
-        var card = cardTask.Result;
+        // awaitを使用してデッドロックを防止（Task.WhenAll後でも.Resultは避ける）
+        var staff = await staffTask;
+        var card = await cardTask;
 
         // 職員証かどうか確認
         if (staff != null)


### PR DESCRIPTION
## Summary
- UIスレッドでの`.Result`/`.Wait()`呼び出しによるデッドロック危険を解消
- 同期版メソッドの追加とリファクタリングで安全な実装に変更

## 変更内容

### 1. MainViewModel.cs
| 変更箇所 | Before | After |
|----------|--------|-------|
| 471-472行目 | `staffTask.Result`, `cardTask.Result` | `await staffTask`, `await cardTask` |

### 2. App.xaml.cs
| 変更箇所 | Before | After |
|----------|--------|-------|
| 198行目 | `RegisterTestDataAsync().Wait()` | `Task.Run(() => RegisterTestDataAsync()).GetAwaiter().GetResult()` |
| 216行目 | `GetAppSettingsAsync().Result` | `GetAppSettings()`（同期版） |

### 3. ISettingsRepository / SettingsRepository
- `GetAppSettings()` 同期版メソッドを新規追加
- 内部で使用する同期版ヘルパーメソッドも追加
  - `Get(string key)`: 設定値取得
  - `GetAppSettingsFromDb()`: DB から設定取得
  - `GetWindowSettingsFromDb()`: ウィンドウ設定取得

### 4. PcScCardReader.cs
| 変更箇所 | Before | After |
|----------|--------|-------|
| StopReadingAsync() | 処理を直接記述 | `StopReadingCore()`をTask.Runでラップ |
| Dispose() | `StopReadingAsync().Wait()` | `StopReadingCore()`を直接呼び出し |

## デッドロックの仕組み（修正前）

```
1. UIスレッド: .Result/.Wait()を呼び出し → ブロック
2. 非同期タスク: 完了後、継続処理をUIスレッドにディスパッチ
3. UIスレッド: ブロック中のためディスパッチ不可
4. → デッドロック発生
```

## Test plan
- [ ] アプリケーション起動時にハングしないことを確認
- [ ] ICカード読み取り処理中にUIが応答することを確認
- [ ] アプリケーション終了時に正常に終了することを確認
- [ ] 設定変更後、再起動時に設定が正しく読み込まれることを確認

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)