### PR TITLE
feat: 物品出納簿のデータ行の高さを30に設定 (Issue #299)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -528,6 +528,9 @@ namespace ICCardManager.Services
         /// </summary>
         private void ApplyDataRowBorder(IXLWorksheet worksheet, int row)
         {
+            // 行の高さを30に設定
+            worksheet.Row(row).Height = 30;
+
             // B列とC列を結合（摘要）
             var summaryRange = worksheet.Range(row, 2, row, 3);
             summaryRange.Merge();


### PR DESCRIPTION
## Summary
- 物品出納簿（Excelファイル）のデータ行の高さを30ポイントに統一

## 変更内容

`ApplyDataRowBorder` メソッドに行の高さ設定を追加しました：

```csharp
// 行の高さを30に設定
worksheet.Row(row).Height = 30;
```

### 対象となる行
この設定はすべてのデータ行に適用されます：
- 前年度繰越行
- 履歴データ行
- 月計行
- 累計行
- 次年度繰越行

## 技術詳細

| 項目 | 値 |
|------|-----|
| 設定メソッド | `ApplyDataRowBorder()` |
| 行の高さ | 30ポイント |
| 適用範囲 | 3行目以降のすべてのデータ行 |

## Test plan
- [x] 物品出納簿を出力し、データ行の高さが30になっていることを確認
- [x] 複数データがある場合、すべての行の高さが統一されていることを確認

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)