### PR TITLE
feat: 物品出納簿の摘要欄と備考欄に折り返し設定を追加 (Issue #297, #298)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -529,10 +529,14 @@ namespace ICCardManager.Services
         private void ApplyDataRowBorder(IXLWorksheet worksheet, int row)
         {
             // B列とC列を結合（摘要）
-            worksheet.Range(row, 2, row, 3).Merge();
+            var summaryRange = worksheet.Range(row, 2, row, 3);
+            summaryRange.Merge();
+            summaryRange.Style.Alignment.WrapText = true; // 折り返して全体を表示
 
             // H列からK列を結合（備考）
-            worksheet.Range(row, 8, row, 11).Merge();
+            var noteRange = worksheet.Range(row, 8, row, 11);
+            noteRange.Merge();
+            noteRange.Style.Alignment.WrapText = true; // 折り返して全体を表示
 
             // A列（出納年月日）を中央寄せ
             worksheet.Cell(row, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;


### PR DESCRIPTION
## Summary
- 物品出納簿（Excelファイル）の摘要欄（B-C列）と備考欄（H-K列）に「折り返して全体を表示する」を設定
- 長いテキストがセル幅を超えた場合でも、自動的に折り返されて全体が表示される

## Changes
- `ReportService.ApplyDataRowBorder()`: 結合セルに `WrapText = true` を設定

## 技術的な変更
```csharp
// B列とC列を結合（摘要）
var summaryRange = worksheet.Range(row, 2, row, 3);
summaryRange.Merge();
summaryRange.Style.Alignment.WrapText = true; // 折り返して全体を表示

// H列からK列を結合（備考）
var noteRange = worksheet.Range(row, 8, row, 11);
noteRange.Merge();
noteRange.Style.Alignment.WrapText = true; // 折り返して全体を表示
```

## Test plan
- [x] 長い摘要テキスト（例: 複数区間の鉄道利用）を含むデータで物品出納簿を出力し、折り返して表示されることを確認
- [x] 長い備考テキストを含むデータで物品出納簿を出力し、折り返して表示されることを確認
- [x] 短いテキストの場合は通常通り表示されることを確認

Closes #297
Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)