### PR TITLE
fix: カード置きっぱなし時の連続読み取りを防止 (Issue #323)

### DIFF
--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/FelicaCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/FelicaCardReader.cs
@@ -559,6 +559,12 @@ namespace ICCardManager.Infrastructure.CardReader
                 // Polling 失敗はカードが載っていない場合も含むので、Traceレベルでログ出力
                 // 通常運用時は出力されず、詳細デバッグ時のみ確認可能
                 _logger.LogTrace("FelicaCardReader: ポーリング例外（カードなし等）: {Message}", ex.Message);
+
+                // Issue #323: 例外発生時もカード離脱とみなす
+                // FelicaUtility.GetIDm() はカードがない場合に null を返すこともあれば
+                // 例外をスローすることもある（ライブラリの実装による）
+                // どちらの場合でもカードが離された状態として扱う
+                _cardWasLifted = true;
             }
             finally
             {

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
@@ -458,6 +458,10 @@ namespace ICCardManager.Infrastructure.CardReader
                 {
                     // カードが素早く離された場合はデバッグログのみ（エラー通知不要）
                     _logger.LogDebug("カードが素早く離されました");
+                    // Issue #323: カード離脱とみなす
+                    // OnCardRemovedイベントより先にこの例外が発生することがあるため、
+                    // ここでもフラグを設定する
+                    _cardWasLifted = true;
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

- カードをリーダーに置きっぱなしにした場合に繰り返し読み取られてしまう問題を修正
- `_cardWasLifted`フラグを導入し、カードが一度離されてから再度置かれた場合のみイベントを発火するよう変更
- これにより、30秒ルール（誤操作キャンセル機能）が意図せず発動する問題が解消

## 変更ファイル

### FelicaCardReader.cs
- `_cardWasLifted`フラグを追加（volatile修飾子でスレッドセーフ）
- ポーリング時にカード未検出の場合、フラグを`true`に設定
- 同じカードが検出された場合、フラグが`true`の場合のみイベントを発火
- イベント発火後、フラグを`false`にリセット

### PcScCardReader.cs
- `_cardWasLifted`フラグを追加（volatile修飾子でスレッドセーフ）
- `OnCardRemoved`イベントでフラグを`true`に設定
- `OnCardInserted`で同じカードが検出された場合、フラグをチェック
- `StopReadingCore`でフラグをリセット（次回起動時の初回検出のため）

## 技術的詳細

### 2つのカードリーダーの実装の違い

| 項目 | FelicaCardReader | PcScCardReader |
|------|------------------|----------------|
| 検出方式 | ポーリング（250ms間隔） | イベントベース |
| 離脱検出 | カード未検出時 | `OnCardRemoved`イベント |
| スレッド安全性 | `volatile` + `lock` | `volatile` |

Closes #323

## Test plan

- [x] カードを置いたままにしても1回のみ読み取られることを確認
- [x] カードを離してから再度置くと再度読み取られることを確認
- [x] 30秒ルール（誤操作キャンセル）が正しく動作することを確認
- [x] 異なるカードを連続でタッチした場合、両方とも読み取られることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)