### PR TITLE
fix: 文字サイズ設定が一部の要素に反映されない問題を修正 (Issue #137)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml
+++ b/ICCardManager/src/ICCardManager/App.xaml
@@ -9,18 +9,18 @@
                 <ResourceDictionary Source="Resources/Styles/AccessibilityStyles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- フォントサイズリソース -->
-            <!-- BaseFontSize: 通常のテキスト用（設定で変更可能） -->
+            <!-- フォントサイズリソース（すべて設定で変更可能、比率で自動計算） -->
+            <!-- BaseFontSize: 通常のテキスト用（基準サイズ） -->
             <sys:Double x:Key="BaseFontSize">14</sys:Double>
             <!-- LargeFontSize: 見出し用（BaseFontSizeの約1.3倍） -->
             <sys:Double x:Key="LargeFontSize">18</sys:Double>
             <!-- SmallFontSize: 補足テキスト用（BaseFontSizeの約0.85倍） -->
             <sys:Double x:Key="SmallFontSize">12</sys:Double>
-            <!-- TitleFontSize: タイトル用（固定） -->
+            <!-- TitleFontSize: タイトル用（BaseFontSizeの約1.6倍） -->
             <sys:Double x:Key="TitleFontSize">22</sys:Double>
-            <!-- IconFontSize: アイコン用（固定） -->
-            <sys:Double x:Key="IconFontSize">72</sys:Double>
-            <!-- StatusFontSize: ステータスメッセージ用（固定） -->
+            <!-- IconFontSize: アイコン用（BaseFontSizeの約5倍） -->
+            <sys:Double x:Key="IconFontSize">70</sys:Double>
+            <!-- StatusFontSize: ステータスメッセージ用（BaseFontSizeの約2倍） -->
             <sys:Double x:Key="StatusFontSize">28</sys:Double>
         </ResourceDictionary>
     </Application.Resources>

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -248,11 +248,19 @@ public partial class App : Application
         var largeFontSize = Math.Round(baseFontSize * 1.3);
         var smallFontSize = Math.Round(baseFontSize * 0.85);
 
+        // タイトル・ステータス・アイコン用のフォントサイズも比率で計算
+        var titleFontSize = Math.Round(baseFontSize * 1.6);      // タイトル用（約1.6倍）
+        var statusFontSize = Math.Round(baseFontSize * 2.0);     // ステータスメッセージ用（約2倍）
+        var iconFontSize = Math.Round(baseFontSize * 5.0);       // アイコン用（約5倍）
+
         // アプリケーションリソースを更新
         var resources = Application.Current.Resources;
         resources["BaseFontSize"] = baseFontSize;
         resources["LargeFontSize"] = largeFontSize;
         resources["SmallFontSize"] = smallFontSize;
+        resources["TitleFontSize"] = titleFontSize;
+        resources["StatusFontSize"] = statusFontSize;
+        resources["IconFontSize"] = iconFontSize;
     }
 
 #if DEBUG

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -298,11 +298,11 @@
                                         <!-- 最終利用日 + 貸出状態 -->
                                         <StackPanel Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
                                                     Orientation="Horizontal">
-                                            <TextBlock FontSize="10" Foreground="Gray">
+                                            <TextBlock FontSize="{DynamicResource SmallFontSize}" Foreground="Gray">
                                                 <Run Text="最終: "/>
                                                 <Run Text="{Binding LastUsageDateDisplay, Mode=OneWay}"/>
                                             </TextBlock>
-                                            <TextBlock FontSize="10" Margin="10,0,0,0">
+                                            <TextBlock FontSize="{DynamicResource SmallFontSize}" Margin="10,0,0,0">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">
                                                         <Setter Property="Foreground" Value="#4CAF50"/>
@@ -382,7 +382,7 @@
 
                 <!-- デバッグ用ボタン (DEBUG ビルドのみ表示) -->
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="20,0,0,0">
-                    <TextBlock Text="[DEBUG]" FontSize="10" Foreground="Red" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <TextBlock Text="[DEBUG]" FontSize="{DynamicResource SmallFontSize}" Foreground="Red" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <Button Content="職員証" Command="{Binding SimulateStaffCardCommand}" Padding="10,3" Margin="0,0,5,0"/>
                     <Button Content="ICカード" Command="{Binding SimulateIcCardCommand}" Padding="10,3"/>
                 </StackPanel>
@@ -467,7 +467,7 @@
                             Command="{Binding ReconnectCardReaderCommand}"
                             Margin="10,0,0,0"
                             Padding="8,2"
-                            FontSize="11"
+                            FontSize="{DynamicResource SmallFontSize}"
                             AutomationProperties.Name="カードリーダーに再接続"
                             ToolTip="カードリーダーへの接続を再試行します">
                         <Button.Style>

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
@@ -48,7 +48,7 @@
             <!-- アイコン -->
             <TextBlock x:Name="IconText"
                        Grid.Column="0"
-                       FontSize="48"
+                       FontSize="{DynamicResource IconFontSize}"
                        VerticalAlignment="Center"
                        Margin="0,0,15,0"
                        AutomationProperties.Name="通知アイコン"/>
@@ -56,18 +56,18 @@
             <!-- メッセージ -->
             <StackPanel Grid.Column="1" VerticalAlignment="Center">
                 <TextBlock x:Name="TitleText"
-                           FontSize="22"
+                           FontSize="{DynamicResource TitleFontSize}"
                            FontWeight="Bold"
                            TextWrapping="Wrap"
                            AutomationProperties.Name="通知タイトル"/>
                 <TextBlock x:Name="MessageText"
-                           FontSize="14"
+                           FontSize="{DynamicResource BaseFontSize}"
                            Margin="0,5,0,0"
                            TextWrapping="Wrap"
                            Opacity="0.8"
                            AutomationProperties.Name="通知メッセージ"/>
                 <TextBlock x:Name="SubMessageText"
-                           FontSize="12"
+                           FontSize="{DynamicResource SmallFontSize}"
                            Margin="0,5,0,0"
                            TextWrapping="Wrap"
                            Opacity="0.6"


### PR DESCRIPTION
## Summary
- 文字サイズ設定（小/中/大/特大）がすべてのUI要素に一貫して適用されるように修正
- 高齢者向けのアクセシビリティ向上

## 変更内容

### 1. App.xaml.cs - ApplyFontSize()の拡張

以前は`BaseFontSize`、`LargeFontSize`、`SmallFontSize`のみ更新していましたが、以下も動的に更新するように拡張:

| リソース | 用途 | 比率 |
|----------|------|------|
| `TitleFontSize` | タイトル用 | BaseFontSizeの約1.6倍 |
| `StatusFontSize` | ステータスメッセージ用 | BaseFontSizeの約2倍 |
| `IconFontSize` | アイコン用 | BaseFontSizeの約5倍 |

### 2. MainWindow.xaml - ハードコードされたフォントサイズをDynamicResourceに変更

| 変更前 | 変更後 | 対象要素 |
|--------|--------|----------|
| `FontSize="10"` | `{DynamicResource SmallFontSize}` | 最終利用日、貸出状態表示 |
| `FontSize="10"` | `{DynamicResource SmallFontSize}` | DEBUG表示 |
| `FontSize="11"` | `{DynamicResource SmallFontSize}` | 再接続ボタン |

### 3. ToastNotificationWindow.xaml - フォントサイズをDynamicResourceに変更

| 変更前 | 変更後 | 対象要素 |
|--------|--------|----------|
| `FontSize="48"` | `{DynamicResource IconFontSize}` | 通知アイコン |
| `FontSize="22"` | `{DynamicResource TitleFontSize}` | 通知タイトル |
| `FontSize="14"` | `{DynamicResource BaseFontSize}` | 通知メッセージ |
| `FontSize="12"` | `{DynamicResource SmallFontSize}` | サブメッセージ |

## 効果

| 文字サイズ設定 | BaseFontSize | TitleFontSize | IconFontSize |
|----------------|--------------|---------------|--------------|
| 小 | 12 | 19 | 60 |
| 中 | 14 | 22 | 70 |
| 大 | 16 | 26 | 80 |
| 特大 | 20 | 32 | 100 |

## Test plan
- [ ] 設定画面で文字サイズを「小」「中」「大」「特大」に変更し、全要素に反映されることを確認
- [ ] MainWindowのダッシュボード内テキストが文字サイズ変更に追従することを確認
- [ ] ToastNotification（貸出/返却時）のアイコン・タイトル・メッセージが文字サイズ変更に追従することを確認
- [ ] アプリケーション再起動後も設定が保持されることを確認

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)