### PR TITLE
chore: テストプロジェクトのnullable参照型警告を修正

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj
+++ b/ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net48</TargetFramework>
     <UseWPF>true</UseWPF>
     <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
@@ -93,7 +93,7 @@ public class PcScCardReaderTests : IDisposable
     public async Task StartReadingAsync_WhenNoReaderAvailable_ThrowsAndSetsDisconnectedState()
     {
         // Arrange
-        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null);
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
         var reader = CreateReader();
 
         // Act & Assert
@@ -164,7 +164,7 @@ public class PcScCardReaderTests : IDisposable
     public async Task CheckConnectionAsync_WhenNoReaderAvailable_ReturnsFalse()
     {
         // Arrange
-        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null);
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
         var reader = CreateReader();
 
         // Act
@@ -260,7 +260,7 @@ public class PcScCardReaderTests : IDisposable
     public async Task ReconnectAsync_ReportsRetryCount()
     {
         // Arrange
-        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null);
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
         var reader = CreateReader();
         var retryCountReported = 0;
         reader.ConnectionStateChanged += (s, e) =>
@@ -291,7 +291,7 @@ public class PcScCardReaderTests : IDisposable
         await reader.StartReadingAsync();
 
         // 再接続中状態をシミュレート
-        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null);
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
         await reader.ReconnectAsync();
 
         var callCountBefore = _providerMock.Invocations.Count(i => i.Method.Name == "GetReaders");

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
@@ -9,7 +9,6 @@ using Moq;
 using Xunit;
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
## Summary

- テストプロジェクトに `<Nullable>enable</Nullable>` を追加してnullable参照型を有効化
- SettingsViewModelTests.csの重複usingディレクティブを削除
- PcScCardReaderTests.csで意図的なnullテスト用にnull-forgiving operatorを使用

## 効果

| 項目 | Before | After |
|------|--------|-------|
| ビルド警告 | 86件 | 0件 |
| テスト | 911件合格 | 911件合格 |

## 変更ファイル

1. `tests/ICCardManager.Tests/ICCardManager.Tests.csproj`
   - `<Nullable>enable</Nullable>` を追加

2. `tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs`
   - 重複 `using System.Collections.Generic;` を削除

3. `tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs`
   - 意図的なnullテスト用に `null!` を使用

Closes #234

## Test plan

- [x] ビルドが成功することを確認（警告0件）
- [x] 全テスト（911件）が合格することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)