### PR TITLE
feat: 重複登録時に既存カード/職員の情報を表示 (Issue #273)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -219,7 +219,7 @@ namespace ICCardManager.ViewModels
                     var existing = await _cardRepository.GetByIdmAsync(EditCardIdm, includeDeleted: true);
                     if (existing != null)
                     {
-                        StatusMessage = "このカードは既に登録されています";
+                        StatusMessage = $"このカードは {existing.CardNumber} として既に登録されています";
                         return;
                     }
 

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -164,7 +164,10 @@ namespace ICCardManager.ViewModels
                         var existing = await _staffRepository.GetByIdmAsync(EditStaffIdm, includeDeleted: true);
                         if (existing != null)
                         {
-                            StatusMessage = "この職員証は既に登録されています";
+                            var identifier = string.IsNullOrWhiteSpace(existing.Number)
+                                ? existing.Name
+                                : $"{existing.Name}（{existing.Number}）";
+                            StatusMessage = $"この職員証は {identifier} として既に登録されています";
                             return;
                         }
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -247,7 +247,7 @@ public class CardManageViewModelTests
         _viewModel.EditCardType = "はやかけん";
         _viewModel.EditCardNumber = "H-001";
 
-        var existingCard = new IcCard { CardIdm = "0102030405060708" };
+        var existingCard = new IcCard { CardIdm = "0102030405060708", CardNumber = "H-999" };
         _cardRepositoryMock.Setup(r => r.GetByIdmAsync("0102030405060708", true)).ReturnsAsync(existingCard);
 
         // Act
@@ -255,6 +255,7 @@ public class CardManageViewModelTests
 
         // Assert
         _viewModel.StatusMessage.Should().Contain("既に登録");
+        _viewModel.StatusMessage.Should().Contain("H-999");  // 管理番号が表示されること
         _cardRepositoryMock.Verify(r => r.InsertAsync(It.IsAny<IcCard>()), Times.Never);
     }
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
@@ -215,7 +215,7 @@ public class StaffManageViewModelTests
         _viewModel.EditStaffIdm = "FFFF000000000001";
         _viewModel.EditName = "田中太郎";
 
-        var existingStaff = new Staff { StaffIdm = "FFFF000000000001", Name = "既存職員" };
+        var existingStaff = new Staff { StaffIdm = "FFFF000000000001", Name = "既存職員", Number = "E001" };
         _staffRepositoryMock.Setup(r => r.GetByIdmAsync("FFFF000000000001", true)).ReturnsAsync(existingStaff);
 
         // Act
@@ -223,6 +223,7 @@ public class StaffManageViewModelTests
 
         // Assert
         _viewModel.StatusMessage.Should().Contain("既に登録");
+        _viewModel.StatusMessage.Should().Contain("既存職員");  // 氏名が表示されること
         _staffRepositoryMock.Verify(r => r.InsertAsync(It.IsAny<Staff>()), Times.Never);
     }
 


### PR DESCRIPTION
## Summary
- ICカードおよび職員証の新規登録時、既に登録されているカードを登録しようとした場合のエラーメッセージを改善
- 既存カード/職員の識別情報（管理番号/氏名）を表示するように変更

## 変更前後の比較

### ICカード
| 変更前 | 変更後 |
|--------|--------|
| このカードは既に登録されています | このカードは H-001 として既に登録されています |

### 職員証
| 変更前 | 変更後 |
|--------|--------|
| この職員証は既に登録されています | この職員証は 田中太郎（E001） として既に登録されています |

※職員番号が未設定の場合は氏名のみ表示

## 修正ファイル
- `CardManageViewModel.cs` - ICカードの重複エラーメッセージ
- `StaffManageViewModel.cs` - 職員証の重複エラーメッセージ
- 関連するテストファイル

## Test plan
- [ ] 既に登録されているICカードを新規登録しようとした際に、管理番号が表示されることを確認
- [ ] 既に登録されている職員証を新規登録しようとした際に、氏名（と職員番号）が表示されることを確認

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)