### PR TITLE
feat: 同じ履歴を二回以上登録しない (Issue #326)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -105,5 +105,19 @@ namespace ICCardManager.Data.Repositories
             DateTime toDate,
             int page,
             int pageSize);
+
+        /// <summary>
+        /// 指定カードの既存の履歴詳細キーを取得（重複チェック用）
+        /// </summary>
+        /// <remarks>
+        /// Issue #326対応: 同じ履歴を二回以上登録しないための重複チェックに使用。
+        /// キーは use_date + balance + is_charge の組み合わせ。
+        /// FeliCa履歴では取引ごとに残高が変化するため、この組み合わせで一意に識別可能。
+        /// </remarks>
+        /// <param name="cardIdm">ICカードIDm</param>
+        /// <param name="fromDate">検索開始日</param>
+        /// <returns>既存の履歴詳細キーのセット</returns>
+        Task<HashSet<(DateTime? UseDate, int? Balance, bool IsCharge)>> GetExistingDetailKeysAsync(
+            string cardIdm, DateTime fromDate);
     }
 }


### PR DESCRIPTION
## Summary

- 同じカードを同日中に複数回貸出・返却した場合の履歴二重登録を防止
- 履歴登録前に既存の履歴詳細と照合して重複を除外

## 問題の詳細

同じカードを同日中に複数回貸出・返却すると、以下のシナリオで履歴が二重登録される可能性がありました：

```
9:00  カードA貸出
10:00 電車利用（FeliCa履歴に記録）
11:00 カードA返却 → 10:00の利用履歴を登録
14:00 カードA貸出（同日）
17:00 カードA返却 → FeliCa履歴を再読み取り
      ↓
      日付フィルタ: 今日 >= 今日 → 10:00の履歴も含まれる
      → 同じ履歴が二重登録される！
```

## 解決策

### 重複判定キー

FeliCa履歴の各エントリを一意に識別するため、以下の組み合わせを使用：

| フィールド | 説明 |
|-----------|------|
| `use_date` | 利用日 |
| `balance` | 取引後の残高（毎取引ごとに異なる） |
| `is_charge` | チャージか利用か |

`balance`（残高）がポイント。ICカードは取引ごとに残高が変化するため、同じ日付・同じ駅でも残高が異なれば別取引として識別できます。

### 実装

1. **ILedgerRepository**: `GetExistingDetailKeysAsync`メソッドを追加
2. **LedgerRepository**: 既存の履歴詳細キーを取得するSQLを実装
3. **LendingService.CreateUsageLedgersAsync**: 登録前に重複チェック＆除外

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `ILedgerRepository.cs` | `GetExistingDetailKeysAsync`インターフェース追加 |
| `LedgerRepository.cs` | 重複チェック用キー取得の実装 |
| `LendingService.cs` | 履歴登録前の重複除外ロジック追加 |

## Test plan

- [ ] 同じカードを同日中に2回貸出・返却して、履歴が二重登録されないことを確認
- [ ] 異なる日に貸出・返却して、正常に履歴が登録されることを確認
- [ ] チャージと利用が混在する場合に正しく処理されることを確認
- [ ] 重複除外のログが出力されることを確認

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)