### PR TITLE
fix: async voidイベントハンドラーに例外処理を追加 (Issue #140)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs;
@@ -18,7 +19,13 @@ public partial class CardManageDialog : Window
         _viewModel = viewModel;
         DataContext = _viewModel;
 
-        Loaded += async (s, e) =>
+        Loaded += CardManageDialog_Loaded;
+        Closed += (s, e) => _viewModel.Cleanup();
+    }
+
+    private async void CardManageDialog_Loaded(object sender, RoutedEventArgs e)
+    {
+        try
         {
             await _viewModel.InitializeAsync();
             // IDmが事前に設定されている場合は新規登録モードで開始
@@ -26,8 +33,11 @@ public partial class CardManageDialog : Window
             {
                 _viewModel.StartNewCardWithIdm(_presetIdm);
             }
-        };
-        Closed += (s, e) => _viewModel.Cleanup();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs;
@@ -8,13 +9,29 @@ namespace ICCardManager.Views.Dialogs;
 /// </summary>
 public partial class OperationLogDialog : Window
 {
+    private readonly OperationLogSearchViewModel _viewModel;
+
     public OperationLogDialog(OperationLogSearchViewModel viewModel)
     {
         InitializeComponent();
-        DataContext = viewModel;
+
+        _viewModel = viewModel;
+        DataContext = _viewModel;
 
         // 画面表示時に初期検索を実行
-        Loaded += async (_, _) => await viewModel.InitializeAsync();
+        Loaded += OperationLogDialog_Loaded;
+    }
+
+    private async void OperationLogDialog_Loaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     private void CloseButton_Click(object sender, RoutedEventArgs e)

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs;
@@ -17,7 +18,19 @@ public partial class ReportDialog : Window
         _viewModel = viewModel;
         DataContext = _viewModel;
 
-        Loaded += async (s, e) => await _viewModel.InitializeAsync();
+        Loaded += ReportDialog_Loaded;
+    }
+
+    private async void ReportDialog_Loaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs;
@@ -17,7 +18,19 @@ public partial class SettingsDialog : Window
         _viewModel = viewModel;
         DataContext = _viewModel;
 
-        Loaded += async (s, e) => await _viewModel.InitializeAsync();
+        Loaded += SettingsDialog_Loaded;
+    }
+
+    private async void SettingsDialog_Loaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     /// <summary>
@@ -25,13 +38,20 @@ public partial class SettingsDialog : Window
     /// </summary>
     private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        await _viewModel.SaveAsync();
-
-        // 保存が成功した場合（IsSavedがtrue）、ダイアログを閉じる
-        if (_viewModel.IsSaved)
+        try
         {
-            DialogResult = true;
-            Close();
+            await _viewModel.SaveAsync();
+
+            // 保存が成功した場合（IsSavedがtrue）、ダイアログを閉じる
+            if (_viewModel.IsSaved)
+            {
+                DialogResult = true;
+                Close();
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "保存エラー");
         }
     }
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs;
@@ -17,8 +18,20 @@ public partial class StaffManageDialog : Window
         _viewModel = viewModel;
         DataContext = _viewModel;
 
-        Loaded += async (s, e) => await _viewModel.InitializeAsync();
+        Loaded += StaffManageDialog_Loaded;
         Closed += (s, e) => _viewModel.Cleanup();
+    }
+
+    private async void StaffManageDialog_Loaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await _viewModel.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Interop;
+using ICCardManager.Common;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
 using ICCardManager.ViewModels;
@@ -28,17 +29,32 @@ public partial class MainWindow : Window
 
     private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
-        // ウィンドウ位置・サイズを復元
-        await RestoreWindowPositionAsync();
+        try
+        {
+            // ウィンドウ位置・サイズを復元
+            await RestoreWindowPositionAsync();
 
-        // 初期化を実行
-        await _viewModel.InitializeAsync();
+            // 初期化を実行
+            await _viewModel.InitializeAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorDialogHelper.ShowError(ex, "初期化エラー");
+        }
     }
 
     private async void MainWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
-        // ウィンドウ位置・サイズを保存
-        await SaveWindowPositionAsync();
+        try
+        {
+            // ウィンドウ位置・サイズを保存
+            await SaveWindowPositionAsync();
+        }
+        catch (Exception ex)
+        {
+            // 終了時のエラーは警告のみ（アプリ終了を妨げない）
+            System.Diagnostics.Debug.WriteLine($"[MainWindow] 終了時エラー: {ex.Message}");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- async voidイベントハンドラーにtry-catch例外処理を追加
- インラインasync lambdaを名前付きメソッドに変換（可読性向上）
- ErrorDialogHelperを使用してユーザーフレンドリーなエラー表示を実装

## 背景

### 問題
`async void`メソッドで発生した例外は呼び出し元でキャッチできないため、未処理例外はアプリケーションのクラッシュを引き起こす可能性がありました。

### 対象箇所（Issue指摘+追加発見）
| ファイル | メソッド | 対応 |
|----------|----------|------|
| MainWindow.xaml.cs | MainWindow_Loaded | try-catch追加 |
| MainWindow.xaml.cs | MainWindow_Closing | try-catch追加（警告のみ） |
| SettingsDialog.xaml.cs | Loaded lambda | 名前付きメソッド化+try-catch |
| SettingsDialog.xaml.cs | SaveButton_Click | try-catch追加 |
| CardManageDialog.xaml.cs | Loaded lambda | 名前付きメソッド化+try-catch |
| StaffManageDialog.xaml.cs | Loaded lambda | 名前付きメソッド化+try-catch |
| ReportDialog.xaml.cs | Loaded lambda | 名前付きメソッド化+try-catch |
| OperationLogDialog.xaml.cs | Loaded lambda | 名前付きメソッド化+try-catch |

## 変更詳細

### 1. MainWindow.xaml.cs
```csharp
private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
{
    try
    {
        await RestoreWindowPositionAsync();
        await _viewModel.InitializeAsync();
    }
    catch (Exception ex)
    {
        ErrorDialogHelper.ShowError(ex, "初期化エラー");
    }
}

private async void MainWindow_Closing(object? sender, ...)
{
    try
    {
        await SaveWindowPositionAsync();
    }
    catch (Exception ex)
    {
        // 終了時のエラーは警告のみ（アプリ終了を妨げない）
        System.Diagnostics.Debug.WriteLine($"[MainWindow] 終了時エラー: {ex.Message}");
    }
}
```

### 2. ダイアログ共通パターン
インラインlambdaを名前付きメソッドに変換：
```csharp
// Before
Loaded += async (s, e) => await _viewModel.InitializeAsync();

// After
Loaded += DialogName_Loaded;
...
private async void DialogName_Loaded(object sender, RoutedEventArgs e)
{
    try
    {
        await _viewModel.InitializeAsync();
    }
    catch (Exception ex)
    {
        ErrorDialogHelper.ShowError(ex, "初期化エラー");
    }
}
```

### 3. OperationLogDialog.xaml.cs
ViewModelをフィールドに保存する形式に統一：
```csharp
private readonly OperationLogSearchViewModel _viewModel;

public OperationLogDialog(OperationLogSearchViewModel viewModel)
{
    InitializeComponent();
    _viewModel = viewModel;
    DataContext = _viewModel;
    Loaded += OperationLogDialog_Loaded;
}
```

## 設計判断

### MainWindow_Closingの例外処理
終了時のエラーはErrorDialogHelperを使用せず、Debug.WriteLineのみとしました。
理由：
- 終了処理中にダイアログを表示すると、ユーザー体験が悪化する
- ウィンドウ位置保存の失敗は致命的ではない
- アプリケーション終了を妨げるべきではない

### インラインlambda → 名前付きメソッド
可読性向上と、デバッグ時のスタックトレース明確化のため、名前付きメソッドに変換しました。

## Test plan
- [x] ビルド成功を確認
- [x] 既存テスト（881件）がパスすることを確認
- [ ] 各ダイアログを開いて正常に初期化されることを確認
- [ ] 設定ダイアログで保存が正常に動作することを確認

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)