### PR TITLE
feat: リリースビルドでDEBUGボタンを非表示 (Issue #289)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -57,6 +57,21 @@ namespace ICCardManager
         /// </summary>
         public static bool IsCardRegistrationActive { get; set; }
 
+        /// <summary>
+        /// DEBUGビルドかどうか（XAMLからデバッグ用UIの表示制御に使用: Issue #289）
+        /// </summary>
+        public static bool IsDebugBuild
+        {
+            get
+            {
+#if DEBUG
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        xmlns:app="clr-namespace:ICCardManager"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:CardManageViewModel}"
         Title="交通系ICカード管理"
@@ -198,12 +199,26 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <!-- デバッグ用ボタン -->
+                            <!-- デバッグ用ボタン (DEBUG ビルドのみ表示: Issue #289) -->
                             <Button Content="[DEBUG] カード読み取りシミュレート"
                                     Command="{Binding SimulateCardReadCommand}"
                                     Margin="0,10,0,0"
-                                    Padding="10,5"
-                                    Visibility="{Binding IsWaitingForCard, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    Padding="10,5">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsWaitingForCard}" Value="True"/>
+                                                    <Condition Binding="{Binding Source={x:Static app:App.IsDebugBuild}}" Value="True"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                         </StackPanel>
                     </Border>
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
         xmlns:converters="clr-namespace:ICCardManager.Views.Converters"
+        xmlns:app="clr-namespace:ICCardManager"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:StaffManageViewModel}"
         Title="職員管理"
@@ -161,12 +162,26 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <!-- デバッグ用ボタン -->
+                            <!-- デバッグ用ボタン (DEBUG ビルドのみ表示: Issue #289) -->
                             <Button Content="[DEBUG] 職員証読み取りシミュレート"
                                     Command="{Binding SimulateCardReadCommand}"
                                     Margin="0,10,0,0"
-                                    Padding="10,5"
-                                    Visibility="{Binding IsWaitingForCard, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    Padding="10,5">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding IsWaitingForCard}" Value="True"/>
+                                                    <Condition Binding="{Binding Source={x:Static app:App.IsDebugBuild}}" Value="True"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                         </StackPanel>
                     </Border>
 

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:vm="clr-namespace:ICCardManager.ViewModels"
         xmlns:conv="clr-namespace:ICCardManager.Common"
         xmlns:cardReader="clr-namespace:ICCardManager.Infrastructure.CardReader"
+        xmlns:app="clr-namespace:ICCardManager"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
         Title="交通系ICカード管理システム"
@@ -740,8 +741,9 @@
                     <Run Text="[Esc] キャンセル"/>
                 </TextBlock>
 
-                <!-- デバッグ用ボタン (DEBUG ビルドのみ表示) -->
-                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="20,0,0,0">
+                <!-- デバッグ用ボタン (DEBUG ビルドのみ表示: Issue #289) -->
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="20,0,0,0"
+                            Visibility="{Binding Source={x:Static app:App.IsDebugBuild}, Converter={StaticResource BoolToVisibilityConverter}}">
                     <TextBlock Text="[DEBUG]" FontSize="{DynamicResource SmallFontSize}" Foreground="Red" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <Button Content="職員証" Command="{Binding SimulateStaffCardCommand}" Padding="10,3" Margin="0,0,5,0"/>
                     <Button Content="交通系ICカード" Command="{Binding SimulateIcCardCommand}" Padding="10,3"/>


### PR DESCRIPTION
## Summary
- リリースビルド（Release構成）ではデバッグ用のボタンを非表示にする
- DEBUGビルドでは従来通りシミュレートボタンが表示される

## 対象のDEBUG要素
| 画面 | 要素 |
|------|------|
| MainWindow | 「職員証」「交通系ICカード」シミュレートボタン |
| CardManageDialog | 「[DEBUG] カード読み取りシミュレート」ボタン |
| StaffManageDialog | 「[DEBUG] 職員証読み取りシミュレート」ボタン |

## 実装方針
1. `App.IsDebugBuild` 静的プロパティを追加（`#if DEBUG` で true/false を返す）
2. XAML から `x:Static` でバインドし、`BooleanToVisibilityConverter` で表示制御
3. 既存の条件（`IsWaitingForCard`）がある場合は `MultiDataTrigger` で AND 条件を実現

## Changes
- `App.xaml.cs`: `IsDebugBuild` プロパティを追加
- `MainWindow.xaml`: デバッグボタンの StackPanel に Visibility バインディングを追加
- `CardManageDialog.xaml`: MultiDataTrigger で条件付き表示
- `StaffManageDialog.xaml`: 同上

## Test plan
- [x] DEBUGビルド: メイン画面にシミュレートボタンが表示される
- [x] DEBUGビルド: カード管理画面の新規登録でシミュレートボタンが表示される
- [x] DEBUGビルド: 職員管理画面の新規登録でシミュレートボタンが表示される
- [x] Releaseビルド: 上記すべてのボタンが非表示になる

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)