### PR TITLE
docs: 管理者マニュアルのZIPインストール記述を削除 (Issue #161)

### DIFF
--- a/ICCardManager/docs/manual/管理者マニュアル.md
+++ b/ICCardManager/docs/manual/管理者マニュアル.md
@@ -61,30 +61,13 @@
 3. インストール先を指定します（デフォルト: `C:\Program Files\ICCardManager`）
 4. 「インストール」をクリックします
 
-### 2.2 ZIPファイルを使用する場合
-
-1. 配布されたZIPファイルを任意のフォルダに展開します
-   ```
-   推奨: C:\ICCardManager\ または D:\ICCardManager\
-   ```
-
-2. フォルダ構成を確認します
-   ```
-   ICCardManager/
-   ├── ICCardManager.exe      # メインアプリケーション
-   ├── appsettings.json       # 設定ファイル（オプション）
-   └── Resources/
-       ├── Sounds/            # 通知音
-       └── Templates/         # 帳票テンプレート
-   ```
-
-### 2.3 PaSoRiドライバのインストール
+### 2.2 PaSoRiドライバのインストール
 
 1. [ソニー公式サイト](https://www.sony.co.jp/Products/felica/consumer/support/download/)からドライバをダウンロード
 2. ダウンロードしたインストーラーを実行
 3. パソコンを再起動
 
-### 2.4 初回起動
+### 2.3 初回起動
 
 1. `ICCardManager.exe` を実行
 2. Windows SmartScreen警告が表示された場合は「詳細情報」→「実行」をクリック
@@ -112,10 +95,12 @@
 データベースファイルは以下の場所に保存されます。
 
 ```
-%LOCALAPPDATA%\ICCardManager\iccard.db
+%PROGRAMDATA%\ICCardManager\iccard.db
 ```
 
-例: `C:\Users\<ユーザー名>\AppData\Local\ICCardManager\iccard.db`
+例: `C:\ProgramData\ICCardManager\iccard.db`
+
+> **補足**: この場所はすべてのユーザーで共有されるため、異なるWindowsユーザーでログインしても同じデータにアクセスできます。
 
 ---
 
@@ -388,7 +373,7 @@ ICカードにチャージした場合、以下の手順で記録します。
 アプリケーションログは以下に出力されます。
 
 ```
-%LOCALAPPDATA%\ICCardManager\logs\
+%PROGRAMDATA%\ICCardManager\logs\
 ```
 
 問題発生時の調査に使用します。
@@ -441,7 +426,7 @@ ICカードにチャージした場合、以下の手順で記録します。
 
 - エラーメッセージのスクリーンショット
 - 操作手順
-- ログファイル（`%LOCALAPPDATA%\ICCardManager\logs\`）
+- ログファイル（`%PROGRAMDATA%\ICCardManager\logs\`）
 
 ---
 


### PR DESCRIPTION
## Summary

- 管理者マニュアルのインストールセクションからZIPファイル配布の記述を削除
- セクション番号を調整（2.3→2.2、2.4→2.3）
- Issue #160対応: データ保存場所のパスを`%LOCALAPPDATA%`から`%PROGRAMDATA%`に更新

## 変更内容

### 削除
- セクション2.2「ZIPファイルを使用する場合」

### 更新
- セクション番号の振り直し
- データ保存場所（セクション3.3）: `%PROGRAMDATA%\ICCardManager\iccard.db`
- ログファイルパス（セクション10.3、11.5）: `%PROGRAMDATA%\ICCardManager\logs\`

## Test plan

- [x] ドキュメントの表示を確認
- [x] セクション番号が連続していることを確認
- [ ] リンクが正しく機能することを確認

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)