### PR TITLE
feat: 削除済みカード/職員の復元機能を追加 (Issue #279)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/CardRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/CardRepository.cs
@@ -306,6 +306,26 @@ WHERE card_idm = @cardIdm AND is_deleted = 0 AND is_lent = 0";
             return result > 0;
         }
 
+        /// <inheritdoc/>
+        public async Task<bool> RestoreAsync(string cardIdm)
+        {
+            var connection = _dbContext.GetConnection();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"UPDATE ic_card
+SET is_deleted = 0, deleted_at = NULL
+WHERE card_idm = @cardIdm AND is_deleted = 1";
+
+            command.Parameters.AddWithValue("@cardIdm", cardIdm);
+
+            var result = await command.ExecuteNonQueryAsync();
+            if (result > 0)
+            {
+                InvalidateCardCache();
+            }
+            return result > 0;
+        }
+
         /// <summary>
         /// カード関連のキャッシュをすべて無効化
         /// </summary>

--- a/ICCardManager/src/ICCardManager/Data/Repositories/ICardRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ICardRepository.cs
@@ -75,6 +75,12 @@ namespace ICCardManager.Data.Repositories
         Task<bool> DeleteAsync(string cardIdm);
 
         /// <summary>
+        /// 論理削除されたICカードを復元
+        /// </summary>
+        /// <param name="cardIdm">ICカードIDm</param>
+        Task<bool> RestoreAsync(string cardIdm);
+
+        /// <summary>
         /// IDmが存在するか確認
         /// </summary>
         Task<bool> ExistsAsync(string cardIdm);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/IStaffRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/IStaffRepository.cs
@@ -56,6 +56,12 @@ namespace ICCardManager.Data.Repositories
         Task<bool> DeleteAsync(string staffIdm);
 
         /// <summary>
+        /// 論理削除された職員を復元
+        /// </summary>
+        /// <param name="staffIdm">職員証IDm</param>
+        Task<bool> RestoreAsync(string staffIdm);
+
+        /// <summary>
         /// IDmが存在するか確認
         /// </summary>
         Task<bool> ExistsAsync(string staffIdm);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/StaffRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/StaffRepository.cs
@@ -204,6 +204,26 @@ WHERE staff_idm = @staffIdm AND is_deleted = 0";
             return result > 0;
         }
 
+        /// <inheritdoc/>
+        public async Task<bool> RestoreAsync(string staffIdm)
+        {
+            var connection = _dbContext.GetConnection();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"UPDATE staff
+SET is_deleted = 0, deleted_at = NULL
+WHERE staff_idm = @staffIdm AND is_deleted = 1";
+
+            command.Parameters.AddWithValue("@staffIdm", staffIdm);
+
+            var result = await command.ExecuteNonQueryAsync();
+            if (result > 0)
+            {
+                InvalidateStaffCache();
+            }
+            return result > 0;
+        }
+
         /// <summary>
         /// 職員関連のキャッシュをすべて無効化
         /// </summary>


### PR DESCRIPTION
## Summary
- 削除済みのカードや職員を新規登録しようとした際、「既に登録されています」ではなく「以前登録されていましたが削除されています。復元しますか？」と表示するように変更
- `ICardRepository`と`IStaffRepository`に`RestoreAsync`メソッドを追加
- `CardManageViewModel`と`StaffManageViewModel`で削除済みレコードを検出し、復元オプションを提供

## Changes
- `ICardRepository.cs`: `RestoreAsync`メソッドのシグネチャを追加
- `CardRepository.cs`: `RestoreAsync`メソッドを実装（論理削除フラグをリセット）
- `IStaffRepository.cs`: `RestoreAsync`メソッドのシグネチャを追加
- `StaffRepository.cs`: `RestoreAsync`メソッドを実装（論理削除フラグをリセット）
- `CardManageViewModel.cs`: 新規登録時に`includeDeleted: true`で重複チェックし、削除済みの場合は復元ダイアログを表示
- `StaffManageViewModel.cs`: 同様に削除済み職員の復元機能を追加

## Test plan
- [x] カード管理画面で新規登録モードを開始
- [x] 以前削除したカードをタッチ
- [x] 「このカードは以前 XXX として登録されていましたが、削除されています。復元しますか？」ダイアログが表示されることを確認
- [x] 「はい」を選択すると、カードが復元されることを確認
- [x] 「いいえ」を選択すると、復元されないことを確認
- [x] 職員管理画面でも同様のテストを実施
- [ ] 削除されていない既存カード/職員の場合は従来どおり「既に登録されています」と表示されることを確認

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)