### PR TITLE
fix: 編集中に他のカード/職員を選択した際に編集フォームが更新されない問題を修正 (Issue #205)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -343,6 +343,25 @@ namespace ICCardManager.ViewModels
         }
 
         /// <summary>
+        /// 選択カード変更時の処理
+        /// </summary>
+        partial void OnSelectedCardChanged(CardDto? value)
+        {
+            // 新規登録モード中は選択変更を無視
+            if (IsNewCard) return;
+
+            // カードが選択された場合、編集中なら選択したカードの情報で更新
+            if (value != null && IsEditing)
+            {
+                EditCardIdm = value.CardIdm;
+                EditCardType = value.CardType;
+                EditCardNumber = value.CardNumber;
+                EditNote = value.Note ?? string.Empty;
+                StatusMessage = string.Empty;
+            }
+        }
+
+        /// <summary>
         /// デバッグ用: カード読み取りをシミュレート
         /// </summary>
         [RelayCommand]

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -291,6 +291,25 @@ namespace ICCardManager.ViewModels
         }
 
         /// <summary>
+        /// 選択職員変更時の処理
+        /// </summary>
+        partial void OnSelectedStaffChanged(StaffDto? value)
+        {
+            // 新規登録モード中は選択変更を無視
+            if (IsNewStaff) return;
+
+            // 職員が選択された場合、編集中なら選択した職員の情報で更新
+            if (value != null && IsEditing)
+            {
+                EditStaffIdm = value.StaffIdm;
+                EditName = value.Name;
+                EditNumber = value.Number ?? string.Empty;
+                EditNote = value.Note ?? string.Empty;
+                StatusMessage = string.Empty;
+            }
+        }
+
+        /// <summary>
         /// デバッグ用: カード読み取りをシミュレート
         /// </summary>
         [RelayCommand]


### PR DESCRIPTION
## Summary
- 交通系ICカード管理画面および職員管理画面で、編集中に他のアイテムを選択した際に編集フォームが更新されない問題を修正
- 選択したアイテムの情報で編集フォームが書き換わり、前のアイテムの編集内容は破棄されるようにした

## 問題の詳細
編集ボタンをクリックして編集モードに入った後、一覧から別のカード/職員を選択しても、編集フォームには最初に選択したアイテムの情報が表示されたままだった。

## 原因
`[ObservableProperty]`で定義された`SelectedCard`/`SelectedStaff`プロパティの変更時に、編集フォームを更新する処理が実装されていなかった。

## 修正内容

### CardManageViewModel
```csharp
partial void OnSelectedCardChanged(CardDto? value)
{
    // 新規登録モード中は選択変更を無視
    if (IsNewCard) return;

    // カードが選択された場合、編集中なら選択したカードの情報で更新
    if (value != null && IsEditing)
    {
        EditCardIdm = value.CardIdm;
        EditCardType = value.CardType;
        EditCardNumber = value.CardNumber;
        EditNote = value.Note ?? string.Empty;
        StatusMessage = string.Empty;
    }
}
```

### StaffManageViewModel
```csharp
partial void OnSelectedStaffChanged(StaffDto? value)
{
    // 新規登録モード中は選択変更を無視
    if (IsNewStaff) return;

    // 職員が選択された場合、編集中なら選択した職員の情報で更新
    if (value != null && IsEditing)
    {
        EditStaffIdm = value.StaffIdm;
        EditName = value.Name;
        EditNumber = value.Number ?? string.Empty;
        EditNote = value.Note ?? string.Empty;
        StatusMessage = string.Empty;
    }
}
```

## 設計上の考慮事項
- **新規登録モード中**: 選択変更を無視（IDmの読み取り中に誤って選択しても影響しない）
- **編集モード中**: 選択したアイテムの情報で編集フォームを更新（前の編集内容は破棄）
- **編集モードでない場合**: 特に処理なし（選択のみ変更される）

## Test plan
- [x] プロジェクトがビルドできることを確認
- [x] 全テスト（901件）が成功することを確認
- [ ] 交通系ICカード管理画面で編集中に他のカードを選択し、編集フォームが更新されることを確認
- [ ] 職員管理画面で編集中に他の職員を選択し、編集フォームが更新されることを確認
- [ ] 新規登録モード中に別のアイテムを選択しても、入力中のIDmが維持されることを確認

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)