### PR TITLE
fix: ICカード登録中の未登録カードに対する登録ダイアログ抑制 (Issue #168)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -49,6 +49,11 @@ public partial class App : Application
     /// </summary>
     public static bool IsStaffCardRegistrationActive { get; set; }
 
+    /// <summary>
+    /// ICカード登録モードが有効かどうか（MainViewModelでの未登録カード処理を抑制するため）
+    /// </summary>
+    public static bool IsCardRegistrationActive { get; set; }
+
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -122,6 +122,9 @@ public partial class CardManageViewModel : ViewModelBase
         EditNote = string.Empty;
         StatusMessage = "カードをタッチするとIDmを読み取ります";
         IsWaitingForCard = true;
+
+        // MainViewModelでの未登録カード処理を抑制
+        App.IsCardRegistrationActive = true;
     }
 
     /// <summary>
@@ -306,6 +309,9 @@ public partial class CardManageViewModel : ViewModelBase
         EditCardNumber = string.Empty;
         EditNote = string.Empty;
         StatusMessage = string.Empty;
+
+        // ICカード登録モードを解除
+        App.IsCardRegistrationActive = false;
     }
 
     /// <summary>
@@ -326,6 +332,9 @@ public partial class CardManageViewModel : ViewModelBase
 
             StatusMessage = "カードを読み取りました。カード種別を確認してください。";
             IsWaitingForCard = false;
+
+            // カード読み取り完了後、フラグを解除
+            App.IsCardRegistrationActive = false;
         });
     }
 
@@ -351,5 +360,8 @@ public partial class CardManageViewModel : ViewModelBase
     public void Cleanup()
     {
         _cardReader.CardRead -= OnCardRead;
+
+        // ダイアログ終了時にフラグを解除
+        App.IsCardRegistrationActive = false;
     }
 }

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -695,6 +695,12 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        // ICカード登録モード中は処理をスキップ（CardManageViewModelが処理する）
+        if (App.IsCardRegistrationActive)
+        {
+            return;
+        }
+
         var cardType = _cardTypeDetector.Detect(idm);
         var cardTypeName = CardTypeDetector.GetDisplayName(cardType);
 


### PR DESCRIPTION
## Summary

- カード管理画面でICカード新規登録待ち状態で未登録カードをタッチした際に、「このカードは登録されていません」ダイアログが表示される問題を修正
- `App.IsCardRegistrationActive` フラグを追加し、ICカード登録モード中は MainViewModel での未登録カード処理をスキップ
- Issue #158（職員証登録）と同様のパターンで修正

## 問題の原因

`MainViewModel` と `CardManageViewModel` の両方が `ICardReader.CardRead` イベントを購読しているため、未登録カード検出時に両方の ViewModel が処理を実行していた。

**期待動作:** ICカード登録待ち状態では、タッチされたカードの IDm を読み取って登録フォームに設定
**実際の動作:** 「このカードは登録されていません」ダイアログが表示されてしまう

## 変更内容

### App.xaml.cs
- `IsCardRegistrationActive` 静的プロパティを追加

### CardManageViewModel.cs
- `StartNewCard()`: フラグを `true` に設定
- `OnCardRead()`: カード読み取り完了後にフラグを `false` に設定
- `CancelEdit()`: キャンセル時にフラグを `false` に設定
- `Cleanup()`: ダイアログ終了時にフラグを `false` に設定

### MainViewModel.cs
- `HandleUnregisteredCardAsync()`: `IsCardRegistrationActive` フラグが `true` の場合は処理をスキップ

## Test plan

- [x] ビルドが成功すること
- [x] CardManageViewModel の 17 テストが成功すること（既存の2件の失敗は変更前から発生）
- [x] カード管理画面で「新規登録」→ 未登録カードタッチ → IDm が設定されること
- [x] 「このカードは登録されていません」ダイアログが表示されないこと
- [x] 通常操作（メイン画面で未登録カードタッチ）で登録ダイアログが表示されること

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)