### PR TITLE
feat: 出納履歴に時刻情報を含めて保存 (Issue #268)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -127,7 +127,7 @@ SELECT last_insert_rowid();";
 
             command.Parameters.AddWithValue("@cardIdm", ledger.CardIdm);
             command.Parameters.AddWithValue("@lenderIdm", (object)ledger.LenderIdm ?? DBNull.Value);
-            command.Parameters.AddWithValue("@date", ledger.Date.ToString("yyyy-MM-dd"));
+            command.Parameters.AddWithValue("@date", ledger.Date.ToString("yyyy-MM-dd HH:mm:ss"));
             command.Parameters.AddWithValue("@summary", ledger.Summary);
             command.Parameters.AddWithValue("@income", ledger.Income);
             command.Parameters.AddWithValue("@expense", ledger.Expense);
@@ -158,7 +158,7 @@ WHERE id = @id";
 
             command.Parameters.AddWithValue("@id", ledger.Id);
             command.Parameters.AddWithValue("@lenderIdm", (object)ledger.LenderIdm ?? DBNull.Value);
-            command.Parameters.AddWithValue("@date", ledger.Date.ToString("yyyy-MM-dd"));
+            command.Parameters.AddWithValue("@date", ledger.Date.ToString("yyyy-MM-dd HH:mm:ss"));
             command.Parameters.AddWithValue("@summary", ledger.Summary);
             command.Parameters.AddWithValue("@income", ledger.Income);
             command.Parameters.AddWithValue("@expense", ledger.Expense);

--- a/ICCardManager/src/ICCardManager/Data/schema.sql
+++ b/ICCardManager/src/ICCardManager/Data/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS ledger (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
     card_idm       TEXT    NOT NULL REFERENCES ic_card(card_idm),
     lender_idm     TEXT    REFERENCES staff(staff_idm),
-    date           TEXT    NOT NULL,       -- 出納年月日（YYYY-MM-DD）
+    date           TEXT    NOT NULL,       -- 出納年月日時（YYYY-MM-DD HH:MM:SS）
     summary        TEXT    NOT NULL,       -- 摘要
     income         INTEGER DEFAULT 0,      -- 受入金額（チャージ額）
     expense        INTEGER DEFAULT 0,      -- 払出金額（利用額）

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -213,7 +213,7 @@ namespace ICCardManager.Services
                     {
                         CardIdm = cardIdm,
                         LenderIdm = staffIdm,
-                        Date = now.Date,
+                        Date = now,
                         Summary = SummaryGenerator.GetLendingSummary(),
                         Income = 0,
                         Expense = 0,
@@ -444,7 +444,7 @@ namespace ICCardManager.Services
                     var chargeLedger = new Ledger
                     {
                         CardIdm = cardIdm,
-                        Date = date,
+                        Date = charge.UseDate ?? date,  // 利用日時があれば時刻を含めて使用
                         Summary = SummaryGenerator.GetChargeSummary(),
                         Income = income,
                         Expense = 0,
@@ -473,7 +473,7 @@ namespace ICCardManager.Services
                     var usageLedger = new Ledger
                     {
                         CardIdm = cardIdm,
-                        Date = date,
+                        Date = usageDetails.FirstOrDefault()?.UseDate ?? date,  // 利用日時があれば時刻を含めて使用
                         Summary = summary,
                         Income = 0,
                         Expense = expense,

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -402,7 +402,7 @@ namespace ICCardManager.ViewModels
                     {
                         CardIdm = cardIdm,
                         LenderIdm = null,  // 新規購入時は貸出者なし
-                        Date = now.Date,
+                        Date = now,
                         Summary = "新規購入",
                         Income = balance.Value,  // 受入金額 = カード残額
                         Expense = 0,


### PR DESCRIPTION
## Summary
- 出納履歴（ledger）の日付フィールドに時刻情報を含めて保存するように変更
- LedgerRepository の Insert/Update メソッドで日付フォーマットを `yyyy-MM-dd HH:mm:ss` に変更
- LendingService の貸出・チャージ・利用履歴作成時に時刻を保持
- CardManageViewModel の新規購入レコード作成時に時刻を保持
- schema.sql のコメントを更新

## Test plan
- [x] 新規カード登録時に「新規購入」レコードが時刻付きで作成されることを確認
- [x] カード貸出時に貸出レコードが時刻付きで作成されることを確認  
- [ ] カード返却時にチャージ・利用履歴レコードが時刻付きで作成されることを確認
- [x] CSVエクスポートで時刻情報が出力されることを確認
- [x] 物品出納簿の表示・印刷で日付のみ表示されることを確認（時刻は表示されない）

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)