### PR TITLE
fix: 利用履歴画面のページネーションが効かない問題を修正 (Issue #226)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -274,6 +274,10 @@ public partial class MainViewModel : ViewModelBase
     [NotifyPropertyChangedFor(nameof(HistoryCanGoToNextPage))]
     [NotifyPropertyChangedFor(nameof(HistoryCanGoToLastPage))]
     [NotifyPropertyChangedFor(nameof(HistoryPageDisplay))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToFirstPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToPrevPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToNextPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToLastPageCommand))]
     private int _historyCurrentPage = 1;
 
     /// <summary>
@@ -285,6 +289,10 @@ public partial class MainViewModel : ViewModelBase
     [NotifyPropertyChangedFor(nameof(HistoryCanGoToNextPage))]
     [NotifyPropertyChangedFor(nameof(HistoryCanGoToLastPage))]
     [NotifyPropertyChangedFor(nameof(HistoryPageDisplay))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToFirstPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToPrevPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToNextPageCommand))]
+    [NotifyCanExecuteChangedFor(nameof(HistoryGoToLastPageCommand))]
     private int _historyTotalPages = 1;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- 利用履歴画面でページネーションボタンが正しく動作しない問題を修正

## 原因
`HistoryCurrentPage` と `HistoryTotalPages` の変更時に、ページネーションコマンドの `CanExecute` 状態が更新されていなかった。

- `[NotifyPropertyChangedFor]` はプロパティ変更イベント（`PropertyChanged`）を発火する
- しかしコマンドの有効/無効状態を更新するには `CanExecuteChanged` イベントが必要
- `[NotifyCanExecuteChangedFor]` 属性が必要だった

## 修正内容

### MainViewModel.cs
`_historyCurrentPage` と `_historyTotalPages` に以下の属性を追加:
```csharp
[NotifyCanExecuteChangedFor(nameof(HistoryGoToFirstPageCommand))]
[NotifyCanExecuteChangedFor(nameof(HistoryGoToPrevPageCommand))]
[NotifyCanExecuteChangedFor(nameof(HistoryGoToNextPageCommand))]
[NotifyCanExecuteChangedFor(nameof(HistoryGoToLastPageCommand))]
```

## Test plan
- [x] ビルドが成功する
- [x] 全906件のテストがパスする
- [x] 履歴画面で50件以上のデータがある場合、ページネーションボタンが正しく動作する
- [x] 「次へ」「最後」ボタンが適切に有効/無効になる
- [ ] 「前へ」「最初」ボタンが適切に有効/無効になる

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)