### PR TITLE
feat: 物品出納簿の氏名欄を中央寄せに設定 (Issue #305)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -549,6 +549,9 @@ namespace ICCardManager.Services
             // A列（出納年月日）を中央寄せ
             worksheet.Cell(row, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
 
+            // G列（氏名）を中央寄せ
+            worksheet.Cell(row, 7).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+
             // A列からK列まで罫線を適用
             var range = worksheet.Range(row, 1, row, 11);
             range.Style.Border.TopBorder = XLBorderStyleValues.Thin;


### PR DESCRIPTION
## Summary
- 物品出納簿のG列（氏名）を中央寄せに設定

## 変更内容

`ApplyDataRowBorder` メソッドにG列の中央寄せ設定を追加：

```csharp
// G列（氏名）を中央寄せ
worksheet.Cell(row, 7).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
```

## 物品出納簿の列配置と書式

| 列 | 内容 | 配置 |
|----|------|------|
| A | 出納年月日 | 中央寄せ |
| B-C | 摘要 | 左寄せ（折り返し） |
| D | 受入金額 | 右寄せ |
| E | 払出金額 | 右寄せ |
| F | 残額 | 右寄せ |
| **G** | **氏名** | **中央寄せ** ← 今回追加 |
| H-K | 備考 | 左寄せ（折り返し） |

## Test plan
- [ ] 物品出納簿を出力し、氏名欄が中央寄せになっていることを確認

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)