### PR TITLE
feat: メイン画面から年月日時分秒表示を削除 (Issue #219)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -149,9 +149,6 @@ public partial class MainViewModel : ViewModelBase
     private string _statusIconDescription = "待機中アイコン";
 
     [ObservableProperty]
-    private string _currentDateTime = string.Empty;
-
-    [ObservableProperty]
     private int _remainingSeconds;
 
     [ObservableProperty]
@@ -363,15 +360,6 @@ public partial class MainViewModel : ViewModelBase
         _cardReader.CardRead += OnCardRead;
         _cardReader.Error += OnCardReaderError;
         _cardReader.ConnectionStateChanged += OnCardReaderConnectionStateChanged;
-
-        // 日時更新タイマー
-        var dateTimeTimer = new DispatcherTimer
-        {
-            Interval = TimeSpan.FromSeconds(1)
-        };
-        dateTimeTimer.Tick += (s, e) => UpdateDateTime();
-        dateTimeTimer.Start();
-        UpdateDateTime();
 
         // 履歴表示用の年リストを初期化（今年度から過去6年分）
         var currentYear = DateTime.Today.Year;
@@ -1344,15 +1332,6 @@ public partial class MainViewModel : ViewModelBase
     public async Task ReconnectCardReaderAsync()
     {
         await _cardReader.ReconnectAsync();
-    }
-
-    /// <summary>
-    /// 日時を更新
-    /// </summary>
-    private void UpdateDateTime()
-    {
-        var now = DateTime.Now;
-        CurrentDateTime = $"{WarekiConverter.ToWareki(now)} {now:HH:mm:ss}";
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -52,17 +52,8 @@
                            VerticalAlignment="Center"
                            Margin="0,0,30,0"/>
 
-                <!-- 日時表示 + ボタン群（右寄せ） -->
+                <!-- ボタン群（右寄せ） -->
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
-                    <!-- 日時表示 -->
-                    <TextBlock Text="{Binding CurrentDateTime}"
-                               FontSize="{DynamicResource LargeFontSize}"
-                               Foreground="White"
-                               VerticalAlignment="Center"
-                               Margin="0,0,20,0"
-                               AutomationProperties.Name="現在日時"
-                               AutomationProperties.LiveSetting="Polite"/>
-
                     <Button Content="設定 (F1)" Margin="5,0"
                             Style="{StaticResource AccessibleButtonStyle}"
                             Command="{Binding OpenSettingsCommand}"


### PR DESCRIPTION
## Summary

メイン画面のヘッダーに表示されていた年月日時分秒の表示を削除しました。

## 変更内容

### MainWindow.xaml
- 日時表示の TextBlock を削除
- コメントを「日時表示 + ボタン群（右寄せ）」から「ボタン群（右寄せ）」に更新

### MainViewModel.cs
- `_currentDateTime` プロパティ（`[ObservableProperty]`）を削除
- 日時更新タイマー（`DispatcherTimer`）のセットアップを削除
- `UpdateDateTime()` メソッドを削除

## Test plan

- [x] ビルド成功
- [x] 全テスト合格 (901件)
- [x] アプリケーションを起動し、ヘッダーから日時表示が消えていることを確認

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)