### PR TITLE
feat: 手動バックアップのデフォルトフォルダを自動バックアップと同じに (Issue #292)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
@@ -92,12 +92,19 @@ public partial class SystemManageViewModel : ViewModelBase
     [RelayCommand]
     public async Task CreateBackupAsync()
     {
+        // 自動バックアップと同じフォルダをデフォルトに設定
+        var settings = await _settingsRepository.GetAppSettingsAsync();
+        var defaultBackupFolder = !string.IsNullOrEmpty(settings.BackupPath)
+            ? settings.BackupPath
+            : PathValidator.GetDefaultBackupPath();
+
         var dialog = new SaveFileDialog
         {
             Filter = "データベースファイル (*.db)|*.db",
             DefaultExt = ".db",
             FileName = $"backup_manual_{DateTime.Now:yyyyMMdd_HHmmss}.db",
-            Title = "バックアップファイルの保存先を選択"
+            Title = "バックアップファイルの保存先を選択",
+            InitialDirectory = Directory.Exists(defaultBackupFolder) ? defaultBackupFolder : null
         };
 
         if (dialog.ShowDialog() != true)


### PR DESCRIPTION
## Summary
- 手動バックアップ作成時の保存ダイアログで、デフォルトフォルダを自動バックアップの設定と同じにする
- 設定でバックアップパスが指定されている場合はそのパス、未設定の場合はデフォルトパス（`C:\ProgramData\ICCardManager\backup`）を使用

## Changes
- `SystemManageViewModel.CreateBackupAsync()`: `SaveFileDialog`の`InitialDirectory`プロパティを設定

## Test plan
- [x] 設定でバックアップパスを指定した状態で手動バックアップを実行し、そのフォルダがデフォルトで開かれることを確認
- [ ] 設定でバックアップパスが未設定の状態で手動バックアップを実行し、デフォルトパスが開かれることを確認
- [ ] 指定したフォルダが存在しない場合、ダイアログが正常に開くことを確認

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)