### PR TITLE
feat: convert-to-docxを全マニュアル対応に拡張 (Issue #179)

### DIFF
--- a/ICCardManager/docs/manual/README.md
+++ b/ICCardManager/docs/manual/README.md
@@ -39,20 +39,46 @@ winget install pandoc
 ### 変換手順
 
 ```powershell
-# PowerShellスクリプトを使用
+# 全マニュアルを変換（更新があるもののみ）
 .\convert-to-docx.ps1
 
-# または、バッチファイルを使用
-.\convert-to-docx.bat
+# 全マニュアルを強制変換
+.\convert-to-docx.ps1 -Force
+
+# 特定のマニュアルのみ変換
+.\convert-to-docx.ps1 -Target user   # ユーザーマニュアル
+.\convert-to-docx.ps1 -Target admin  # 管理者マニュアル
+.\convert-to-docx.ps1 -Target dev    # 開発者ガイド
+```
+
+バッチファイルを使用する場合:
+
+```batch
+rem 全マニュアルを変換（更新があるもののみ）
+convert-to-docx.bat
+
+rem 全マニュアルを強制変換
+convert-to-docx.bat /force
+
+rem 特定のマニュアルのみ変換
+convert-to-docx.bat user   # ユーザーマニュアル
+convert-to-docx.bat admin  # 管理者マニュアル
+convert-to-docx.bat dev    # 開発者ガイド
 ```
 
 ### 出力ファイル
 
-変換後、`ユーザーマニュアル.docx` が同じディレクトリに生成されます。
+変換後、以下のファイルが同じディレクトリに生成されます（更新があるもののみ）:
+
+- `ユーザーマニュアル.docx`
+- `管理者マニュアル.docx`
+- `開発者ガイド.docx`
+
+> **注意**: `.md` ファイルより `.docx` ファイルの方が新しい場合は、変換がスキップされます。強制的に変換する場合は `-Force` オプションを使用してください。
 
 ## マニュアルの更新
 
-マニュアルの内容を更新する場合は、`ユーザーマニュアル.md` を編集してください。
+マニュアルの内容を更新する場合は、対応する `.md` ファイルを編集してください。
 Word形式が必要な場合は、編集後に変換スクリプトを実行して再生成してください。
 
 ## 注意事項

--- a/ICCardManager/docs/manual/convert-to-docx.bat
+++ b/ICCardManager/docs/manual/convert-to-docx.bat
@@ -1,17 +1,35 @@
 @echo off
 chcp 65001 > nul
-setlocal
+setlocal enabledelayedexpansion
+
+rem マニュアル Word変換スクリプト
+rem 使用方法:
+rem   convert-to-docx.bat         全マニュアルを変換（更新があるもののみ）
+rem   convert-to-docx.bat /force  全マニュアルを強制変換
+rem   convert-to-docx.bat user    ユーザーマニュアルのみ変換
+rem   convert-to-docx.bat admin   管理者マニュアルのみ変換
+rem   convert-to-docx.bat dev     開発者ガイドのみ変換
+
+set "SCRIPT_DIR=%~dp0"
+set "TARGET=all"
+set "FORCE=0"
+set "CONVERTED=0"
+set "SKIPPED=0"
+set "ERRORS=0"
+
+rem 引数の解析
+if "%~1"=="/force" set "FORCE=1"
+if "%~1"=="-force" set "FORCE=1"
+if "%~1"=="user" set "TARGET=user"
+if "%~1"=="admin" set "TARGET=admin"
+if "%~1"=="dev" set "TARGET=dev"
 
 echo ======================================
-echo  ユーザーマニュアル Word変換
+echo  マニュアル Word変換
 echo ======================================
 echo.
 
-set "SCRIPT_DIR=%~dp0"
-set "INPUT_FILE=%SCRIPT_DIR%ユーザーマニュアル.md"
-set "OUTPUT_FILE=%SCRIPT_DIR%ユーザーマニュアル.docx"
-
-:: pandocの確認
+rem pandocの確認
 where pandoc >nul 2>&1
 if errorlevel 1 (
     echo エラー: pandocが見つかりません。
@@ -24,32 +42,82 @@ if errorlevel 1 (
     exit /b 1
 )
 
-:: 入力ファイルの確認
+rem ユーザーマニュアル
+if "%TARGET%"=="all" call :convert_manual "ユーザーマニュアル" "ユーザーマニュアル.md" "ユーザーマニュアル.docx" "交通系ICカード管理システム ユーザーマニュアル"
+if "%TARGET%"=="user" call :convert_manual "ユーザーマニュアル" "ユーザーマニュアル.md" "ユーザーマニュアル.docx" "交通系ICカード管理システム ユーザーマニュアル"
+
+rem 管理者マニュアル
+if "%TARGET%"=="all" call :convert_manual "管理者マニュアル" "管理者マニュアル.md" "管理者マニュアル.docx" "交通系ICカード管理システム 管理者マニュアル"
+if "%TARGET%"=="admin" call :convert_manual "管理者マニュアル" "管理者マニュアル.md" "管理者マニュアル.docx" "交通系ICカード管理システム 管理者マニュアル"
+
+rem 開発者ガイド
+if "%TARGET%"=="all" call :convert_manual "開発者ガイド" "開発者ガイド.md" "開発者ガイド.docx" "交通系ICカード管理システム 開発者ガイド"
+if "%TARGET%"=="dev" call :convert_manual "開発者ガイド" "開発者ガイド.md" "開発者ガイド.docx" "交通系ICカード管理システム 開発者ガイド"
+
+rem 結果サマリ
+echo.
+echo ======================================
+echo  完了!
+echo ======================================
+echo.
+echo   変換: %CONVERTED% 件
+echo   スキップ: %SKIPPED% 件
+if %ERRORS% gtr 0 echo   エラー: %ERRORS% 件
+echo.
+
+if %ERRORS% gtr 0 exit /b 1
+exit /b 0
+
+rem ========================================
+rem サブルーチン: マニュアル変換
+rem %1: マニュアル名
+rem %2: 入力ファイル名
+rem %3: 出力ファイル名
+rem %4: タイトル
+rem ========================================
+:convert_manual
+set "MANUAL_NAME=%~1"
+set "INPUT_FILE=%SCRIPT_DIR%%~2"
+set "OUTPUT_FILE=%SCRIPT_DIR%%~3"
+set "TITLE=%~4"
+
+echo --------------------------------------
+echo [%MANUAL_NAME%]
+
+rem 入力ファイルの確認
 if not exist "%INPUT_FILE%" (
-    echo エラー: 入力ファイルが見つかりません
-    echo   %INPUT_FILE%
-    pause
-    exit /b 1
+    echo   スキップ: 入力ファイルが見つかりません
+    set /a SKIPPED+=1
+    goto :eof
 )
 
-echo 変換中...
-pandoc "%INPUT_FILE%" -o "%OUTPUT_FILE%" --from markdown --to docx --toc --toc-depth=2 --metadata title="交通系ICカード管理システム ユーザーマニュアル" --metadata author="システム管理者" --metadata lang=ja-JP
+rem 更新チェック（/forceでない場合）
+if %FORCE%==0 (
+    if exist "%OUTPUT_FILE%" (
+        rem ファイルの更新日時を比較
+        for %%I in ("%INPUT_FILE%") do set "INPUT_TIME=%%~tI"
+        for %%O in ("%OUTPUT_FILE%") do set "OUTPUT_TIME=%%~tO"
+
+        rem 簡易比較（文字列比較）
+        rem 注意: この方法は完全ではないが、多くのケースで動作する
+        if "!OUTPUT_TIME!" geq "!INPUT_TIME!" (
+            echo   スキップ: 変更なし（.docxが最新）
+            set /a SKIPPED+=1
+            goto :eof
+        )
+    )
+)
+
+rem 変換実行
+echo   変換中...
+pandoc "%INPUT_FILE%" -o "%OUTPUT_FILE%" --from markdown --to docx --toc --toc-depth=2 --metadata title="%TITLE%" --metadata author="システム管理者" --metadata lang=ja-JP
 
 if errorlevel 1 (
-    echo エラー: 変換に失敗しました。
-    pause
-    exit /b 1
+    echo   エラー: 変換に失敗しました
+    set /a ERRORS+=1
+    goto :eof
 )
 
-echo.
-echo ======================================
-echo  変換完了!
-echo ======================================
-echo.
-echo 出力ファイル: %OUTPUT_FILE%
-echo.
-
-set /p OPEN_FILE="ファイルを開きますか？ (Y/N): "
-if /i "%OPEN_FILE%"=="Y" (
-    start "" "%OUTPUT_FILE%"
-)
+echo   完了: %~3
+set /a CONVERTED+=1
+goto :eof

--- a/ICCardManager/docs/manual/convert-to-docx.ps1
+++ b/ICCardManager/docs/manual/convert-to-docx.ps1
@@ -1,27 +1,59 @@
-# ユーザーマニュアル Word変換スクリプト
-# 使用方法: .\convert-to-docx.ps1
+# マニュアル Word変換スクリプト
+# 使用方法:
+#   .\convert-to-docx.ps1              # 全マニュアルを変換（更新があるもののみ）
+#   .\convert-to-docx.ps1 -Force       # 全マニュアルを強制変換
+#   .\convert-to-docx.ps1 -Target user # ユーザーマニュアルのみ変換
 # 前提条件: pandocがインストールされていること
 #   インストール: winget install pandoc または https://pandoc.org/installing.html
 
 param(
-    [string]$InputFile = "ユーザーマニュアル.md",
-    [string]$OutputFile = "ユーザーマニュアル.docx"
+    [ValidateSet("all", "user", "admin", "dev")]
+    [string]$Target = "all",
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
 
 # スクリプトのディレクトリを取得
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$InputPath = Join-Path $ScriptDir $InputFile
-$OutputPath = Join-Path $ScriptDir $OutputFile
+
+# マニュアル定義
+$Manuals = @(
+    @{
+        Name = "ユーザーマニュアル"
+        Key = "user"
+        Input = "ユーザーマニュアル.md"
+        Output = "ユーザーマニュアル.docx"
+        Title = "交通系ICカード管理システム ユーザーマニュアル"
+    },
+    @{
+        Name = "管理者マニュアル"
+        Key = "admin"
+        Input = "管理者マニュアル.md"
+        Output = "管理者マニュアル.docx"
+        Title = "交通系ICカード管理システム 管理者マニュアル"
+    },
+    @{
+        Name = "開発者ガイド"
+        Key = "dev"
+        Input = "開発者ガイド.md"
+        Output = "開発者ガイド.docx"
+        Title = "交通系ICカード管理システム 開発者ガイド"
+    }
+)
+
+# 対象マニュアルをフィルタ
+if ($Target -ne "all") {
+    $Manuals = $Manuals | Where-Object { $_.Key -eq $Target }
+}
 
 Write-Host "======================================" -ForegroundColor Cyan
-Write-Host " ユーザーマニュアル Word変換" -ForegroundColor Cyan
+Write-Host " マニュアル Word変換" -ForegroundColor Cyan
 Write-Host "======================================" -ForegroundColor Cyan
 Write-Host ""
 
 # pandocの確認
-Write-Host "[1/3] pandocの確認..." -ForegroundColor Yellow
+Write-Host "[準備] pandocの確認..." -ForegroundColor Yellow
 $PandocPath = Get-Command pandoc -ErrorAction SilentlyContinue
 
 if (-not $PandocPath) {
@@ -34,59 +66,90 @@ if (-not $PandocPath) {
     exit 1
 }
 Write-Host "  pandoc: $($PandocPath.Source)" -ForegroundColor Green
-
-# 入力ファイルの確認
 Write-Host ""
-Write-Host "[2/3] 入力ファイルの確認..." -ForegroundColor Yellow
-if (-not (Test-Path $InputPath)) {
-    Write-Host "エラー: 入力ファイルが見つかりません: $InputPath" -ForegroundColor Red
-    exit 1
-}
-Write-Host "  入力: $InputPath" -ForegroundColor Green
 
-# 変換実行
-Write-Host ""
-Write-Host "[3/3] Word形式に変換中..." -ForegroundColor Yellow
+# 変換結果の追跡
+$ConvertedCount = 0
+$SkippedCount = 0
+$ErrorCount = 0
 
-# pandocオプション
-# --reference-doc: カスタムテンプレートを使用する場合に指定
-# --toc: 目次を生成
-# --toc-depth: 目次の深さ
-$PandocArgs = @(
-    $InputPath,
-    "-o", $OutputPath,
-    "--from", "markdown",
-    "--to", "docx",
-    "--toc",
-    "--toc-depth=2",
-    "--metadata", "title=交通系ICカード管理システム ユーザーマニュアル",
-    "--metadata", "author=システム管理者",
-    "--metadata", "lang=ja-JP"
-)
+# 各マニュアルを処理
+foreach ($Manual in $Manuals) {
+    $InputPath = Join-Path $ScriptDir $Manual.Input
+    $OutputPath = Join-Path $ScriptDir $Manual.Output
 
-& pandoc $PandocArgs
+    Write-Host "--------------------------------------" -ForegroundColor Gray
+    Write-Host "[$($Manual.Name)]" -ForegroundColor Cyan
 
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "エラー: 変換に失敗しました。" -ForegroundColor Red
-    exit 1
-}
-
-# 結果の表示
-Write-Host ""
-Write-Host "======================================" -ForegroundColor Cyan
-Write-Host " 変換完了!" -ForegroundColor Green
-Write-Host "======================================" -ForegroundColor Cyan
-
-if (Test-Path $OutputPath) {
-    $FileInfo = Get-Item $OutputPath
-    Write-Host ""
-    Write-Host "出力ファイル: $OutputPath" -ForegroundColor Green
-    Write-Host "ファイルサイズ: $([math]::Round($FileInfo.Length / 1KB, 2)) KB" -ForegroundColor Green
-    Write-Host ""
-
-    # ファイルを開くか確認
-    $OpenFile = Read-Host "ファイルを開きますか？ (Y/N)"
-    if ($OpenFile -eq "Y" -or $OpenFile -eq "y") {
-        Start-Process $OutputPath
+    # 入力ファイルの確認
+    if (-not (Test-Path $InputPath)) {
+        Write-Host "  スキップ: 入力ファイルが見つかりません" -ForegroundColor Yellow
+        Write-Host "    $InputPath" -ForegroundColor Gray
+        $SkippedCount++
+        continue
     }
+
+    # 更新チェック（-Forceでない場合）
+    if (-not $Force -and (Test-Path $OutputPath)) {
+        $InputInfo = Get-Item $InputPath
+        $OutputInfo = Get-Item $OutputPath
+
+        if ($OutputInfo.LastWriteTime -ge $InputInfo.LastWriteTime) {
+            Write-Host "  スキップ: 変更なし（.docxが最新）" -ForegroundColor Gray
+            Write-Host "    .md:   $($InputInfo.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))" -ForegroundColor Gray
+            Write-Host "    .docx: $($OutputInfo.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'))" -ForegroundColor Gray
+            $SkippedCount++
+            continue
+        }
+    }
+
+    # 変換実行
+    Write-Host "  変換中..." -ForegroundColor Yellow
+
+    $PandocArgs = @(
+        $InputPath,
+        "-o", $OutputPath,
+        "--from", "markdown",
+        "--to", "docx",
+        "--toc",
+        "--toc-depth=2",
+        "--metadata", "title=$($Manual.Title)",
+        "--metadata", "author=システム管理者",
+        "--metadata", "lang=ja-JP"
+    )
+
+    try {
+        & pandoc $PandocArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "pandocがエラーコード $LASTEXITCODE を返しました"
+        }
+
+        $FileInfo = Get-Item $OutputPath
+        Write-Host "  完了: $($Manual.Output)" -ForegroundColor Green
+        Write-Host "    サイズ: $([math]::Round($FileInfo.Length / 1KB, 2)) KB" -ForegroundColor Gray
+        $ConvertedCount++
+    }
+    catch {
+        Write-Host "  エラー: 変換に失敗しました" -ForegroundColor Red
+        Write-Host "    $($_.Exception.Message)" -ForegroundColor Red
+        $ErrorCount++
+    }
+}
+
+# 結果サマリ
+Write-Host ""
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host " 完了!" -ForegroundColor Green
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  変換: $ConvertedCount 件" -ForegroundColor $(if ($ConvertedCount -gt 0) { "Green" } else { "Gray" })
+Write-Host "  スキップ: $SkippedCount 件" -ForegroundColor Gray
+if ($ErrorCount -gt 0) {
+    Write-Host "  エラー: $ErrorCount 件" -ForegroundColor Red
+}
+Write-Host ""
+
+# エラーがあった場合は終了コード1
+if ($ErrorCount -gt 0) {
+    exit 1
 }


### PR DESCRIPTION
## Summary

Issue #179 の対応として、Word変換スクリプトを拡張しました。

### 変更内容

1. **全マニュアル対応**
   - ユーザーマニュアル
   - 管理者マニュアル
   - 開発者ガイド

2. **更新チェック機能**
   - `.md` ファイルが `.docx` ファイルより新しい場合のみ変換
   - 不要な再変換を防止

3. **オプション追加**
   - `-Force` / `/force`: 強制変換
   - `-Target` / 引数: 特定マニュアルのみ変換

### 使用例

```powershell
# 全マニュアルを変換（更新があるもののみ）
.\convert-to-docx.ps1

# 全マニュアルを強制変換
.\convert-to-docx.ps1 -Force

# 特定のマニュアルのみ変換
.\convert-to-docx.ps1 -Target user   # ユーザーマニュアル
.\convert-to-docx.ps1 -Target admin  # 管理者マニュアル
.\convert-to-docx.ps1 -Target dev    # 開発者ガイド
```

```batch
rem バッチファイル版
convert-to-docx.bat
convert-to-docx.bat /force
convert-to-docx.bat user
```

### 出力例

```
======================================
 マニュアル Word変換
======================================

[準備] pandocの確認...
  pandoc: C:\Users\...\pandoc.exe

--------------------------------------
[ユーザーマニュアル]
  スキップ: 変更なし（.docxが最新）
--------------------------------------
[管理者マニュアル]
  変換中...
  完了: 管理者マニュアル.docx
    サイズ: 45.2 KB
--------------------------------------
[開発者ガイド]
  変換中...
  完了: 開発者ガイド.docx
    サイズ: 72.8 KB

======================================
 完了!
======================================

  変換: 2 件
  スキップ: 1 件
```

Closes #179

## Test plan

- [x] PowerShellスクリプトが全マニュアルを対象とすることを確認
- [x] バッチファイルが全マニュアルを対象とすることを確認
- [x] 更新チェック機能が動作することを確認（.docxが新しい場合はスキップ）
- [x] -Force オプションで強制変換できることを確認
- [x] -Target オプションで特定マニュアルのみ変換できることを確認
- [x] README.mdの使用方法が更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)