### PR TITLE
feat: 「カード管理」を「交通系ICカード管理」に変更 (Issue #203)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -6,12 +6,12 @@
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:CardManageViewModel}"
-        Title="カード管理"
+        Title="交通系ICカード管理"
         Height="600"
         Width="900"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
-        AutomationProperties.Name="カード管理ダイアログ"
+        AutomationProperties.Name="交通系ICカード管理ダイアログ"
         AutomationProperties.HelpText="交通系ICカードの登録・編集・削除ができます。カードをタッチして新規登録できます。">
 
     <Window.Resources>
@@ -34,7 +34,7 @@
 
             <!-- ヘッダー -->
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
-                <TextBlock Text="登録済みカード一覧"
+                <TextBlock Text="登録済み交通系ICカード一覧"
                            FontSize="{DynamicResource LargeFontSize}"
                            FontWeight="Bold"
                            VerticalAlignment="Center"/>
@@ -168,7 +168,7 @@
                                     <Setter Property="Text" Value="新規登録"/>
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding IsNewCard}" Value="False">
-                                    <Setter Property="Text" Value="カード編集"/>
+                                    <Setter Property="Text" Value="交通系ICカード編集"/>
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -77,13 +77,13 @@
                             AutomationProperties.Name="帳票ダイアログを開く"
                             AutomationProperties.HelpText="物品出納簿を作成します。ショートカット: F2"
                             ToolTip="帳票を開く (F2)"/>
-                    <Button Content="カード管理 (F3)" Margin="5,0"
+                    <Button Content="交通系ICカード管理 (F3)" Margin="5,0"
                             Style="{StaticResource AccessibleButtonStyle}"
                             Command="{Binding OpenCardManageCommand}"
                             TabIndex="3"
-                            AutomationProperties.Name="カード管理ダイアログを開く"
+                            AutomationProperties.Name="交通系ICカード管理ダイアログを開く"
                             AutomationProperties.HelpText="交通系ICカードの登録・編集を行います。ショートカット: F3"
-                            ToolTip="カード管理を開く (F3)"/>
+                            ToolTip="交通系ICカード管理を開く (F3)"/>
                     <Button Content="職員管理 (F4)" Margin="5,0"
                             Style="{StaticResource AccessibleButtonStyle}"
                             Command="{Binding OpenStaffManageCommand}"


### PR DESCRIPTION
## Summary
- メイン画面およびカード管理画面のUI文言を「交通系ICカード管理」に統一
- ボタン、ダイアログタイトル、一覧ヘッダー、編集ヘッダーを変更

## 変更内容

### MainWindow.xaml
- ボタン: 「カード管理 (F3)」→「交通系ICカード管理 (F3)」
- ToolTip: 「カード管理を開く (F3)」→「交通系ICカード管理を開く (F3)」
- AutomationProperties.Name: 「カード管理ダイアログを開く」→「交通系ICカード管理ダイアログを開く」

### CardManageDialog.xaml
- ウィンドウタイトル: 「カード管理」→「交通系ICカード管理」
- AutomationProperties.Name: 「カード管理ダイアログ」→「交通系ICカード管理ダイアログ」
- 一覧ヘッダー: 「登録済みカード一覧」→「登録済み交通系ICカード一覧」
- 編集ヘッダー: 「カード編集」→「交通系ICカード編集」

## Test plan
- [x] プロジェクトがビルドできることを確認
- [x] 全テスト（901件）が成功することを確認
- [ ] メイン画面のボタン表示を確認
- [ ] カード管理ダイアログの各箇所の文言を確認

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)