### PR TITLE
fix: カード種別自動判定テストを削除し、デフォルト値テストに変更 (Issue #194)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -125,11 +125,15 @@ public class CardManageViewModelTests
     /// <summary>
     /// IDmを指定して新規登録モードを開始できること
     /// </summary>
+    /// <remarks>
+    /// カード種別はIDmから自動判定できないため、デフォルト値（nimoca）が設定される。
+    /// ユーザーは必要に応じて手動でカード種別を変更する。
+    /// </remarks>
     [Fact]
-    public void StartNewCardWithIdm_ShouldSetIdmAndAutoDetectType()
+    public void StartNewCardWithIdm_ShouldSetIdmAndDefaultCardType()
     {
         // Arrange
-        var idm = "07FE112233445566"; // はやかけん
+        var idm = "0102030405060708";
 
         // Act
         _viewModel.StartNewCardWithIdm(idm);
@@ -139,39 +143,8 @@ public class CardManageViewModelTests
         _viewModel.IsNewCard.Should().BeTrue();
         _viewModel.IsWaitingForCard.Should().BeFalse(); // IDmがあるので待機しない
         _viewModel.EditCardIdm.Should().Be(idm);
-        _viewModel.EditCardType.Should().Be("はやかけん");
-    }
-
-    /// <summary>
-    /// nimocaのIDmで種別が自動検出されること
-    /// </summary>
-    [Fact]
-    public void StartNewCardWithIdm_WithNimocaIdm_ShouldDetectNimoca()
-    {
-        // Arrange
-        var idm = "05FE112233445566"; // nimoca
-
-        // Act
-        _viewModel.StartNewCardWithIdm(idm);
-
-        // Assert
+        // カード種別はIDmから自動判定できないため、デフォルト値（nimoca）が設定される
         _viewModel.EditCardType.Should().Be("nimoca");
-    }
-
-    /// <summary>
-    /// SUGOCAのIDmで種別が自動検出されること
-    /// </summary>
-    [Fact]
-    public void StartNewCardWithIdm_WithSugocaIdm_ShouldDetectSugoca()
-    {
-        // Arrange
-        var idm = "06FE112233445566"; // SUGOCA
-
-        // Act
-        _viewModel.StartNewCardWithIdm(idm);
-
-        // Assert
-        _viewModel.EditCardType.Should().Be("SUGOCA");
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- カード種別自動判定を期待するテストを削除
- IDmからカード種別を自動判定することは技術的に不可能なため、実装に合わせてテストを修正

## 背景
`CardManageViewModel.StartNewCardWithIdm()`の実装では、カード種別は自動判定されず、デフォルト値（nimoca）が設定される：
```csharp
// カード種別はユーザーに手動選択させる（IDmからの自動判定は技術的に不可能なため）
// デフォルトはnimoca（利用頻度が最も高いため）
EditCardType = "nimoca";
```

## 変更内容
削除したテスト:
- `StartNewCardWithIdm_ShouldSetIdmAndAutoDetectType` - はやかけん自動判定を期待
- `StartNewCardWithIdm_WithSugocaIdm_ShouldDetectSugoca` - SUGOCA自動判定を期待
- `StartNewCardWithIdm_WithNimocaIdm_ShouldDetectNimoca` - nimoca自動判定を期待（冗長）

追加したテスト:
- `StartNewCardWithIdm_ShouldSetIdmAndDefaultCardType` - IDm設定とデフォルト値（nimoca）を確認

## Test plan
- [x] `CardManageViewModelTests`の全17テストが成功することを確認
  ```
  成功!   -失敗:     0、合格:    17、スキップ:     0
  ```

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)