### PR TITLE
feat: 受入金額、払出金額、残額のフォントサイズを14ptに設定 (Issue #303)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -531,6 +531,11 @@ namespace ICCardManager.Services
             // 行の高さを30に設定
             worksheet.Row(row).Height = 30;
 
+            // D〜F列（受入金額、払出金額、残額）のフォントサイズを14ptに設定
+            // 最大金額20,000円（6文字）を考慮し、列幅10.58に収まるサイズ
+            var amountRange = worksheet.Range(row, 4, row, 6);
+            amountRange.Style.Font.FontSize = 14;
+
             // B列とC列を結合（摘要）
             var summaryRange = worksheet.Range(row, 2, row, 3);
             summaryRange.Merge();


### PR DESCRIPTION
## Summary
- 物品出納簿の金額欄（受入金額、払出金額、残額）のフォントサイズを14ptに拡大

## 変更内容

`ApplyDataRowBorder` メソッドでD〜F列のフォントサイズを設定：

```csharp
// D〜F列（受入金額、払出金額、残額）のフォントサイズを14ptに設定
// 最大金額20,000円（6文字）を考慮し、列幅10.58に収まるサイズ
var amountRange = worksheet.Range(row, 4, row, 6);
amountRange.Style.Font.FontSize = 14;
```

## 設計根拠

| 項目 | 値 |
|------|-----|
| 最大金額 | 20,000円 |
| 表示文字数 | 6文字（カンマ含む） |
| 列幅 | 10.58（Excel文字単位） |
| 行の高さ | 30pt |
| **フォントサイズ** | **14pt** |

14ptは以下の制約をすべて満たします：
- 列幅10.58に6文字が収まる
- 行の高さ30ptに収まる
- デフォルト11ptより見やすく、視認性が向上

## 対象セル
| 列 | 内容 |
|----|------|
| D列 | 受入金額 |
| E列 | 払出金額 |
| F列 | 残額 |

## Test plan
- [x] 物品出納簿を出力し、D〜F列のフォントが大きくなっていることを確認
- [ ] 最大金額（20,000円）を入力しても列幅に収まることを確認

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)