### PR TITLE
feat: 職員証タッチスキップ機能を削除 (Issue #331)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/SettingsRepository.cs
@@ -29,10 +29,6 @@ namespace ICCardManager.Data.Repositories
         public const string KeyWindowHeight = "window_height";
         public const string KeyWindowMaximized = "window_maximized";
 
-        // 職員証スキップ設定キー
-        public const string KeySkipStaffTouch = "skip_staff_touch";
-        public const string KeyDefaultStaffIdm = "default_staff_idm";
-
         // 音声モード設定キー
         public const string KeySoundMode = "sound_mode";
 
@@ -131,13 +127,6 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
             // ウィンドウ設定
             settings.MainWindowSettings = GetWindowSettingsFromDb();
 
-            // 職員証スキップ設定
-            var skipStaffTouch = Get(KeySkipStaffTouch);
-            settings.SkipStaffTouch = skipStaffTouch?.ToLowerInvariant() == "true";
-
-            var defaultStaffIdm = Get(KeyDefaultStaffIdm);
-            settings.DefaultStaffIdm = string.IsNullOrEmpty(defaultStaffIdm) ? null : defaultStaffIdm;
-
             // 音声モード設定
             var soundMode = Get(KeySoundMode);
             settings.SoundMode = ParseSoundMode(soundMode);
@@ -233,13 +222,6 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
             // ウィンドウ設定
             settings.MainWindowSettings = await GetWindowSettingsFromDbAsync();
 
-            // 職員証スキップ設定
-            var skipStaffTouch = await GetAsync(KeySkipStaffTouch);
-            settings.SkipStaffTouch = skipStaffTouch?.ToLowerInvariant() == "true";
-
-            var defaultStaffIdm = await GetAsync(KeyDefaultStaffIdm);
-            settings.DefaultStaffIdm = string.IsNullOrEmpty(defaultStaffIdm) ? null : defaultStaffIdm;
-
             // 音声モード設定
             var soundMode = await GetAsync(KeySoundMode);
             settings.SoundMode = ParseSoundMode(soundMode);
@@ -304,10 +286,6 @@ ON CONFLICT(key) DO UPDATE SET value = @value";
 
             // ウィンドウ設定を保存
             success &= await SaveWindowSettingsToDbAsync(settings.MainWindowSettings);
-
-            // 職員証スキップ設定を保存
-            success &= await SetAsync(KeySkipStaffTouch, settings.SkipStaffTouch.ToString().ToLowerInvariant());
-            success &= await SetAsync(KeyDefaultStaffIdm, settings.DefaultStaffIdm);
 
             // 音声モード設定を保存
             success &= await SetAsync(KeySoundMode, SoundModeToString(settings.SoundMode));

--- a/ICCardManager/src/ICCardManager/Models/AppSettings.cs
+++ b/ICCardManager/src/ICCardManager/Models/AppSettings.cs
@@ -36,16 +36,6 @@ namespace ICCardManager.Models
         public WindowSettings MainWindowSettings { get; set; } = new();
 
         /// <summary>
-        /// 職員証タッチをスキップするかどうか
-        /// </summary>
-        public bool SkipStaffTouch { get; set; } = false;
-
-        /// <summary>
-        /// デフォルト職員のIDm（スキップ時に使用）
-        /// </summary>
-        public string DefaultStaffIdm { get; set; }
-
-        /// <summary>
         /// 音声モード
         /// </summary>
         public SoundMode SoundMode { get; set; } = SoundMode.Beep;

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -118,21 +118,6 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private const int TimeoutSeconds = 60;
 
-    /// <summary>
-    /// 職員証タッチスキップモードが有効か
-    /// </summary>
-    private bool _skipStaffTouchEnabled;
-
-    /// <summary>
-    /// デフォルト職員IDm（スキップモード用）
-    /// </summary>
-    private string? _defaultStaffIdm;
-
-    /// <summary>
-    /// デフォルト職員名（スキップモード用）
-    /// </summary>
-    private string? _defaultStaffName;
-
     [ObservableProperty]
     private AppState _currentState = AppState.WaitingForStaffCard;
 
@@ -420,56 +405,12 @@ public partial class MainViewModel : ViewModelBase
             // カード残高ダッシュボードを取得
             await RefreshDashboardAsync();
 
-            // 職員証スキップ設定を読み込み
-            await LoadSkipStaffTouchSettingsAsync();
+            // 音声モード設定を適用
+            var settings = await _settingsRepository.GetAppSettingsAsync();
+            _soundPlayer.SoundMode = settings.SoundMode;
 
             // カード読み取り開始
             await _cardReader.StartReadingAsync();
-        }
-    }
-
-    /// <summary>
-    /// 職員証スキップ設定を読み込み
-    /// </summary>
-    private async Task LoadSkipStaffTouchSettingsAsync()
-    {
-        var settings = await _settingsRepository.GetAppSettingsAsync();
-        _skipStaffTouchEnabled = settings.SkipStaffTouch;
-        _defaultStaffIdm = settings.DefaultStaffIdm;
-
-        // 音声モードを適用
-        _soundPlayer.SoundMode = settings.SoundMode;
-
-        if (_skipStaffTouchEnabled && !string.IsNullOrEmpty(_defaultStaffIdm))
-        {
-            // デフォルト職員名を取得
-            var staff = await _staffRepository.GetByIdmAsync(_defaultStaffIdm);
-            _defaultStaffName = staff?.Name;
-
-            if (staff != null)
-            {
-                // スキップモードで初期化：ICカード待ち状態から開始
-                ApplySkipStaffTouchMode();
-            }
-            else
-            {
-                // デフォルト職員が見つからない場合は通常モード
-                _skipStaffTouchEnabled = false;
-                WarningMessages.Add("⚠️ 設定されたデフォルト職員が見つかりません。職員証スキップは無効です。");
-            }
-        }
-    }
-
-    /// <summary>
-    /// 職員証スキップモードを適用
-    /// </summary>
-    private void ApplySkipStaffTouchMode()
-    {
-        if (_skipStaffTouchEnabled && !string.IsNullOrEmpty(_defaultStaffIdm) && !string.IsNullOrEmpty(_defaultStaffName))
-        {
-            _currentStaffIdm = _defaultStaffIdm;
-            _currentStaffName = _defaultStaffName;
-            SetState(AppState.WaitingForIcCard, $"🚃 交通系ICカードをタッチしてください\n（操作者: {_defaultStaffName}）");
         }
     }
 
@@ -1276,19 +1217,9 @@ public partial class MainViewModel : ViewModelBase
     {
         StopTimeout();
 
-        // スキップモードの場合はICカード待ち状態に戻す
-        if (_skipStaffTouchEnabled && !string.IsNullOrEmpty(_defaultStaffIdm) && !string.IsNullOrEmpty(_defaultStaffName))
-        {
-            _currentStaffIdm = _defaultStaffIdm;
-            _currentStaffName = _defaultStaffName;
-            SetState(AppState.WaitingForIcCard, $"🚃 交通系ICカードをタッチしてください\n（操作者: {_defaultStaffName}）");
-        }
-        else
-        {
-            _currentStaffIdm = null;
-            _currentStaffName = null;
-            SetState(AppState.WaitingForStaffCard, "職員証をタッチしてください");
-        }
+        _currentStaffIdm = null;
+        _currentStaffName = null;
+        SetState(AppState.WaitingForStaffCard, "職員証をタッチしてください");
     }
 
     /// <summary>
@@ -1455,14 +1386,9 @@ public partial class MainViewModel : ViewModelBase
         dialog.Owner = System.Windows.Application.Current.MainWindow;
         dialog.ShowDialog();
 
-        // 設定変更後にスキップ設定を再読み込み
-        await LoadSkipStaffTouchSettingsAsync();
-
-        // スキップモードでない場合は通常状態にリセット
-        if (!_skipStaffTouchEnabled && CurrentState == AppState.WaitingForIcCard && _currentStaffIdm == _defaultStaffIdm)
-        {
-            ResetState();
-        }
+        // 設定変更後に音声モードを再適用
+        var settings = await _settingsRepository.GetAppSettingsAsync();
+        _soundPlayer.SoundMode = settings.SoundMode;
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -154,58 +154,6 @@
                     </StackPanel>
                 </GroupBox>
 
-                <!-- 操作設定 -->
-                <GroupBox Header="操作設定" Margin="0,0,0,20" Padding="15">
-                    <StackPanel>
-                        <CheckBox IsChecked="{Binding SkipStaffTouch}"
-                                  Content="職員証タッチをスキップする"
-                                  FontWeight="Bold"
-                                  AutomationProperties.Name="職員証タッチスキップ"
-                                  AutomationProperties.HelpText="有効にすると、交通系ICカードのみで貸出・返却ができます"
-                                  ToolTip="少人数環境向け：職員証をタッチせずに交通系ICカードのみで操作可能にします"/>
-
-                        <StackPanel Margin="0,15,0,0"
-                                    IsEnabled="{Binding SkipStaffTouch}">
-                            <TextBlock Text="デフォルト職員"
-                                       FontWeight="Bold"
-                                       Margin="0,0,0,10"/>
-                            <ComboBox ItemsSource="{Binding StaffList}"
-                                      SelectedItem="{Binding SelectedDefaultStaff}"
-                                      DisplayMemberPath="Name"
-                                      Padding="8"
-                                      Width="250"
-                                      HorizontalAlignment="Left"
-                                      AutomationProperties.Name="デフォルト職員選択"
-                                      AutomationProperties.HelpText="スキップ時に操作者として記録される職員を選択します"
-                                      ToolTip="操作者として記録される職員を選択"/>
-                            <TextBlock Text="※ スキップ時、この職員が操作者として記録されます"
-                                       FontSize="{DynamicResource SmallFontSize}"
-                                       Foreground="Gray"
-                                       Margin="0,5,0,0"/>
-                        </StackPanel>
-
-                        <!-- セキュリティ警告 -->
-                        <Border Background="#FFF3E0"
-                                BorderBrush="#FF9800"
-                                BorderThickness="1"
-                                CornerRadius="4"
-                                Padding="10"
-                                Margin="0,15,0,0"
-                                Visibility="{Binding SkipStaffTouch, Converter={StaticResource BoolToVisibilityConverter}}">
-                            <StackPanel>
-                                <TextBlock Text="⚠️ セキュリティに関する注意"
-                                           FontWeight="Bold"
-                                           Foreground="#E65100"/>
-                                <TextBlock Text="この機能を有効にすると、誰でも交通系ICカードをタッチするだけで貸出・返却が可能になります。限られた職員のみが使用する環境でのみご利用ください。"
-                                           TextWrapping="Wrap"
-                                           FontSize="{DynamicResource SmallFontSize}"
-                                           Foreground="#795548"
-                                           Margin="0,5,0,0"/>
-                            </StackPanel>
-                        </Border>
-                    </StackPanel>
-                </GroupBox>
-
             </StackPanel>
         </ScrollViewer>
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/SettingsViewModelTests.cs
@@ -21,7 +21,6 @@ namespace ICCardManager.Tests.ViewModels;
 public class SettingsViewModelTests
 {
     private readonly Mock<ISettingsRepository> _settingsRepositoryMock;
-    private readonly Mock<IStaffRepository> _staffRepositoryMock;
     private readonly Mock<IValidationService> _validationServiceMock;
     private readonly Mock<ISoundPlayer> _soundPlayerMock;
     private readonly SettingsViewModel _viewModel;
@@ -29,19 +28,14 @@ public class SettingsViewModelTests
     public SettingsViewModelTests()
     {
         _settingsRepositoryMock = new Mock<ISettingsRepository>();
-        _staffRepositoryMock = new Mock<IStaffRepository>();
         _validationServiceMock = new Mock<IValidationService>();
         _soundPlayerMock = new Mock<ISoundPlayer>();
 
         // バリデーションはデフォルトで成功を返す
         _validationServiceMock.Setup(v => v.ValidateWarningBalance(It.IsAny<int>())).Returns(ValidationResult.Success());
 
-        // 空の職員リストを返す
-        _staffRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Staff>());
-
         _viewModel = new SettingsViewModel(
             _settingsRepositoryMock.Object,
-            _staffRepositoryMock.Object,
             _validationServiceMock.Object,
             _soundPlayerMock.Object);
     }


### PR DESCRIPTION
## Summary

Issue #331 対応。職員証タッチをスキップする機能を完全に削除します。

この機能はセキュリティ上の懸念があり、実運用でも使用されていなかったため削除しました。

## 削除した機能

- 設定画面の「職員証タッチをスキップする」オプション
- デフォルト職員の選択機能
- スキップモード時のICカード待ち状態からの開始

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `AppSettings.cs` | `SkipStaffTouch`, `DefaultStaffIdm` プロパティ削除 |
| `SettingsRepository.cs` | 関連する設定の読み書き処理削除 |
| `SettingsViewModel.cs` | 関連するプロパティ・バリデーション削除、`IStaffRepository`依存削除 |
| `SettingsDialog.xaml` | 「操作設定」グループボックス全体を削除 |
| `MainViewModel.cs` | スキップモード関連ロジック削除 |
| `SettingsViewModelTests.cs` | `IStaffRepository`依存を削除 |

## 削除された設定項目

- `skip_staff_touch` - 職員証タッチスキップ有効/無効
- `default_staff_idm` - スキップ時のデフォルト職員IDm

## Test plan

- [x] アプリケーションが正常に起動することを確認
- [x] 設定画面が正常に開けることを確認
- [x] 設定画面に「操作設定」セクションがないことを確認
- [x] 通常の貸出・返却フロー（職員証タッチ→ICカードタッチ）が正常に動作することを確認

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)