### PR TITLE
fix: 削除済みカード・職員のCSVインポートを修正 (Issue #328)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ICardRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ICardRepository.cs
@@ -81,6 +81,13 @@ namespace ICCardManager.Data.Repositories
         Task<bool> RestoreAsync(string cardIdm);
 
         /// <summary>
+        /// 論理削除されたICカードを復元（トランザクション対応）
+        /// </summary>
+        /// <param name="cardIdm">ICカードIDm</param>
+        /// <param name="transaction">SQLiteトランザクション</param>
+        Task<bool> RestoreAsync(string cardIdm, SQLiteTransaction transaction);
+
+        /// <summary>
         /// IDmが存在するか確認
         /// </summary>
         Task<bool> ExistsAsync(string cardIdm);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/IStaffRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/IStaffRepository.cs
@@ -62,6 +62,13 @@ namespace ICCardManager.Data.Repositories
         Task<bool> RestoreAsync(string staffIdm);
 
         /// <summary>
+        /// 論理削除された職員を復元（トランザクション対応）
+        /// </summary>
+        /// <param name="staffIdm">職員証IDm</param>
+        /// <param name="transaction">SQLiteトランザクション</param>
+        Task<bool> RestoreAsync(string staffIdm, SQLiteTransaction transaction);
+
+        /// <summary>
         /// IDmが存在するか確認
         /// </summary>
         Task<bool> ExistsAsync(string staffIdm);


### PR DESCRIPTION
## Summary

- CSVインポート時に削除済みレコードが正しくインポートされない問題を修正
- 削除済みカード・職員を復元してから更新する処理を追加
- トランザクション対応の`RestoreAsync`メソッドを追加

## 問題の詳細

CSVインポート処理で`includeDeleted: true`を使用して既存レコードをチェックしていたため：

1. **`skipExisting=true`の場合**: 削除済みレコードが「既存」と判定されスキップされる → 再インポート不可
2. **`skipExisting=false`の場合**: 削除済みレコードを更新しようとするが、`UpdateAsync`の`WHERE is_deleted=0`条件で0件更新 → トランザクション全体がロールバック

## 修正内容

### CsvImportService
- 削除済みレコードを検出した場合、`isRestore=true`フラグを設定
- インポート実行時に`RestoreAsync`で復元後`UpdateAsync`で更新
- `ImportAction.Restore`アクションを追加し、プレビューで復元対象を表示

### ICardRepository / CardRepository
- `RestoreAsync(string cardIdm, SQLiteTransaction transaction)`オーバーロードを追加
- 内部実装を`RestoreAsyncInternal`にリファクタリング

### IStaffRepository / StaffRepository
- `RestoreAsync(string staffIdm, SQLiteTransaction transaction)`オーバーロードを追加
- 内部実装を`RestoreAsyncInternal`にリファクタリング

## Test plan

- [x] 削除済みカードを含むCSVをインポートし、正しく復元・更新されることを確認
- [x] 削除済み職員を含むCSVをインポートし、正しく復元・更新されることを確認
- [ ] `skipExisting=true`で有効なレコードがスキップされることを確認
- [ ] プレビューで「Restore」アクションが正しく表示されることを確認
- [ ] インポート途中でエラーが発生した場合、トランザクションがロールバックされることを確認

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)