### PR TITLE
feat: トースト通知の表示位置を設定可能に (Issue #189)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -233,13 +233,17 @@ namespace ICCardManager
                 // 文字サイズを適用
                 ApplyFontSize(settings.FontSize);
 
-                _logger?.LogDebug("設定を適用: フォントサイズ={FontSize}", settings.FontSize);
+                // トースト位置を適用
+                ApplyToastPosition(settings.ToastPosition);
+
+                _logger?.LogDebug("設定を適用: フォントサイズ={FontSize}, トースト位置={ToastPosition}", settings.FontSize, settings.ToastPosition);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "設定の適用でエラー");
                 // デフォルト値を適用
                 ApplyFontSize(FontSizeOption.Medium);
+                ApplyToastPosition(ToastPosition.TopRight);
             }
         }
 
@@ -274,6 +278,14 @@ namespace ICCardManager
             resources["TitleFontSize"] = titleFontSize;
             resources["StatusFontSize"] = statusFontSize;
             resources["IconFontSize"] = iconFontSize;
+        }
+
+        /// <summary>
+        /// トースト通知の表示位置をアプリケーション全体に適用
+        /// </summary>
+        public static void ApplyToastPosition(ToastPosition position)
+        {
+            Views.ToastNotificationWindow.CurrentPosition = position;
         }
 
     #if DEBUG

--- a/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
@@ -36,6 +36,9 @@ namespace ICCardManager.Data.Repositories
         // 音声モード設定キー
         public const string KeySoundMode = "sound_mode";
 
+        // トースト位置設定キー
+        public const string KeyToastPosition = "toast_position";
+
         public SettingsRepository(DbContext dbContext, ICacheService cacheService)
         {
             _dbContext = dbContext;
@@ -135,6 +138,14 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
             var defaultStaffIdm = Get(KeyDefaultStaffIdm);
             settings.DefaultStaffIdm = string.IsNullOrEmpty(defaultStaffIdm) ? null : defaultStaffIdm;
 
+            // 音声モード設定
+            var soundMode = Get(KeySoundMode);
+            settings.SoundMode = ParseSoundMode(soundMode);
+
+            // トースト位置設定
+            var toastPosition = Get(KeyToastPosition);
+            settings.ToastPosition = ParseToastPosition(toastPosition);
+
             return settings;
         }
 
@@ -233,6 +244,10 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
             var soundMode = await GetAsync(KeySoundMode);
             settings.SoundMode = ParseSoundMode(soundMode);
 
+            // トースト位置設定
+            var toastPosition = await GetAsync(KeyToastPosition);
+            settings.ToastPosition = ParseToastPosition(toastPosition);
+
             return settings;
         }
 
@@ -296,6 +311,9 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
 
             // 音声モード設定を保存
             success &= await SetAsync(KeySoundMode, SoundModeToString(settings.SoundMode));
+
+            // トースト位置設定を保存
+            success &= await SetAsync(KeyToastPosition, ToastPositionToString(settings.ToastPosition));
 
             // 設定保存後にキャッシュを無効化
             _cacheService.Invalidate(CacheKeys.AppSettings);
@@ -408,6 +426,36 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
                 SoundMode.VoiceFemale => "voice_female",
                 SoundMode.None => "none",
                 _ => "beep"
+            };
+        }
+
+        /// <summary>
+        /// 文字列からToastPositionに変換
+        /// </summary>
+        private static ToastPosition ParseToastPosition(string value)
+        {
+            return value?.ToLowerInvariant() switch
+            {
+                "top_right" => ToastPosition.TopRight,
+                "top_left" => ToastPosition.TopLeft,
+                "bottom_right" => ToastPosition.BottomRight,
+                "bottom_left" => ToastPosition.BottomLeft,
+                _ => ToastPosition.TopRight
+            };
+        }
+
+        /// <summary>
+        /// ToastPositionを文字列に変換
+        /// </summary>
+        private static string ToastPositionToString(ToastPosition position)
+        {
+            return position switch
+            {
+                ToastPosition.TopRight => "top_right",
+                ToastPosition.TopLeft => "top_left",
+                ToastPosition.BottomRight => "bottom_right",
+                ToastPosition.BottomLeft => "bottom_left",
+                _ => "top_right"
             };
         }
     }

--- a/ICCardManager/src/ICCardManager/Models/AppSettings.cs
+++ b/ICCardManager/src/ICCardManager/Models/AppSettings.cs
@@ -49,6 +49,11 @@ namespace ICCardManager.Models
         /// 音声モード
         /// </summary>
         public SoundMode SoundMode { get; set; } = SoundMode.Beep;
+
+        /// <summary>
+        /// トースト通知の表示位置
+        /// </summary>
+        public ToastPosition ToastPosition { get; set; } = ToastPosition.TopRight;
     }
 
     /// <summary>
@@ -137,5 +142,31 @@ namespace ICCardManager.Models
         /// 無し
         /// </summary>
         None
+    }
+
+    /// <summary>
+    /// トースト通知の表示位置オプション
+    /// </summary>
+    public enum ToastPosition
+    {
+        /// <summary>
+        /// 右上（デフォルト）
+        /// </summary>
+        TopRight,
+
+        /// <summary>
+        /// 左上
+        /// </summary>
+        TopLeft,
+
+        /// <summary>
+        /// 右下
+        /// </summary>
+        BottomRight,
+
+        /// <summary>
+        /// 左下
+        /// </summary>
+        BottomLeft
     }
 }

--- a/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
@@ -93,6 +93,20 @@ public partial class SettingsViewModel : ViewModelBase
     [ObservableProperty]
     private SoundModeItem? _selectedSoundModeItem;
 
+    /// <summary>
+    /// トースト位置の選択肢
+    /// </summary>
+    public ObservableCollection<ToastPositionItem> ToastPositionOptions { get; } = new()
+    {
+        new ToastPositionItem { Value = ToastPosition.TopRight, DisplayName = "右上（デフォルト）" },
+        new ToastPositionItem { Value = ToastPosition.TopLeft, DisplayName = "左上" },
+        new ToastPositionItem { Value = ToastPosition.BottomRight, DisplayName = "右下" },
+        new ToastPositionItem { Value = ToastPosition.BottomLeft, DisplayName = "左下" }
+    };
+
+    [ObservableProperty]
+    private ToastPositionItem? _selectedToastPositionItem;
+
     public SettingsViewModel(
         ISettingsRepository settingsRepository,
         IStaffRepository staffRepository,
@@ -134,6 +148,10 @@ public partial class SettingsViewModel : ViewModelBase
             // SoundModeItemを選択
             SelectedSoundModeItem = SoundModeOptions.FirstOrDefault(x => x.Value == settings.SoundMode)
                                     ?? SoundModeOptions[0]; // デフォルトは「効果音」
+
+            // ToastPositionItemを選択
+            SelectedToastPositionItem = ToastPositionOptions.FirstOrDefault(x => x.Value == settings.ToastPosition)
+                                        ?? ToastPositionOptions[0]; // デフォルトは「右上」
 
             // 職員一覧を読み込み
             await LoadStaffListAsync();
@@ -210,6 +228,7 @@ public partial class SettingsViewModel : ViewModelBase
                 BackupPath = validatedBackupPath,
                 FontSize = SelectedFontSizeItem?.Value ?? FontSizeOption.Medium,
                 SoundMode = SelectedSoundModeItem?.Value ?? SoundMode.Beep,
+                ToastPosition = SelectedToastPositionItem?.Value ?? ToastPosition.TopRight,
                 SkipStaffTouch = SkipStaffTouch,
                 DefaultStaffIdm = SelectedDefaultStaff?.StaffIdm
             };
@@ -232,6 +251,9 @@ public partial class SettingsViewModel : ViewModelBase
 
                 // 音声モードの変更を反映
                 _soundPlayer.SoundMode = settings.SoundMode;
+
+                // トースト位置の変更を反映
+                App.ApplyToastPosition(settings.ToastPosition);
 
                 // 保存完了フラグを立てる（ダイアログを閉じるトリガー）
                 IsSaved = true;
@@ -309,6 +331,11 @@ public partial class SettingsViewModel : ViewModelBase
     {
         HasChanges = true;
     }
+
+    partial void OnSelectedToastPositionItemChanged(ToastPositionItem? value)
+    {
+        HasChanges = true;
+    }
 }
 
 /// <summary>
@@ -336,5 +363,14 @@ public class StaffItem
 public class SoundModeItem
 {
     public SoundMode Value { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// トースト位置選択アイテム
+/// </summary>
+public class ToastPositionItem
+{
+    public ToastPosition Value { get; set; }
     public string DisplayName { get; set; } = string.Empty;
 }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -132,6 +132,28 @@
                     </StackPanel>
                 </GroupBox>
 
+                <!-- 通知設定 -->
+                <GroupBox Header="通知設定" Margin="0,0,0,20" Padding="15">
+                    <StackPanel>
+                        <TextBlock Text="トースト通知の表示位置"
+                                   FontWeight="Bold"
+                                   Margin="0,0,0,10"/>
+                        <ComboBox ItemsSource="{Binding ToastPositionOptions}"
+                                  SelectedItem="{Binding SelectedToastPositionItem}"
+                                  DisplayMemberPath="DisplayName"
+                                  Padding="8"
+                                  Width="200"
+                                  HorizontalAlignment="Left"
+                                  AutomationProperties.Name="トースト通知位置選択"
+                                  AutomationProperties.HelpText="貸出・返却時の通知が表示される画面の位置を選択します"
+                                  ToolTip="右上・左上・右下・左下から選択"/>
+                        <TextBlock Text="※ 「いってらっしゃい！」「おかえりなさい！」の表示位置"
+                                   FontSize="{DynamicResource SmallFontSize}"
+                                   Foreground="Gray"
+                                   Margin="0,5,0,0"/>
+                    </StackPanel>
+                </GroupBox>
+
                 <!-- 操作設定 -->
                 <GroupBox Header="操作設定" Margin="0,0,0,20" Padding="15">
                     <StackPanel>

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
+using ICCardManager.Models;
 
 namespace ICCardManager.Views
 {
@@ -54,6 +55,11 @@ namespace ICCardManager.Views
         private const int DefaultDisplayDurationMs = 3000;
         private bool _autoCloseEnabled = true;
 
+        /// <summary>
+        /// 現在のトースト表示位置
+        /// </summary>
+        public static ToastPosition CurrentPosition { get; set; } = ToastPosition.TopRight;
+
         public ToastNotificationWindow()
         {
             InitializeComponent();
@@ -73,11 +79,11 @@ namespace ICCardManager.Views
         }
 
         /// <summary>
-        /// ウィンドウ読み込み時に画面右上に配置
+        /// ウィンドウ読み込み時に指定位置に配置
         /// </summary>
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            PositionToTopRight();
+            PositionToast();
             StartFadeInAnimation();
             if (_autoCloseEnabled)
             {
@@ -86,13 +92,36 @@ namespace ICCardManager.Views
         }
 
         /// <summary>
-        /// 画面右上に配置
+        /// 設定に応じた位置に配置
         /// </summary>
-        private void PositionToTopRight()
+        private void PositionToast()
         {
             var workArea = SystemParameters.WorkArea;
-            Left = workArea.Right - ActualWidth - 20;
-            Top = workArea.Top + 20;
+            const double margin = 20;
+
+            switch (CurrentPosition)
+            {
+                case ToastPosition.TopRight:
+                    Left = workArea.Right - ActualWidth - margin;
+                    Top = workArea.Top + margin;
+                    break;
+                case ToastPosition.TopLeft:
+                    Left = workArea.Left + margin;
+                    Top = workArea.Top + margin;
+                    break;
+                case ToastPosition.BottomRight:
+                    Left = workArea.Right - ActualWidth - margin;
+                    Top = workArea.Bottom - ActualHeight - margin;
+                    break;
+                case ToastPosition.BottomLeft:
+                    Left = workArea.Left + margin;
+                    Top = workArea.Bottom - ActualHeight - margin;
+                    break;
+                default:
+                    Left = workArea.Right - ActualWidth - margin;
+                    Top = workArea.Top + margin;
+                    break;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- 設定画面に「通知設定」セクションを追加し、トースト通知の表示位置を選択可能にした
- 右上（デフォルト）・左上・右下・左下の4つの位置から選択可能
- 設定は即座に反映され、次回以降も保持される

## 変更内容
- `Models/AppSettings.cs`: `ToastPosition`列挙型とプロパティを追加
- `Data/Repositories/SettingsRepository.cs`: 位置設定の保存・読み込み処理を追加
- `ViewModels/SettingsViewModel.cs`: 位置選択オプションとバインディングを追加
- `Views/Dialogs/SettingsDialog.xaml`: 通知設定セクションとComboBoxを追加
- `Views/ToastNotificationWindow.xaml.cs`: 設定に応じた位置計算ロジックを追加
- `App.xaml.cs`: 起動時と設定保存時のトースト位置適用を追加

## Test plan
- [x] プロジェクトがビルドできることを確認
- [x] 全テスト（901件）が成功することを確認
- [ ] 設定画面で各位置を選択して保存できることを確認
- [ ] 貸出・返却時に選択した位置にトースト通知が表示されることを確認
- [ ] アプリ再起動後も設定が保持されることを確認

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)