### PR TITLE
fix: バス停名入力画面でスキップ・保存後にダイアログが閉じない問題を修正 (Issue #202)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
@@ -41,7 +41,8 @@ public partial class BusStopInputViewModel : ViewModelBase
     /// <summary>
     /// 保存完了フラグ（ダイアログ結果用）
     /// </summary>
-    public bool IsSaved { get; private set; }
+    [ObservableProperty]
+    private bool _isSaved;
 
     public BusStopInputViewModel(ILedgerRepository ledgerRepository)
     {


### PR DESCRIPTION
## Summary
- バス停名入力画面で「後で入力（スキップ）」や「保存」をクリックした際、メッセージは表示されるがダイアログが閉じない問題を修正

## 原因
- `BusStopInputViewModel`の`IsSaved`プロパティが通常のプロパティで、`[ObservableProperty]`属性が付与されていなかった
- そのため、`IsSaved = true`を設定しても`PropertyChanged`イベントが発火しなかった
- コードビハインド（`BusStopInputDialog.xaml.cs`）は`PropertyChanged`イベントを監視してダイアログを閉じる処理を行っていたため、閉じることができなかった

## 修正内容
```csharp
// Before
public bool IsSaved { get; private set; }

// After
[ObservableProperty]
private bool _isSaved;
```

## Test plan
- [x] プロジェクトがビルドできることを確認
- [x] 全テスト（901件）が成功することを確認
- [ ] バス停名入力画面で「保存」をクリックしてダイアログが閉じることを確認
- [ ] バス停名入力画面で「後で入力（スキップ）」をクリックしてダイアログが閉じることを確認

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)