### PR TITLE
feat: メイン画面に終了ボタンを追加 (Issue #220)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1347,6 +1347,15 @@ public partial class MainViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// アプリケーションを終了
+    /// </summary>
+    [RelayCommand]
+    public void Exit()
+    {
+        System.Windows.Application.Current.Shutdown();
+    }
+
+    /// <summary>
     /// 設定画面を開く
     /// </summary>
     [RelayCommand]

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -96,6 +96,13 @@
                             AutomationProperties.Name="操作ログダイアログを開く"
                             AutomationProperties.HelpText="システムの操作履歴を検索・表示します。ショートカット: F6"
                             ToolTip="操作ログを開く (F6)"/>
+                    <Button Content="終了" Margin="15,0,5,0"
+                            Style="{StaticResource AccessibleButtonStyle}"
+                            Command="{Binding ExitCommand}"
+                            TabIndex="7"
+                            AutomationProperties.Name="アプリケーションを終了"
+                            AutomationProperties.HelpText="アプリケーションを終了します。"
+                            ToolTip="アプリケーションを終了"/>
                 </StackPanel>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## Summary

メイン画面のヘッダー右側に「終了」ボタンを追加しました。

## 変更内容

### MainWindow.xaml
- 操作ログボタンの右側に「終了」ボタンを追加
- 他のボタンと区別するため左マージンを15pxに設定

### MainViewModel.cs
- `Exit()` コマンドを追加
- `Application.Current.Shutdown()` でアプリケーションを終了

## ボタン配置

```
[設定] [帳票] [交通系ICカード管理] [職員管理] [データ入出力] [操作ログ]   [終了]
```

## Test plan

- [x] ビルド成功
- [x] 全テスト合格 (901件)
- [ ] アプリケーションを起動し、終了ボタンをクリックしてアプリが終了することを確認

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)