### PR TITLE
feat: 物品出納簿の出納年月日欄を中央寄せに (Issue #295)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -534,6 +534,9 @@ namespace ICCardManager.Services
             // H列からK列を結合（備考）
             worksheet.Range(row, 8, row, 11).Merge();
 
+            // A列（出納年月日）を中央寄せ
+            worksheet.Cell(row, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+
             // A列からK列まで罫線を適用
             var range = worksheet.Range(row, 1, row, 11);
             range.Style.Border.TopBorder = XLBorderStyleValues.Thin;


### PR DESCRIPTION
## Summary
- 物品出納簿（Excelファイル）の出納年月日欄（A列）を中央寄せに変更
- 「R7.12.2」などの和暦表記がセル内で中央に配置される

## Changes
- `ReportService.ApplyDataRowBorder()`: A列に `XLAlignmentHorizontalValues.Center` を設定

## 影響範囲
以下の全ての行に適用:
- 前年度繰越行
- 利用明細行（日付あり）
- 月計行（空欄）
- 累計行（空欄）
- 次年度繰越行（空欄）

## Test plan
- [ ] 物品出納簿を出力し、A列（出納年月日）の値が中央寄せで表示されることを確認
- [ ] 複数月分のデータで出力し、全ての行で中央寄せが適用されていることを確認

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)