### PR TITLE
fix: 無効なパス文字テストでPath.Combineを使用しないように修正 (Issue #195)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
@@ -1305,7 +1305,8 @@ public class ReportServiceTests : IDisposable
         var cardIdm = "0102030405060708";
         var card = CreateTestCard(cardIdm);
         // Windowsで無効なファイル名文字（< > : | ? *）を含むパス
-        var invalidPath = Path.Combine(Path.GetTempPath(), "Invalid<>|Path", "report.xlsx");
+        // Path.Combineは無効な文字で例外をスローするため、直接文字列で構築
+        var invalidPath = Path.GetTempPath() + "Invalid<>|Path" + Path.DirectorySeparatorChar + "report.xlsx";
 
         var ledgers = new List<Ledger>
         {


### PR DESCRIPTION
## Summary
- `ReportServiceTests.CreateMonthlyReportAsync_WithInvalidPathCharacters_ReturnsFailure` テストが失敗していた問題を修正
- テストコード自体が例外をスローしていたのを修正

## 原因
`Path.Combine`は無効なパス文字（`<`, `>`, `|` 等）を含む引数で`ArgumentException`をスローする。
テストの目的は「無効なパスでサービスがエラーを返すこと」を確認することだが、
テストコード自体がサービス呼び出し前に例外で失敗していた。

## 変更内容
```csharp
// 修正前（例外がスローされる）
var invalidPath = Path.Combine(Path.GetTempPath(), "Invalid<>|Path", "report.xlsx");

// 修正後（文字列結合で構築）
var invalidPath = Path.GetTempPath() + "Invalid<>|Path" + Path.DirectorySeparatorChar + "report.xlsx";
```

## Test plan
- [x] `CreateMonthlyReportAsync_WithInvalidPathCharacters_ReturnsFailure` テストが成功することを確認
  ```
  成功!   -失敗:     0、合格:     1、スキップ:     0
  ```

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)