### PR TITLE
fix: 職員証登録中の未登録カードに対するICカード登録ダイアログ抑制 (Issue #158)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -44,6 +44,11 @@ public partial class App : Application
     /// </summary>
     public static new App Current => (App)Application.Current;
 
+    /// <summary>
+    /// 職員証登録モードが有効かどうか（MainViewModelでの未登録カード処理を抑制するため）
+    /// </summary>
+    public static bool IsStaffCardRegistrationActive { get; set; }
+
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -689,6 +689,12 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private async Task HandleUnregisteredCardAsync(string idm)
     {
+        // 職員証登録モード中は処理をスキップ（StaffManageViewModelが処理する）
+        if (App.IsStaffCardRegistrationActive)
+        {
+            return;
+        }
+
         var cardType = _cardTypeDetector.Detect(idm);
         var cardTypeName = CardTypeDetector.GetDisplayName(cardType);
 

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -101,6 +101,9 @@ public partial class StaffManageViewModel : ViewModelBase
         EditNote = string.Empty;
         StatusMessage = "職員証をタッチするとIDmを読み取ります";
         IsWaitingForCard = true;
+
+        // MainViewModelでの未登録カード処理を抑制
+        App.IsStaffCardRegistrationActive = true;
     }
 
     /// <summary>
@@ -259,6 +262,9 @@ public partial class StaffManageViewModel : ViewModelBase
         EditNumber = string.Empty;
         EditNote = string.Empty;
         StatusMessage = string.Empty;
+
+        // 職員証登録モードを解除
+        App.IsStaffCardRegistrationActive = false;
     }
 
     /// <summary>
@@ -274,6 +280,9 @@ public partial class StaffManageViewModel : ViewModelBase
             EditStaffIdm = e.Idm;
             StatusMessage = "職員証を読み取りました";
             IsWaitingForCard = false;
+
+            // カード読み取り完了後、フラグを解除
+            App.IsStaffCardRegistrationActive = false;
         });
     }
 
@@ -299,5 +308,8 @@ public partial class StaffManageViewModel : ViewModelBase
     public void Cleanup()
     {
         _cardReader.CardRead -= OnCardRead;
+
+        // ダイアログ終了時にフラグを解除
+        App.IsStaffCardRegistrationActive = false;
     }
 }


### PR DESCRIPTION
## Summary

- 職員証登録待ち状態で未登録カードをタッチした際に、ICカード新規登録ダイアログが表示される問題を修正
- `App.IsStaffCardRegistrationActive` フラグを追加し、職員証登録モード中は MainViewModel での未登録カード処理をスキップ

## 問題の原因

`MainViewModel` と `StaffManageViewModel` の両方が `ICardReader.CardRead` イベントを購読しているため、未登録カード検出時に両方の ViewModel が処理を実行していた。

**期待動作:** 職員証登録待ち状態では、タッチされたカードを職員証として登録
**実際の動作:** ICカード新規登録ダイアログが表示されてしまう

## 変更内容

### App.xaml.cs
- `IsStaffCardRegistrationActive` 静的プロパティを追加

### StaffManageViewModel.cs
- `StartNewStaff()`: フラグを `true` に設定
- `OnCardRead()`: カード読み取り完了後にフラグを `false` に設定
- `CancelEdit()`: キャンセル時にフラグを `false` に設定
- `Cleanup()`: ダイアログ終了時にフラグを `false` に設定

### MainViewModel.cs
- `HandleUnregisteredCardAsync()`: フラグが `true` の場合は処理をスキップ

## Test plan

- [x] ビルドが成功すること
- [x] StaffManageViewModel の 16 テストがすべて成功すること
- [x] 職員管理画面で「新規登録」→ 未登録カードタッチ → 職員証として IDm が設定されること
- [x] ICカード新規登録ダイアログが表示されないこと
- [x] 通常操作（メイン画面で未登録カードタッチ）で ICカード登録ダイアログが表示されること

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)