### PR TITLE
feat: 出納年月日のフォントサイズを14ptに設定 (Issue #307)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -546,8 +546,12 @@ namespace ICCardManager.Services
             noteRange.Merge();
             noteRange.Style.Alignment.WrapText = true; // 折り返して全体を表示
 
-            // A列（出納年月日）を中央寄せ
-            worksheet.Cell(row, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            // A列（出納年月日）のフォントサイズを14ptに設定し、中央寄せ
+            // 文字が大きすぎる場合に備えて「縮小して全体を表示する」を設定
+            var dateCell = worksheet.Cell(row, 1);
+            dateCell.Style.Font.FontSize = 14;
+            dateCell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            dateCell.Style.Alignment.ShrinkToFit = true;
 
             // A列からK列まで罫線を適用
             var range = worksheet.Range(row, 1, row, 11);


### PR DESCRIPTION
## Summary
- 物品出納簿のA列（出納年月日）のフォントサイズを14ptに拡大
- 「縮小して全体を表示する」（ShrinkToFit）を設定

## 変更内容

`ApplyDataRowBorder` メソッドでA列の書式設定を拡張：

```csharp
// A列（出納年月日）のフォントサイズを14ptに設定し、中央寄せ
// 文字が大きすぎる場合に備えて「縮小して全体を表示する」を設定
var dateCell = worksheet.Cell(row, 1);
dateCell.Style.Font.FontSize = 14;
dateCell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
dateCell.Style.Alignment.ShrinkToFit = true;
```

## A列（出納年月日）の書式設定

| 設定項目 | 値 |
|----------|-----|
| フォントサイズ | 14pt |
| 水平配置 | 中央寄せ |
| ShrinkToFit | 有効 |

### ShrinkToFitについて
「縮小して全体を表示する」機能は、セルの内容がセル幅に収まらない場合に、
フォントサイズを自動的に縮小して全体を表示します。

これにより：
- 基本は14ptの見やすいサイズで表示
- 和暦日付（例：「R6.12.31」）が列幅に収まらない場合は自動縮小

## Test plan
- [ ] 物品出納簿を出力し、出納年月日のフォントが大きくなっていることを確認
- [ ] 長い日付文字列でも列幅に収まることを確認

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)