### PR TITLE
docs: 技術スタック情報を実際の環境に合わせて修正 (Issue #240)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@
 
 ## 技術スタック
 
-- **言語**: C# 12
-- **フレームワーク**: .NET 8 + WPF
+- **言語**: C# 10
+- **フレームワーク**: .NET Framework 4.8 + WPF
 - **アーキテクチャ**: MVVM
 - **DB**: SQLite3
 - **ICカードリーダー**: PaSoRi（PC/SC API経由）
@@ -128,8 +128,8 @@ dotnet run --project src/ICCardManager
 # テスト実行
 dotnet test
 
-# 自己完結型ビルド（配布用）
-dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+# リリースビルド（配布用）
+dotnet publish -c Release
 
 # DB初期化（開発時）
 # DbContext.InitializeDatabase() を呼び出す

--- a/ICCardManager/README.md
+++ b/ICCardManager/README.md
@@ -51,7 +51,7 @@
 
 | 項目 | 要件 |
 |------|------|
-| .NET Runtime | **不要**（自己完結型ビルド） |
+| .NET Framework | 4.8（通常Windows 10/11にプリインストール済み） |
 | PaSoRiドライバ | [ソニー公式サイト](https://www.sony.co.jp/Products/felica/consumer/support/download/)よりダウンロード |
 | Excel | 出力ファイルの閲覧に必要 |
 
@@ -141,8 +141,8 @@
 
 | カテゴリ | 技術 | バージョン |
 |----------|------|------------|
-| 言語 | C# | 12 |
-| フレームワーク | .NET | 8.0 |
+| 言語 | C# | 10 |
+| フレームワーク | .NET Framework | 4.8 |
 | UI | WPF | - |
 | アーキテクチャ | MVVM | - |
 | データベース | SQLite | 3.x |
@@ -174,10 +174,9 @@ ICCardManager/
 dotnet build
 
 # リリースビルド（配布用）
-dotnet publish src/ICCardManager/ICCardManager.csproj \
-  -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+dotnet publish src/ICCardManager/ICCardManager.csproj -c Release
 
-# 出力先: bin/Release/net8.0-windows/win-x64/publish/
+# 出力先: src/ICCardManager/bin/Release/net48/publish/
 ```
 
 ### インストーラーのビルド

--- a/ICCardManager/docs/DISTRIBUTION.md
+++ b/ICCardManager/docs/DISTRIBUTION.md
@@ -8,7 +8,7 @@
 
 ### 開発マシン
 - Windows 10/11 (64-bit)
-- .NET 8 SDK
+- .NET SDK（.NET Framework 4.8対応版）または Visual Studio 2022
 - Visual Studio 2022 または VS Code（任意）
 
 ### ビルドコマンド
@@ -18,7 +18,7 @@
 cd src/ICCardManager
 
 # リリースビルド（配布用）
-dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+dotnet publish -c Release
 ```
 
 ### ビルドオプションの説明
@@ -26,29 +26,16 @@ dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=
 | オプション | 説明 |
 |-----------|------|
 | `-c Release` | リリース構成でビルド（最適化有効） |
-| `-r win-x64` | Windows 64-bit向けにビルド |
-| `--self-contained true` | .NET ランタイムを同梱（実行環境に.NET不要） |
-| `-p:PublishSingleFile=true` | 単一の実行ファイルにパッケージング |
-
-### 追加の設定（csproj）
-
-以下の設定は `ICCardManager.csproj` に既に構成済みです：
-
-```xml
-<PublishSingleFile>true</PublishSingleFile>
-<SelfContained>true</SelfContained>
-<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
-```
 
 ## 出力ファイル構成
 
-ビルド成功後、以下のファイルが `bin/Release/net8.0-windows/win-x64/publish/` に生成されます：
+ビルド成功後、以下のファイルが `bin/Release/net48/publish/` に生成されます：
 
 ```
 publish/
-├── ICCardManager.exe          # メイン実行ファイル（約70-75MB）
+├── ICCardManager.exe          # メイン実行ファイル
 ├── ICCardManager.pdb          # デバッグシンボル（配布時は任意）
+├── *.dll                      # 依存ライブラリ
 └── Resources/
     ├── Sounds/
     │   ├── error.wav          # エラー音
@@ -63,11 +50,12 @@ publish/
 
 | ファイル | サイズ目安 |
 |----------|-----------|
-| ICCardManager.exe | 約 70-75 MB |
+| ICCardManager.exe | 約 1 MB |
+| 依存DLL合計 | 約 15-20 MB |
 | Resources/ 合計 | 約 100 KB |
 
-> **注記**: 実行ファイルが大きいのは、.NET ランタイム全体を同梱しているためです。
-> これにより、配布先のPCに.NETがインストールされていなくても動作します。
+> **注記**: .NET Framework 4.8はWindows 10/11にプリインストールされているため、
+> 配布先のPCに追加のランタイムインストールは通常不要です。
 
 ## 配布パッケージの作成
 
@@ -75,12 +63,12 @@ publish/
 
 1. **ビルドの実行**
    ```bash
-   dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+   dotnet publish -c Release
    ```
 
 2. **出力ディレクトリの確認**
    ```
-   bin/Release/net8.0-windows/win-x64/publish/
+   bin/Release/net48/publish/
    ```
 
 3. **配布用ZIPの作成**
@@ -109,7 +97,7 @@ publish/
 
 - **OS**: Windows 10/11 (64-bit)
 - **ICカードリーダー**: Sony PaSoRi（RC-S380等）
-- **.NET**: 不要（実行ファイルに同梱）
+- **.NET Framework**: 4.8（Windows 10/11にプリインストール済み）
 
 ### インストール手順
 

--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -61,14 +61,14 @@ graph LR
 
 | カテゴリ | 技術 | バージョン |
 |----------|------|------------|
-| 言語 | C# | 12 |
-| フレームワーク | .NET | 8.0 |
+| 言語 | C# | 10 |
+| フレームワーク | .NET Framework | 4.8 |
 | UIフレームワーク | WPF | - |
 | MVVMツールキット | CommunityToolkit.Mvvm | 8.x |
-| データベース | SQLite (Microsoft.Data.Sqlite) | 3.x |
+| データベース | SQLite (System.Data.SQLite.Core) | 3.x |
 | ICカード | PC/SC API | - |
 | Excel出力 | ClosedXML | 0.102.x |
-| ロギング | Microsoft.Extensions.Logging | 8.x |
+| ロギング | Microsoft.Extensions.Logging | 3.1.x |
 
 ---
 
@@ -842,11 +842,11 @@ dotnet test --filter "FullyQualifiedName~ValidationServiceTests"
 
 ### 8.2 配布用ビルド
 
-本システムは自己完結型（self-contained）でビルドし、.NET Runtimeのインストールを不要とする。
+本システムは.NET Framework 4.8上で動作する。Windows 10/11には.NET Framework 4.8がプリインストールされているため、通常は追加のランタイムインストールは不要である。
 
 ```bash
-# 自己完結型ビルド
-dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+# リリースビルド（配布用）
+dotnet publish -c Release
 ```
 
 **出力ファイル**:
@@ -897,7 +897,7 @@ dotnet run --project src/ICCardManager
 dotnet test
 
 # 配布ビルド
-dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true
+dotnet publish -c Release
 
 # テストカバレッジ（要: coverlet）
 dotnet test /p:CollectCoverage=true


### PR DESCRIPTION
## Summary
- ドキュメントに記載されていた技術スタック情報を実際のプロジェクト設定（csproj）に合わせて修正
- 言語: C# 12 → C# 10
- フレームワーク: .NET 8 → .NET Framework 4.8

## 修正したファイル
- CLAUDE.md
- README.md
- docs/DISTRIBUTION.md
- docs/manual/開発者ガイド.md

## Test plan
- [ ] 各ドキュメントの記述が実際のcsprojの設定と一致していることを確認

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)