### PR TITLE
fix: カード削除機能の修正と確認ダイアログ追加 (Issue #311)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -126,7 +126,6 @@
                             ToolTip="新しいカードを登録"/>
                     <Button Content="編集"
                             Command="{Binding StartEditCommand}"
-                            IsEnabled="{Binding SelectedCard, Converter={StaticResource BoolToVisibilityConverter}}"
                             Padding="15,8"
                             Margin="0,0,10,5"
                             AutomationProperties.Name="カード情報編集"
@@ -134,7 +133,6 @@
                             ToolTip="選択したカードを編集"/>
                     <Button Content="削除"
                             Command="{Binding DeleteCommand}"
-                            IsEnabled="{Binding SelectedCard, Converter={StaticResource BoolToVisibilityConverter}}"
                             Padding="15,8"
                             Margin="0,0,0,5"
                             Foreground="Red"


### PR DESCRIPTION
## Summary
- カード管理画面の削除機能が動作しない問題を修正
- 削除前の確認ダイアログを追加

## 問題の原因

### 1. コンバーターの誤用

```xml
<!-- 問題のあったコード -->
<Button Content="削除"
        Command="{Binding DeleteCommand}"
        IsEnabled="{Binding SelectedCard, Converter={StaticResource BoolToVisibilityConverter}}" />
```

`BooleanToVisibilityConverter` は `bool` → `Visibility` の変換用ですが、ここでは：
- **入力**: `SelectedCard` (`CardDto?`) - `bool`ではない
- **出力先**: `IsEnabled` (`bool`) - `Visibility`ではない

型の不一致により、バインディングが正しく動作しませんでした。

### 2. 確認ダイアログの欠如

削除ボタンをクリックすると確認なしで即座に削除が実行される仕様でした。

## 修正内容

### ViewModel (`CardManageViewModel.cs`)

```csharp
// CanExecute メソッドを追加
private bool CanEdit() => SelectedCard != null;
private bool CanDelete() => SelectedCard != null && !SelectedCard.IsLent;

// RelayCommand に CanExecute を指定
[RelayCommand(CanExecute = nameof(CanEdit))]
public void StartEdit() { ... }

[RelayCommand(CanExecute = nameof(CanDelete))]
public async Task DeleteAsync() { ... }

// 選択変更時に CanExecute を再評価
partial void OnSelectedCardChanged(CardDto? value)
{
    StartEditCommand.NotifyCanExecuteChanged();
    DeleteCommand.NotifyCanExecuteChanged();
    ...
}
```

### 確認ダイアログの追加

```csharp
// 削除確認ダイアログを表示
var result = MessageBox.Show(
    $"カード「{SelectedCard.CardType} {SelectedCard.CardNumber}」を削除しますか？\n\n※削除後も履歴データは保持されます。",
    "削除確認",
    MessageBoxButton.YesNo,
    MessageBoxImage.Warning);

if (result != MessageBoxResult.Yes)
{
    return;
}
```

### XAML (`CardManageDialog.xaml`)

```xml
<!-- 修正後: IsEnabled バインディングを削除（コマンドが自動制御） -->
<Button Content="編集" Command="{Binding StartEditCommand}" ... />
<Button Content="削除" Command="{Binding DeleteCommand}" ... />
```

## 動作の変更

| 操作 | 変更前 | 変更後 |
|------|--------|--------|
| カード未選択時の削除ボタン | 動作が不安定 | 無効化（グレーアウト） |
| 貸出中カードの削除ボタン | 有効（クリックでエラー） | 無効化（グレーアウト） |
| 削除ボタンクリック | 即座に削除 | 確認ダイアログ表示後に削除 |

## Test plan
- [x] カード未選択時に編集・削除ボタンが無効化されることを確認
- [x] カード選択時に編集・削除ボタンが有効化されることを確認
- [x] 貸出中カード選択時に削除ボタンが無効化されることを確認
- [x] 削除ボタンクリック時に確認ダイアログが表示されることを確認
- [x] 確認ダイアログで「はい」を選択するとカードが削除されることを確認
- [x] 確認ダイアログで「いいえ」を選択するとカードが削除されないことを確認

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)