### PR TITLE
fix: 先月分を表示すると今月分が表示されるバグを修正 (Issue #215)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -926,8 +926,9 @@ public partial class MainViewModel : ViewModelBase
             HistoryLedgers.Clear();
 
             // ページングされた履歴を取得
+            // 注: 日付はyyyy-MM-dd形式で保存されているため、AddDays(1)は不要
             var (ledgers, totalCount) = await _ledgerRepository.GetPagedAsync(
-                HistoryCard.CardIdm, HistoryFromDate, HistoryToDate.AddDays(1), HistoryCurrentPage, HistoryPageSize);
+                HistoryCard.CardIdm, HistoryFromDate, HistoryToDate, HistoryCurrentPage, HistoryPageSize);
 
             foreach (var ledger in ledgers)
             {


### PR DESCRIPTION
## Summary

先月分の履歴を表示すると今月1日のデータも表示されてしまうバグを修正しました。

## 原因

`LoadHistoryLedgersAsync()` メソッドで `GetPagedAsync()` を呼び出す際に、`toDate` パラメータに `AddDays(1)` を加えていました。

```csharp
// 修正前
var (ledgers, totalCount) = await _ledgerRepository.GetPagedAsync(
    HistoryCard.CardIdm, HistoryFromDate, HistoryToDate.AddDays(1), ...);
```

これにより、11月を選択した場合:
- `HistoryToDate` = 2024-11-30
- `toDate` = 2024-12-01 (AddDays(1)により)
- SQL: `WHERE date BETWEEN '2024-11-01' AND '2024-12-01'`
- → 12月1日のレコードも含まれてしまう

## 修正内容

`AddDays(1)` を削除しました。日付は `yyyy-MM-dd` 形式（時刻なし）で保存されているため、追加は不要です。

```csharp
// 修正後
var (ledgers, totalCount) = await _ledgerRepository.GetPagedAsync(
    HistoryCard.CardIdm, HistoryFromDate, HistoryToDate, ...);
```

## Test plan

- [x] ビルド成功
- [x] 全テスト合格 (901件)
- [x] アプリケーションを起動し、先月を選択しても今月1日のデータが表示されないことを確認

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)