### PR TITLE
fix: 未登録カード検出時に種別とIDmを表示しない (Issue #278)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -97,7 +97,6 @@ public partial class MainViewModel : ViewModelBase
     private readonly ILedgerRepository _ledgerRepository;
     private readonly ISettingsRepository _settingsRepository;
     private readonly LendingService _lendingService;
-    private readonly CardTypeDetector _cardTypeDetector;
     private readonly IToastNotificationService _toastNotificationService;
 
     private DispatcherTimer? _timeoutTimer;
@@ -361,7 +360,6 @@ public partial class MainViewModel : ViewModelBase
         ILedgerRepository ledgerRepository,
         ISettingsRepository settingsRepository,
         LendingService lendingService,
-        CardTypeDetector cardTypeDetector,
         IToastNotificationService toastNotificationService)
     {
         _cardReader = cardReader;
@@ -371,7 +369,6 @@ public partial class MainViewModel : ViewModelBase
         _ledgerRepository = ledgerRepository;
         _settingsRepository = settingsRepository;
         _lendingService = lendingService;
-        _cardTypeDetector = cardTypeDetector;
         _toastNotificationService = toastNotificationService;
 
         // イベント登録
@@ -917,15 +914,13 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
-        var cardType = _cardTypeDetector.Detect(idm);
-        var cardTypeName = CardTypeDetector.GetDisplayName(cardType);
-
         _soundPlayer.Play(SoundType.Warning);
         // メイン画面は変更しない（Issue #186）
 
         // 登録確認ダイアログを表示
+        // 種別は自動判別できないため、IDmは職員にとって意味がないため、表示しない（Issue #278）
         var result = System.Windows.MessageBox.Show(
-            $"このカードは登録されていません。\n\n種別: {cardTypeName}\nIDm: {idm}\n\n新規登録しますか？",
+            "このカードは登録されていません。\n\n新規登録しますか？",
             "未登録カード",
             System.Windows.MessageBoxButton.YesNo,
             System.Windows.MessageBoxImage.Question);


### PR DESCRIPTION
## Summary
- 未登録カードがタッチされた際のダイアログから種別（cardType）とIDmの表示を削除
- 種別は自動判別が不正確であり、IDmは職員にとって意味のない技術的情報であるため

## Before
```
このカードは登録されていません。

種別: nimoca
IDm: 07FE123456789ABC

新規登録しますか？
```

## After
```
このカードは登録されていません。

新規登録しますか？
```

## Changes
- `MainViewModel.cs`: 
  - `HandleUnregisteredCardAsync` メソッドからカード種別とIDmの表示を削除
  - 未使用となった `CardTypeDetector` の依存関係を削除（フィールド、コンストラクタ引数、代入）

## Test plan
- [x] 未登録の交通系ICカードをタッチすると、種別・IDmなしで「このカードは登録されていません。新規登録しますか？」と表示される
- [x] 「はい」を選択するとカード管理画面が開き、新規登録ができる

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)