### PR TITLE
fix: OperationLogRepositoryTestsのテストデータ分離問題を修正 (Issue #193)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Repositories/OperationLogRepositoryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Repositories/OperationLogRepositoryTests.cs
@@ -25,6 +25,25 @@ public class OperationLogRepositoryTests : IDisposable
         _dbContext = new DbContext(":memory:");
         _dbContext.InitializeDatabase();
         _repository = new OperationLogRepository(_dbContext);
+
+        // 各テストの前にテストデータをクリーンアップ
+        ClearTestData();
+    }
+
+    /// <summary>
+    /// テストデータをクリアして、テスト間の分離を確保する
+    /// </summary>
+    /// <remarks>
+    /// インメモリSQLiteデータベースでは、同一接続を使用しないと
+    /// 別のデータベースインスタンスに対して操作してしまうため、
+    /// DbContext.GetConnection()を使用して同じ接続を取得する。
+    /// </remarks>
+    private void ClearTestData()
+    {
+        var connection = _dbContext.GetConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM operation_log";
+        command.ExecuteNonQuery();
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- OperationLogRepositoryTestsで`SearchAsync_EmptyCriteria_ReturnsAll`と`SearchAsync_Pagination_WorksCorrectly`が期待より多くのレコードを返していた問題を修正
- 各テストの前に`operation_log`テーブルをクリアすることで、テスト間のデータ分離を確保

## 変更内容
- コンストラクタに`ClearTestData()`呼び出しを追加
- `ClearTestData()`メソッドを追加
  - `DbContext.GetConnection()`を使用して同一接続を取得
  - `DELETE FROM operation_log`でテストデータをクリア
- インメモリSQLiteの接続に関する注意事項をXMLドキュメントに記載

## 原因
`InitializeDatabase()`実行時にマイグレーションログ(`MIGRATION_UP`)が`operation_log`テーブルに挿入されていたため、テストが期待する件数と実際の件数が一致していなかった。

## Test plan
- [x] `OperationLogRepositoryTests`の全15テストが成功することを確認
  ```
  成功!   -失敗:     0、合格:    15、スキップ:     0
  ```

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)