### PR TITLE
feat: データ保存場所をユーザー非依存の場所に変更 (Issue #160)

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/ErrorDialogHelper.cs
+++ b/ICCardManager/src/ICCardManager/Common/ErrorDialogHelper.cs
@@ -10,8 +10,11 @@ namespace ICCardManager.Common;
 /// </summary>
 public static class ErrorDialogHelper
 {
+    /// <summary>
+    /// ログディレクトリ（CommonApplicationDataを使用して全ユーザーで共有）
+    /// </summary>
     private static readonly string LogDirectory = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
         "ICCardManager",
         "Logs");
 

--- a/ICCardManager/src/ICCardManager/Common/PathValidator.cs
+++ b/ICCardManager/src/ICCardManager/Common/PathValidator.cs
@@ -236,10 +236,13 @@ public static partial class PathValidator
     /// <summary>
     /// デフォルトのバックアップパスを取得
     /// </summary>
+    /// <remarks>
+    /// CommonApplicationData（C:\ProgramData）を使用して全ユーザーで共有
+    /// </remarks>
     public static string GetDefaultBackupPath()
     {
         return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
             "ICCardManager",
             "backup");
     }

--- a/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
@@ -336,10 +336,13 @@ public class SettingsRepository : ISettingsRepository
     /// <summary>
     /// デフォルトのバックアップパスを取得
     /// </summary>
+    /// <remarks>
+    /// CommonApplicationData（C:\ProgramData）を使用して全ユーザーで共有
+    /// </remarks>
     private static string GetDefaultBackupPath()
     {
         var appDataPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
             "ICCardManager",
             "backup");
 


### PR DESCRIPTION
## Summary

- データ保存場所を LocalApplicationData（ユーザー固有）から CommonApplicationData（全ユーザー共有）に変更
- ログインするユーザーが変わっても同じデータにアクセスできるようになる
- ディレクトリ作成時に適切なアクセス権限を設定

## 保存場所の変更

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| パス | `C:\Users\<ユーザー名>\AppData\Local\ICCardManager` | `C:\ProgramData\ICCardManager` |
| 対象 | 単一ユーザー | 全ユーザー共有 |

## 変更内容

### DbContext.cs
- `GetDefaultDatabasePath()`: CommonApplicationData を使用
- `EnsureDirectoryWithPermissions()`: 新規追加
  - ディレクトリ作成時に Users グループにフルコントロール権限を付与
  - 権限設定失敗時もディレクトリ作成は継続

### ErrorDialogHelper.cs
- ログディレクトリを CommonApplicationData に変更

### PathValidator.cs
- デフォルトバックアップパスを CommonApplicationData に変更

### SettingsRepository.cs
- デフォルトバックアップパスを CommonApplicationData に変更

## 注意事項

- 既存のユーザーは旧保存場所（LocalApplicationData）のデータを新保存場所にマイグレーションする必要があります
- 初回起動時に管理者権限が必要になる場合があります（C:\ProgramData への書き込み権限）

## Test plan

- [x] ビルドが成功すること
- [x] DbContext 関連の 17 テストが成功すること（既存の2件の失敗は変更前から発生）
- [x] C:\ProgramData\ICCardManager フォルダが作成されること
- [ ] 異なるユーザーでログインしても同じデータベースにアクセスできること
- [x] ログファイルが共有フォルダに出力されること

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)