### PR TITLE
fix: カード連続読み取り防止と削除済みカード復元確認の改善 (Issue #323, #284)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
@@ -35,7 +35,13 @@ namespace ICCardManager.Views.Dialogs
                 // IDmが事前に設定されている場合は新規登録モードで開始
                 if (!string.IsNullOrEmpty(_presetIdm))
                 {
-                    _viewModel.StartNewCardWithIdm(_presetIdm);
+                    // Issue #284対応: タッチ時点で削除済み/登録済みチェックを行う
+                    var shouldClose = await _viewModel.StartNewCardWithIdmAsync(_presetIdm);
+                    if (shouldClose)
+                    {
+                        // 削除済みカードの復元完了、または登録済みカードの場合はダイアログを閉じる
+                        Close();
+                    }
                 }
             }
             catch (Exception ex)

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
@@ -35,7 +35,13 @@ namespace ICCardManager.Views.Dialogs
                 // IDmが事前に設定されている場合は新規登録モードで開始
                 if (!string.IsNullOrEmpty(_presetIdm))
                 {
-                    _viewModel.StartNewStaffWithIdm(_presetIdm);
+                    // Issue #284対応: タッチ時点で削除済み/登録済みチェックを行う
+                    var shouldClose = await _viewModel.StartNewStaffWithIdmAsync(_presetIdm);
+                    if (shouldClose)
+                    {
+                        // 削除済み職員の復元完了、または登録済み職員の場合はダイアログを閉じる
+                        Close();
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

- カードをリーダーに置きっぱなしにした場合の連続読み取りを防止 (Issue #323)
- 30秒ルール（誤操作キャンセル機能）が正しく動作するよう修正
- メイン画面からの削除済みカード検出時にタッチ時点で復元確認を表示 (Issue #284)

## 変更内容

### Issue #323: カード連続読み取り防止

#### 1. `_cardWasLifted` フラグの導入
- カードが物理的にリーダーから離されたかを追跡するフラグを追加
- カードが離されていない（置きっぱなし）場合は再読み取りを無視
- カードが離されて再度置かれた場合のみイベントを発火

#### 2. チェック順序の修正
- **Before**: 時間チェック → 離脱チェック（1秒以内だと離脱チェックに到達しない）
- **After**: 離脱チェックのみ（時間チェックは不要）

#### 3. 例外発生時のフラグ設定
- `FelicaUtility.GetIDm()` が例外をスローする場合もカード離脱とみなす
- `SCardError.RemovedCard` 発生時もフラグを設定

### Issue #284: 削除済みカード復元確認

#### 問題
メイン画面で削除済みカードをタッチした場合:
1. MainViewModelが「未登録カード」として検出
2. カード管理ダイアログを開く
3. `StartNewCardWithIdm()` が呼ばれるが削除済みチェックなし
4. 保存ボタン押下後にやっと復元確認が表示される

#### 修正
- `StartNewCardWithIdm` → `StartNewCardWithIdmAsync` に変更
- ダイアログ表示時に即座に削除済み/登録済みチェックを実行
- `StaffManageViewModel` にも同様の修正を適用

## 修正ファイル

| ファイル | 変更内容 |
|---------|---------|
| `FelicaCardReader.cs` | `_cardWasLifted`フラグ追加、例外時のフラグ設定 |
| `PcScCardReader.cs` | `_cardWasLifted`フラグ追加、RemovedCard時のフラグ設定 |
| `CardManageViewModel.cs` | `StartNewCardWithIdmAsync`で削除済みチェック追加 |
| `StaffManageViewModel.cs` | `StartNewStaffWithIdmAsync`で削除済みチェック追加 |
| `CardManageDialog.xaml.cs` | 非同期メソッド呼び出しに変更 |
| `StaffManageDialog.xaml.cs` | 非同期メソッド呼び出しに変更 |

## Test plan

### Issue #323
- [ ] カードを置いたままにしても1回のみ読み取られることを確認
- [ ] カードを離してから再度置くと再度読み取られることを確認
- [ ] 30秒ルール（誤操作キャンセル）が正しく動作することを確認
- [ ] 異なるカードを連続でタッチした場合、両方とも読み取られることを確認

### Issue #284
- [ ] メイン画面で削除済みカードをタッチした場合、タッチ時点で復元確認ダイアログが表示されることを確認
- [ ] カード管理画面から新規登録時も同様に動作することを確認
- [ ] 職員管理画面でも同様に動作することを確認

Closes #323
Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)