### PR TITLE
fix: 削除済みカード復元で「いいえ」選択時に案内メッセージを表示 (Issue #314)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -259,6 +259,17 @@ namespace ICCardManager.ViewModels
                                     IsStatusError = true;
                                 }
                             }
+                            else
+                            {
+                                // Issue #314: 復元しない場合は案内メッセージを表示
+                                MessageBox.Show(
+                                    $"このカードは以前 {existing.CardNumber} として登録されていたため、新規登録はできません。\n\n" +
+                                    "異なるカード番号等で登録したい場合は、先に復元を行い、その後に編集してください。",
+                                    "ご案内",
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Information);
+                                CancelEdit();
+                            }
                             return;
                         }
                         else
@@ -439,7 +450,13 @@ namespace ICCardManager.ViewModels
                         }
                         else
                         {
-                            // 復元しない場合は編集モードをキャンセル
+                            // Issue #314: 復元しない場合は案内メッセージを表示
+                            MessageBox.Show(
+                                $"このカードは以前 {existing.CardNumber} として登録されていたため、新規登録はできません。\n\n" +
+                                "異なるカード番号等で登録したい場合は、先に復元を行い、その後に編集してください。",
+                                "ご案内",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Information);
                             CancelEdit();
                         }
                     }

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -201,6 +201,17 @@ namespace ICCardManager.ViewModels
                                         IsStatusError = true;
                                     }
                                 }
+                                else
+                                {
+                                    // Issue #314: 復元しない場合は案内メッセージを表示
+                                    MessageBox.Show(
+                                        $"この職員証は以前 {identifier} として登録されていたため、新規登録はできません。\n\n" +
+                                        "異なる名前等で登録したい場合は、先に復元を行い、その後に編集してください。",
+                                        "ご案内",
+                                        MessageBoxButton.OK,
+                                        MessageBoxImage.Information);
+                                    CancelEdit();
+                                }
                                 return;
                             }
                             else
@@ -370,7 +381,13 @@ namespace ICCardManager.ViewModels
                         }
                         else
                         {
-                            // 復元しない場合は編集モードをキャンセル
+                            // Issue #314: 復元しない場合は案内メッセージを表示
+                            MessageBox.Show(
+                                $"この職員証は以前 {identifier} として登録されていたため、新規登録はできません。\n\n" +
+                                "異なる名前等で登録したい場合は、先に復元を行い、その後に編集してください。",
+                                "ご案内",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Information);
                             CancelEdit();
                         }
                     }


### PR DESCRIPTION
## Summary
- 削除済みの職員証/交通系ICカードを検出し「復元しますか？」で「いいえ」を選択した場合、新規登録ができずユーザーが混乱する問題を修正
- 「いいえ」選択時に適切な案内メッセージを表示

## 問題点

### 修正前の動作
1. 削除済みカードをタッチ
2. 「このカードは以前 ○○ として登録されていましたが、削除されています。復元しますか？」
3. 「いいえ」を選択
4. **何も表示されず処理が終了** → ユーザーは次に何をすべきか分からない

### 修正後の動作
1. 削除済みカードをタッチ
2. 「このカードは以前 ○○ として登録されていましたが、削除されています。復元しますか？」
3. 「いいえ」を選択
4. **案内メッセージを表示**:
   > このカード（IDm）は以前 ○○ として登録されていたため、新規登録はできません。
   > 
   > 異なる名前等で登録したい場合は、先に復元を行い、その後に編集してください。

## 変更内容

### StaffManageViewModel.cs
- `SaveAsync` メソッド内の削除済み職員検出処理を修正
- `OnCardRead` イベントハンドラ内の削除済み職員検出処理を修正

### CardManageViewModel.cs
- `SaveAsync` メソッド内の削除済みカード検出処理を修正
- `OnCardRead` イベントハンドラ内の削除済みカード検出処理を修正

## ユーザーへの案内フロー

```
削除済みカードを検出
    │
    ▼
「復元しますか？」ダイアログ
    │
    ├─「はい」→ 復元処理を実行
    │
    └─「いいえ」→ 案内メッセージを表示
                  「異なる名前等で登録したい場合は、
                   先に復元を行い、その後に編集してください。」
                        │
                        └─ 編集モードをキャンセル
```

## Test plan
- [x] 職員証管理画面で削除済み職員証をタッチ→「いいえ」選択→案内メッセージが表示されることを確認
- [ ] 職員証管理画面で削除済み職員証のIDmを入力して保存→「いいえ」選択→案内メッセージが表示されることを確認
- [x] カード管理画面で削除済みICカードをタッチ→「いいえ」選択→案内メッセージが表示されることを確認
- [ ] カード管理画面で削除済みICカードのIDmを入力して保存→「いいえ」選択→案内メッセージが表示されることを確認
- [ ] 「はい」を選択した場合は従来通り復元処理が行われることを確認

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)