### PR TITLE
fix: 日付範囲フィルタリングで最終日のデータが含まれない問題を修正 (Issue #271)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -42,8 +42,10 @@ ORDER BY date, id";
             {
                 command.Parameters.AddWithValue("@cardIdm", cardIdm);
             }
-            command.Parameters.AddWithValue("@fromDate", fromDate.ToString("yyyy-MM-dd"));
-            command.Parameters.AddWithValue("@toDate", toDate.ToString("yyyy-MM-dd"));
+            // 日付範囲フィルタリング: 時刻を含むデータに対応
+            // fromDate: その日の00:00:00から、toDate: その日の23:59:59まで
+            command.Parameters.AddWithValue("@fromDate", fromDate.Date.ToString("yyyy-MM-dd HH:mm:ss"));
+            command.Parameters.AddWithValue("@toDate", toDate.Date.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss"));
 
             using var reader = await command.ExecuteReaderAsync();
             while (await reader.ReadAsync())
@@ -354,8 +356,9 @@ FROM ledger
             {
                 countCommand.Parameters.AddWithValue("@cardIdm", cardIdm);
             }
-            countCommand.Parameters.AddWithValue("@fromDate", fromDate.ToString("yyyy-MM-dd"));
-            countCommand.Parameters.AddWithValue("@toDate", toDate.ToString("yyyy-MM-dd"));
+            // 日付範囲フィルタリング: 時刻を含むデータに対応
+            countCommand.Parameters.AddWithValue("@fromDate", fromDate.Date.ToString("yyyy-MM-dd HH:mm:ss"));
+            countCommand.Parameters.AddWithValue("@toDate", toDate.Date.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss"));
 
             var totalCount = Convert.ToInt32(await countCommand.ExecuteScalarAsync());
 
@@ -376,8 +379,9 @@ LIMIT @pageSize OFFSET @offset";
             {
                 command.Parameters.AddWithValue("@cardIdm", cardIdm);
             }
-            command.Parameters.AddWithValue("@fromDate", fromDate.ToString("yyyy-MM-dd"));
-            command.Parameters.AddWithValue("@toDate", toDate.ToString("yyyy-MM-dd"));
+            // 日付範囲フィルタリング: 時刻を含むデータに対応
+            command.Parameters.AddWithValue("@fromDate", fromDate.Date.ToString("yyyy-MM-dd HH:mm:ss"));
+            command.Parameters.AddWithValue("@toDate", toDate.Date.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss"));
             command.Parameters.AddWithValue("@pageSize", pageSize);
             command.Parameters.AddWithValue("@offset", offset);
 


### PR DESCRIPTION
## Summary
- 履歴データ出力時に終了日のデータが含まれない問題を修正
- `LedgerRepository` の日付範囲フィルタリングを時刻対応に変更
  - `fromDate`: その日の `00:00:00` から
  - `toDate`: その日の `23:59:59` まで

## 原因
PR #270（Issue #268）で `ledger.date` が時刻情報を含む形式（例: `2026-01-13 05:12:00`）で保存されるようになりました。しかし、`BETWEEN`句のパラメータが日付のみ（例: `2026-01-13`）だったため、SQLiteの辞書順比較で最終日のデータが除外されていました。

```
"2026-01-13 05:12:00" > "2026-01-13"  ← 辞書順で「大きい」と判定される
```

## 修正箇所
| メソッド | 修正内容 |
|----------|----------|
| `GetByDateRangeAsync` | 日付パラメータを時刻付きフォーマットに変更 |
| `GetPagedAsync` | 同様の修正を適用（カウントクエリとデータ取得クエリの両方） |

## Test plan
- [ ] 2026/1/13までのデータを出力した際、2026/1/13 05:12のデータが含まれることを確認
- [ ] 履歴画面で期間指定時に最終日のデータが表示されることを確認
- [ ] CSVエクスポートで終了日のデータが含まれることを確認

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)