### PR TITLE
feat: 利用履歴一覧の摘要欄を広くする (Issue #212)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -357,9 +357,9 @@
                                   AlternatingRowBackground="#FAFAFA"
                                   AutomationProperties.Name="利用履歴一覧">
                             <DataGrid.Columns>
-                                <DataGridTextColumn Header="日付" Binding="{Binding DateDisplay}" Width="120"/>
+                                <DataGridTextColumn Header="日付" Binding="{Binding DateDisplay}" Width="90"/>
                                 <DataGridTextColumn Header="摘要" Binding="{Binding Summary}" Width="*"/>
-                                <DataGridTextColumn Header="受入" Width="90">
+                                <DataGridTextColumn Header="受入" Width="75">
                                     <DataGridTextColumn.Binding>
                                         <Binding Path="IncomeDisplay"/>
                                     </DataGridTextColumn.Binding>
@@ -371,7 +371,7 @@
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="払出" Width="90">
+                                <DataGridTextColumn Header="払出" Width="75">
                                     <DataGridTextColumn.Binding>
                                         <Binding Path="ExpenseDisplay"/>
                                     </DataGridTextColumn.Binding>
@@ -383,7 +383,7 @@
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="残高" Width="100">
+                                <DataGridTextColumn Header="残高" Width="85">
                                     <DataGridTextColumn.Binding>
                                         <Binding Path="BalanceDisplay"/>
                                     </DataGridTextColumn.Binding>
@@ -393,8 +393,8 @@
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
-                                <DataGridTextColumn Header="利用者" Binding="{Binding StaffName}" Width="100"/>
-                                <DataGridTextColumn Header="備考" Binding="{Binding Note}" Width="120"/>
+                                <DataGridTextColumn Header="利用者" Binding="{Binding StaffName}" Width="80"/>
+                                <DataGridTextColumn Header="備考" Binding="{Binding Note}" Width="100"/>
                             </DataGrid.Columns>
 
                             <!-- 貸出中レコードのスタイル -->


### PR DESCRIPTION
## Summary

- 利用履歴一覧のDataGridカラム幅を調整し、摘要欄をより広く表示できるようにしました
- 日付や金額の欄を狭くすることで、摘要欄に追加スペースを確保

## 変更内容

| カラム | 変更前 | 変更後 | 削減 |
|--------|--------|--------|------|
| 日付 | 120px | 90px | -30px |
| 受入 | 90px | 75px | -15px |
| 払出 | 90px | 75px | -15px |
| 残高 | 100px | 85px | -15px |
| 利用者 | 100px | 80px | -20px |
| 備考 | 120px | 100px | -20px |
| **合計** | **620px** | **505px** | **-115px** |

摘要欄は `Width="*"` で残りスペースを使用するため、115px分広くなります。

## Test plan

- [x] ビルド成功
- [x] テスト合格 (901件)
- [ ] アプリケーションを起動し、利用履歴一覧のカラム幅が適切であることを確認

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)