### PR TITLE
fix: 職員管理画面の保存・削除機能を改善 (Issue #156)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Converters/VisibilityConverters.cs
+++ b/ICCardManager/src/ICCardManager/Views/Converters/VisibilityConverters.cs
@@ -87,3 +87,19 @@ public class StringNotEmptyToVisibilityConverter : IValueConverter
         throw new NotImplementedException();
     }
 }
+
+/// <summary>
+/// オブジェクトがnullでない場合にtrueを返す（IsEnabled用）
+/// </summary>
+public class NotNullToBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value != null;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        xmlns:converters="clr-namespace:ICCardManager.Views.Converters"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:StaffManageViewModel}"
         Title="職員管理"
@@ -16,6 +17,7 @@
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <converters:NotNullToBoolConverter x:Key="NotNullToBoolConverter"/>
     </Window.Resources>
 
     <Grid Margin="15">
@@ -86,7 +88,7 @@
                             ToolTip="新しい職員を登録"/>
                     <Button Content="編集"
                             Command="{Binding StartEditCommand}"
-                            IsEnabled="{Binding SelectedStaff, Converter={StaticResource BoolToVisibilityConverter}}"
+                            IsEnabled="{Binding SelectedStaff, Converter={StaticResource NotNullToBoolConverter}}"
                             Padding="15,8"
                             Margin="0,0,10,5"
                             AutomationProperties.Name="職員情報編集"
@@ -94,7 +96,7 @@
                             ToolTip="選択した職員を編集"/>
                     <Button Content="削除"
                             Command="{Binding DeleteCommand}"
-                            IsEnabled="{Binding SelectedStaff, Converter={StaticResource BoolToVisibilityConverter}}"
+                            IsEnabled="{Binding SelectedStaff, Converter={StaticResource NotNullToBoolConverter}}"
                             Padding="15,8"
                             Margin="0,0,0,5"
                             Foreground="Red"


### PR DESCRIPTION
## Summary

- SaveAsync() と DeleteAsync() に try-catch 例外処理を追加し、エラー発生時にユーザーにメッセージを表示するよう改善
- 編集・削除ボタンの IsEnabled バインディングで誤ったコンバーター（BoolToVisibilityConverter）が使用されていた問題を修正
- 新規 NotNullToBoolConverter を追加して IsEnabled プロパティ用に適切な bool 型を返すよう修正

## 変更内容

### StaffManageViewModel.cs
- `SaveAsync()` と `DeleteAsync()` に try-catch を追加
- エラー発生時に StatusMessage にエラーメッセージを表示
- デバッグ出力でエラーをログ記録

### VisibilityConverters.cs
- `NotNullToBoolConverter` を新規追加（オブジェクトが null でない場合に true を返す）

### StaffManageDialog.xaml
- converters 名前空間を追加
- 編集・削除ボタンの IsEnabled コンバーターを NotNullToBoolConverter に変更

## 問題の原因

`BoolToVisibilityConverter` は `Visibility` 列挙型を返しますが、WPF の `IsEnabled` プロパティは `bool` 型を期待します。
`Visibility.Visible`（0）は false に、`Visibility.Collapsed`（2）は true に解釈されるため、ボタンの有効/無効が逆転していました。

## Test plan

- [x] ビルドが成功すること
- [x] StaffManageViewModel 関連の 16 テストがすべて成功すること
- [ ] 職員管理画面で職員選択時に編集・削除ボタンが有効になること
- [ ] 新規登録後に保存ボタンが正常に動作すること
- [ ] エラー発生時にエラーメッセージが表示されること

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)