### PR TITLE
feat: エラーメッセージを赤色で表示 (Issue #286)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -53,6 +53,9 @@ namespace ICCardManager.ViewModels
         private string _statusMessage = string.Empty;
 
         [ObservableProperty]
+        private bool _isStatusError;
+
+        [ObservableProperty]
         private bool _isWaitingForCard;
 
         /// <summary>
@@ -129,6 +132,7 @@ namespace ICCardManager.ViewModels
             EditCardNumber = string.Empty;
             EditNote = string.Empty;
             StatusMessage = "カードをタッチするとIDmを読み取ります";
+            IsStatusError = false;
             IsWaitingForCard = true;
 
             // MainViewModelでの未登録カード処理を抑制
@@ -153,6 +157,7 @@ namespace ICCardManager.ViewModels
             EditCardNumber = string.Empty;
             EditNote = string.Empty;
             StatusMessage = "カードを読み取りました。カード種別を確認してください。";
+            IsStatusError = false;
             IsWaitingForCard = false; // すでにIDmがあるので待機しない
         }
 
@@ -171,6 +176,7 @@ namespace ICCardManager.ViewModels
             EditCardNumber = SelectedCard.CardNumber;
             EditNote = SelectedCard.Note ?? string.Empty;
             StatusMessage = string.Empty;
+            IsStatusError = false;
             IsWaitingForCard = false;
         }
 
@@ -189,6 +195,7 @@ namespace ICCardManager.ViewModels
             if (!idmResult)
             {
                 StatusMessage = idmResult.ErrorMessage!;
+                IsStatusError = true;
                 return;
             }
 
@@ -196,6 +203,7 @@ namespace ICCardManager.ViewModels
             if (!typeResult)
             {
                 StatusMessage = typeResult.ErrorMessage!;
+                IsStatusError = true;
                 return;
             }
 
@@ -203,6 +211,7 @@ namespace ICCardManager.ViewModels
             if (!numberResult)
             {
                 StatusMessage = numberResult.ErrorMessage!;
+                IsStatusError = true;
                 return;
             }
 
@@ -235,12 +244,14 @@ namespace ICCardManager.ViewModels
                                 if (restored)
                                 {
                                     StatusMessage = $"{existing.CardNumber} を復元しました";
+                                    IsStatusError = false;
                                     await LoadCardsAsync();
                                     CancelEdit();
                                 }
                                 else
                                 {
                                     StatusMessage = "復元に失敗しました";
+                                    IsStatusError = true;
                                 }
                             }
                             return;
@@ -248,6 +259,7 @@ namespace ICCardManager.ViewModels
                         else
                         {
                             StatusMessage = $"このカードは {existing.CardNumber} として既に登録されています";
+                            IsStatusError = true;
                             return;
                         }
                     }
@@ -267,12 +279,14 @@ namespace ICCardManager.ViewModels
                         await CreateNewPurchaseLedgerAsync(EditCardIdm);
 
                         StatusMessage = "登録しました";
+                        IsStatusError = false;
                         await LoadCardsAsync();
                         CancelEdit();
                     }
                     else
                     {
                         StatusMessage = "登録に失敗しました";
+                        IsStatusError = true;
                     }
                 }
                 else
@@ -293,12 +307,14 @@ namespace ICCardManager.ViewModels
                     if (success)
                     {
                         StatusMessage = "更新しました";
+                        IsStatusError = false;
                         await LoadCardsAsync();
                         CancelEdit();
                     }
                     else
                     {
                         StatusMessage = "更新に失敗しました";
+                        IsStatusError = true;
                     }
                 }
             }
@@ -315,6 +331,7 @@ namespace ICCardManager.ViewModels
             if (SelectedCard.IsLent)
             {
                 StatusMessage = "貸出中のカードは削除できません";
+                IsStatusError = true;
                 return;
             }
 
@@ -324,12 +341,14 @@ namespace ICCardManager.ViewModels
                 if (success)
                 {
                     StatusMessage = "削除しました";
+                    IsStatusError = false;
                     await LoadCardsAsync();
                     CancelEdit();
                 }
                 else
                 {
                     StatusMessage = "削除に失敗しました";
+                    IsStatusError = true;
                 }
             }
         }
@@ -348,6 +367,7 @@ namespace ICCardManager.ViewModels
             EditCardNumber = string.Empty;
             EditNote = string.Empty;
             StatusMessage = string.Empty;
+            IsStatusError = false;
 
             // ICカード登録モードを解除
             App.IsCardRegistrationActive = false;
@@ -385,12 +405,14 @@ namespace ICCardManager.ViewModels
                             if (restored)
                             {
                                 StatusMessage = $"{existing.CardNumber} を復元しました";
+                                IsStatusError = false;
                                 await LoadCardsAsync();
                                 CancelEdit();
                             }
                             else
                             {
                                 StatusMessage = "復元に失敗しました";
+                                IsStatusError = true;
                             }
                         }
                         else
@@ -401,8 +423,9 @@ namespace ICCardManager.ViewModels
                     }
                     else
                     {
-                        // 既に登録済みの場合はメッセージを表示
+                        // 既に登録済みの場合はメッセージを表示（赤色で目立たせる: Issue #286）
                         StatusMessage = $"このカードは {existing.CardNumber} として既に登録されています";
+                        IsStatusError = true;
                         // フォームはそのままにして、ユーザーが確認できるようにする
                     }
                     return;
@@ -413,6 +436,7 @@ namespace ICCardManager.ViewModels
                 // デフォルトはnimoca（利用頻度が最も高いため）
                 EditCardType = "nimoca";
                 StatusMessage = "カードを読み取りました。カード種別を確認してください。";
+                IsStatusError = false;
 
                 // 注意: App.IsCardRegistrationActive はここで解除しない
                 // ダイアログが開いている間は常にフラグを維持し、
@@ -436,6 +460,7 @@ namespace ICCardManager.ViewModels
                 EditCardNumber = value.CardNumber;
                 EditNote = value.Note ?? string.Empty;
                 StatusMessage = string.Empty;
+                IsStatusError = false;
             }
         }
 

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -51,6 +51,9 @@ namespace ICCardManager.ViewModels
         private string _statusMessage = string.Empty;
 
         [ObservableProperty]
+        private bool _isStatusError;
+
+        [ObservableProperty]
         private bool _isWaitingForCard;
 
         public StaffManageViewModel(
@@ -105,6 +108,7 @@ namespace ICCardManager.ViewModels
             EditNumber = string.Empty;
             EditNote = string.Empty;
             StatusMessage = "職員証をタッチするとIDmを読み取ります";
+            IsStatusError = false;
             IsWaitingForCard = true;
 
             // MainViewModelでの未登録カード処理を抑制
@@ -126,6 +130,7 @@ namespace ICCardManager.ViewModels
             EditNumber = SelectedStaff.Number ?? string.Empty;
             EditNote = SelectedStaff.Note ?? string.Empty;
             StatusMessage = string.Empty;
+            IsStatusError = false;
             IsWaitingForCard = false;
         }
 
@@ -147,6 +152,7 @@ namespace ICCardManager.ViewModels
                 if (!idmResult)
                 {
                     StatusMessage = idmResult.ErrorMessage!;
+                    IsStatusError = true;
                     return;
                 }
 
@@ -154,6 +160,7 @@ namespace ICCardManager.ViewModels
                 if (!nameResult)
                 {
                     StatusMessage = nameResult.ErrorMessage!;
+                    IsStatusError = true;
                     return;
                 }
 
@@ -184,12 +191,14 @@ namespace ICCardManager.ViewModels
                                     if (restored)
                                     {
                                         StatusMessage = $"{identifier} を復元しました";
+                                        IsStatusError = false;
                                         await LoadStaffAsync();
                                         CancelEdit();
                                     }
                                     else
                                     {
                                         StatusMessage = "復元に失敗しました";
+                                        IsStatusError = true;
                                     }
                                 }
                                 return;
@@ -197,6 +206,7 @@ namespace ICCardManager.ViewModels
                             else
                             {
                                 StatusMessage = $"この職員証は {identifier} として既に登録されています";
+                                IsStatusError = true;
                                 return;
                             }
                         }
@@ -213,12 +223,14 @@ namespace ICCardManager.ViewModels
                         if (success)
                         {
                             StatusMessage = "登録しました";
+                            IsStatusError = false;
                             await LoadStaffAsync();
                             CancelEdit();
                         }
                         else
                         {
                             StatusMessage = "登録に失敗しました";
+                            IsStatusError = true;
                         }
                     }
                     else
@@ -236,12 +248,14 @@ namespace ICCardManager.ViewModels
                         if (success)
                         {
                             StatusMessage = "更新しました";
+                            IsStatusError = false;
                             await LoadStaffAsync();
                             CancelEdit();
                         }
                         else
                         {
                             StatusMessage = "更新に失敗しました";
+                            IsStatusError = true;
                         }
                     }
                 }
@@ -249,6 +263,7 @@ namespace ICCardManager.ViewModels
             catch (Exception ex)
             {
                 StatusMessage = $"エラー: {ex.Message}";
+                IsStatusError = true;
                 System.Diagnostics.Debug.WriteLine($"[StaffManageViewModel] SaveAsync エラー: {ex}");
             }
         }
@@ -269,18 +284,21 @@ namespace ICCardManager.ViewModels
                     if (success)
                     {
                         StatusMessage = "削除しました";
+                        IsStatusError = false;
                         await LoadStaffAsync();
                         CancelEdit();
                     }
                     else
                     {
                         StatusMessage = "削除に失敗しました";
+                        IsStatusError = true;
                     }
                 }
             }
             catch (Exception ex)
             {
                 StatusMessage = $"エラー: {ex.Message}";
+                IsStatusError = true;
                 System.Diagnostics.Debug.WriteLine($"[StaffManageViewModel] DeleteAsync エラー: {ex}");
             }
         }
@@ -340,12 +358,14 @@ namespace ICCardManager.ViewModels
                             if (restored)
                             {
                                 StatusMessage = $"{identifier} を復元しました";
+                                IsStatusError = false;
                                 await LoadStaffAsync();
                                 CancelEdit();
                             }
                             else
                             {
                                 StatusMessage = "復元に失敗しました";
+                                IsStatusError = true;
                             }
                         }
                         else
@@ -356,8 +376,9 @@ namespace ICCardManager.ViewModels
                     }
                     else
                     {
-                        // 既に登録済みの場合はメッセージを表示
+                        // 既に登録済みの場合はメッセージを表示（赤色で目立たせる: Issue #286）
                         StatusMessage = $"この職員証は {identifier} として既に登録されています";
+                        IsStatusError = true;
                         // フォームはそのままにして、ユーザーが確認できるようにする
                     }
 
@@ -368,6 +389,7 @@ namespace ICCardManager.ViewModels
 
                 // 未登録職員証の場合は通常処理
                 StatusMessage = "職員証を読み取りました";
+                IsStatusError = false;
 
                 // カード読み取り完了後、フラグを解除
                 App.IsStaffCardRegistrationActive = false;
@@ -390,6 +412,7 @@ namespace ICCardManager.ViewModels
                 EditNumber = value.Number ?? string.Empty;
                 EditNote = value.Note ?? string.Empty;
                 StatusMessage = string.Empty;
+                IsStatusError = false;
             }
         }
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -243,12 +243,22 @@
                              AutomationProperties.HelpText="メモや備考を入力してください（任意）"
                              ToolTip="備考（任意）"/>
 
-                    <!-- ステータスメッセージ -->
+                    <!-- ステータスメッセージ（エラー時は赤色: Issue #286） -->
                     <TextBlock Text="{Binding StatusMessage}"
-                               Foreground="#1976D2"
                                FontWeight="Bold"
                                TextWrapping="Wrap"
-                               Margin="0,0,0,10"/>
+                               Margin="0,0,0,10">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="#1976D2"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStatusError}" Value="True">
+                                        <Setter Property="Foreground" Value="#D32F2F"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
                 </StackPanel>
 
                 <!-- 未選択時の表示（編集モードでない場合のみ表示） -->

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -201,12 +201,22 @@
                              AutomationProperties.HelpText="メモや備考を入力してください（任意）"
                              ToolTip="備考（任意）"/>
 
-                    <!-- ステータスメッセージ -->
+                    <!-- ステータスメッセージ（エラー時は赤色: Issue #286） -->
                     <TextBlock Text="{Binding StatusMessage}"
-                               Foreground="#1976D2"
                                FontWeight="Bold"
                                TextWrapping="Wrap"
-                               Margin="0,0,0,10"/>
+                               Margin="0,0,0,10">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="#1976D2"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsStatusError}" Value="True">
+                                        <Setter Property="Foreground" Value="#D32F2F"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
                 </StackPanel>
 
                 <!-- 未選択時の表示（編集モードでない場合のみ表示） -->


### PR DESCRIPTION
## Summary
- カード管理画面・職員管理画面のステータスメッセージをエラー時は赤色（#D32F2F）、通常時は青色（#1976D2）で表示するよう変更
- `IsStatusError` プロパティを追加し、XAML で `DataTrigger` を使用して色を切り替え
- 「既に登録されています」などのエラーメッセージが視認しやすくなる

## Changes
- `CardManageViewModel.cs`: `IsStatusError` プロパティを追加、全 StatusMessage 設定箇所で適切に true/false を設定
- `StaffManageViewModel.cs`: `IsStatusError` プロパティを追加、全 StatusMessage 設定箇所で適切に true/false を設定
- `CardManageDialog.xaml`: TextBlock に DataTrigger を追加して色分け
- `StaffManageDialog.xaml`: TextBlock に DataTrigger を追加して色分け

## Test plan
- [x] カード管理画面で新規登録時、登録済みカードをタッチすると赤色でエラーメッセージが表示される
- [x] カード管理画面で新規登録が成功すると青色でメッセージが表示される
- [x] 職員管理画面で新規登録時、登録済み職員証をタッチすると赤色でエラーメッセージが表示される
- [ ] 職員管理画面で新規登録が成功すると青色でメッセージが表示される

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)