### PR TITLE
feat: 職員・ICカードの全CRUD操作を操作ログに記録

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
@@ -24,6 +24,7 @@ namespace ICCardManager.Services
             public const string Insert = "INSERT";
             public const string Update = "UPDATE";
             public const string Delete = "DELETE";
+            public const string Restore = "RESTORE";
         }
 
         /// <summary>
@@ -63,14 +64,18 @@ namespace ICCardManager.Services
         /// <summary>
         /// 職員登録のログを記録
         /// </summary>
-        public async Task LogStaffInsertAsync(string operatorIdm, Staff staff)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="staff">登録した職員データ</param>
+        public async Task LogStaffInsertAsync(string? operatorIdm, Staff staff)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.Staff,
                 TargetId = staff.StaffIdm,
@@ -85,14 +90,19 @@ namespace ICCardManager.Services
         /// <summary>
         /// 職員更新のログを記録
         /// </summary>
-        public async Task LogStaffUpdateAsync(string operatorIdm, Staff beforeStaff, Staff afterStaff)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="beforeStaff">変更前の職員データ</param>
+        /// <param name="afterStaff">変更後の職員データ</param>
+        public async Task LogStaffUpdateAsync(string? operatorIdm, Staff beforeStaff, Staff afterStaff)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.Staff,
                 TargetId = afterStaff.StaffIdm,
@@ -107,14 +117,18 @@ namespace ICCardManager.Services
         /// <summary>
         /// 職員削除のログを記録
         /// </summary>
-        public async Task LogStaffDeleteAsync(string operatorIdm, Staff staff)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="staff">削除する職員データ</param>
+        public async Task LogStaffDeleteAsync(string? operatorIdm, Staff staff)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.Staff,
                 TargetId = staff.StaffIdm,
@@ -127,16 +141,46 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
-        /// ICカード登録のログを記録
+        /// 職員復元のログを記録
         /// </summary>
-        public async Task LogCardInsertAsync(string operatorIdm, IcCard card)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="staff">復元後の職員データ</param>
+        public async Task LogStaffRestoreAsync(string? operatorIdm, Staff staff)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
+                OperatorName = operatorName,
+                TargetTable = Tables.Staff,
+                TargetId = staff.StaffIdm,
+                Action = Actions.Restore,
+                BeforeData = null,
+                AfterData = SerializeToJson(staff)
+            };
+
+            await _operationLogRepository.InsertAsync(log);
+        }
+
+        /// <summary>
+        /// ICカード登録のログを記録
+        /// </summary>
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="card">登録したICカードデータ</param>
+        public async Task LogCardInsertAsync(string? operatorIdm, IcCard card)
+        {
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
+
+            var log = new OperationLog
+            {
+                Timestamp = DateTime.Now,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.IcCard,
                 TargetId = card.CardIdm,
@@ -151,14 +195,19 @@ namespace ICCardManager.Services
         /// <summary>
         /// ICカード更新のログを記録
         /// </summary>
-        public async Task LogCardUpdateAsync(string operatorIdm, IcCard beforeCard, IcCard afterCard)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="beforeCard">変更前のICカードデータ</param>
+        /// <param name="afterCard">変更後のICカードデータ</param>
+        public async Task LogCardUpdateAsync(string? operatorIdm, IcCard beforeCard, IcCard afterCard)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.IcCard,
                 TargetId = afterCard.CardIdm,
@@ -173,20 +222,50 @@ namespace ICCardManager.Services
         /// <summary>
         /// ICカード削除のログを記録
         /// </summary>
-        public async Task LogCardDeleteAsync(string operatorIdm, IcCard card)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="card">削除するICカードデータ</param>
+        public async Task LogCardDeleteAsync(string? operatorIdm, IcCard card)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.IcCard,
                 TargetId = card.CardIdm,
                 Action = Actions.Delete,
                 BeforeData = SerializeToJson(card),
                 AfterData = null
+            };
+
+            await _operationLogRepository.InsertAsync(log);
+        }
+
+        /// <summary>
+        /// ICカード復元のログを記録
+        /// </summary>
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="card">復元後のICカードデータ</param>
+        public async Task LogCardRestoreAsync(string? operatorIdm, IcCard card)
+        {
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
+
+            var log = new OperationLog
+            {
+                Timestamp = DateTime.Now,
+                OperatorIdm = actualIdm,
+                OperatorName = operatorName,
+                TargetTable = Tables.IcCard,
+                TargetId = card.CardIdm,
+                Action = Actions.Restore,
+                BeforeData = null,
+                AfterData = SerializeToJson(card)
             };
 
             await _operationLogRepository.InsertAsync(log);

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -7,6 +7,7 @@ using ICCardManager.Services;
 using ICCardManager.ViewModels;
 using Moq;
 using Xunit;
+using IOperationLogRepository = ICCardManager.Data.Repositories.IOperationLogRepository;
 
 using System;
 using System.Collections.Generic;
@@ -22,17 +23,26 @@ namespace ICCardManager.Tests.ViewModels;
 public class CardManageViewModelTests
 {
     private readonly Mock<ICardRepository> _cardRepositoryMock;
+    private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
     private readonly Mock<ICardReader> _cardReaderMock;
     private readonly Mock<IValidationService> _validationServiceMock;
+    private readonly Mock<IStaffRepository> _staffRepositoryMock;
+    private readonly Mock<OperationLogger> _operationLoggerMock;
     private readonly CardTypeDetector _cardTypeDetector;
     private readonly CardManageViewModel _viewModel;
 
     public CardManageViewModelTests()
     {
         _cardRepositoryMock = new Mock<ICardRepository>();
+        _ledgerRepositoryMock = new Mock<ILedgerRepository>();
         _cardReaderMock = new Mock<ICardReader>();
         _validationServiceMock = new Mock<IValidationService>();
+        _staffRepositoryMock = new Mock<IStaffRepository>();
         _cardTypeDetector = new CardTypeDetector();
+
+        // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
+        var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
 
         // バリデーションはデフォルトで成功を返す
         _validationServiceMock.Setup(v => v.ValidateCardIdm(It.IsAny<string>())).Returns(ValidationResult.Success());
@@ -41,9 +51,11 @@ public class CardManageViewModelTests
 
         _viewModel = new CardManageViewModel(
             _cardRepositoryMock.Object,
+            _ledgerRepositoryMock.Object,
             _cardReaderMock.Object,
             _cardTypeDetector,
-            _validationServiceMock.Object);
+            _validationServiceMock.Object,
+            _operationLoggerMock.Object);
     }
 
     #region カード一覧読み込みテスト

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
@@ -7,6 +7,7 @@ using ICCardManager.Services;
 using ICCardManager.ViewModels;
 using Moq;
 using Xunit;
+using IOperationLogRepository = ICCardManager.Data.Repositories.IOperationLogRepository;
 
 using System;
 using System.Collections.Generic;
@@ -24,6 +25,7 @@ public class StaffManageViewModelTests
     private readonly Mock<IStaffRepository> _staffRepositoryMock;
     private readonly Mock<ICardReader> _cardReaderMock;
     private readonly Mock<IValidationService> _validationServiceMock;
+    private readonly Mock<OperationLogger> _operationLoggerMock;
     private readonly StaffManageViewModel _viewModel;
 
     public StaffManageViewModelTests()
@@ -32,6 +34,10 @@ public class StaffManageViewModelTests
         _cardReaderMock = new Mock<ICardReader>();
         _validationServiceMock = new Mock<IValidationService>();
 
+        // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
+        var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+
         // バリデーションはデフォルトで成功を返す
         _validationServiceMock.Setup(v => v.ValidateStaffIdm(It.IsAny<string>())).Returns(ValidationResult.Success());
         _validationServiceMock.Setup(v => v.ValidateStaffName(It.IsAny<string>())).Returns(ValidationResult.Success());
@@ -39,7 +45,8 @@ public class StaffManageViewModelTests
         _viewModel = new StaffManageViewModel(
             _staffRepositoryMock.Object,
             _cardReaderMock.Object,
-            _validationServiceMock.Object);
+            _validationServiceMock.Object,
+            _operationLoggerMock.Object);
     }
 
     #region 職員一覧読み込みテスト


### PR DESCRIPTION
## Summary

- 職員管理画面（StaffManageViewModel）の操作ログ記録を実装
  - 職員の登録・更新・削除・復元操作を記録
- カード管理画面（CardManageViewModel）の操作ログ記録を実装
  - ICカードの登録・更新・削除・復元操作を記録
- OperationLoggerに `RESTORE` 操作種別を追加（論理削除からの復元用）

## 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `OperationLogger.cs` | RESTORE操作種別追加、全メソッドのnull対応（GUI操作対応） |
| `StaffManageViewModel.cs` | OperationLoggerをDI、全CRUD操作にログ記録を追加 |
| `CardManageViewModel.cs` | OperationLoggerをDI、全CRUD操作にログ記録を追加 |
| `*ViewModelTests.cs` | テストファイルをOperationLogger追加に対応 |

## 操作ログに記録される操作

### 職員（staff）
- `INSERT`: 新規登録
- `UPDATE`: 情報更新
- `DELETE`: 削除
- `RESTORE`: 復元

### ICカード（ic_card）
- `INSERT`: 新規登録
- `UPDATE`: 情報更新
- `DELETE`: 削除
- `RESTORE`: 復元

### 利用履歴（ledger）
- `UPDATE`: 摘要・備考の編集（既存実装）

## Test plan
- [ ] 職員を新規登録し、操作ログに`INSERT`レコードが記録されることを確認
- [ ] 職員情報を更新し、操作ログに`UPDATE`レコードが記録されることを確認
- [x] 職員を削除し、操作ログに`DELETE`レコードが記録されることを確認
- [ ] 削除済み職員を復元し、操作ログに`RESTORE`レコードが記録されることを確認
- [ ] ICカードの登録・更新・削除・復元についても同様に確認
- [ ] 操作ログ閲覧画面で各操作が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)