### PR TITLE
fix: PathValidatorTestsをCommonApplicationDataに修正 (Issue #191)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Common/PathValidatorTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/PathValidatorTests.cs
@@ -362,10 +362,14 @@ public class PathValidatorTests : IDisposable
     #region GetDefaultBackupPath テスト
 
     /// <summary>
-    /// デフォルトパスがLocalApplicationData内であることを確認
+    /// デフォルトパスがCommonApplicationData内であることを確認
     /// </summary>
+    /// <remarks>
+    /// バックアップは共有フォルダ（C:\ProgramData）に保存される。
+    /// これにより、管理者が全ユーザーのバックアップを一元管理できる。
+    /// </remarks>
     [Fact]
-    public void GetDefaultBackupPath_ReturnsLocalAppDataPath()
+    public void GetDefaultBackupPath_ReturnsCommonAppDataPath()
     {
         // Act
         var result = PathValidator.GetDefaultBackupPath();
@@ -373,7 +377,7 @@ public class PathValidatorTests : IDisposable
         // Assert
         result.Should().Contain("ICCardManager");
         result.Should().Contain("backup");
-        result.Should().StartWith(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        result.Should().StartWith(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- `GetDefaultBackupPath` テストを実装に合わせて修正
- `LocalApplicationData` ではなく `CommonApplicationData` を期待するよう変更

## 変更内容

### PathValidatorTests.cs
- メソッド名: `GetDefaultBackupPath_ReturnsLocalAppDataPath` → `GetDefaultBackupPath_ReturnsCommonAppDataPath`
- アサーション: `LocalApplicationData` → `CommonApplicationData`
- XMLドキュメントに `CommonApplicationData` を使用する理由を追記

## 背景
バックアップは共有フォルダ（`C:\ProgramData\ICCardManager\backup`）に保存される設計になっている。
これにより、管理者が全ユーザーのバックアップを一元管理できる。

## Test plan
- [x] `GetDefaultBackupPath_ReturnsCommonAppDataPath` テスト成功
- [x] `GetDefaultBackupPath_ReturnsAbsolutePath` テスト成功

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)