### PR TITLE
feat: 履歴CSVインポート時に既存の履歴をスキップ (Issue #334)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -119,5 +119,17 @@ namespace ICCardManager.Data.Repositories
         /// <returns>既存の履歴詳細キーのセット</returns>
         Task<HashSet<(DateTime? UseDate, int? Balance, bool IsCharge)>> GetExistingDetailKeysAsync(
             string cardIdm, DateTime fromDate);
+
+        /// <summary>
+        /// 指定カードの既存の履歴キーを取得（CSVインポート重複チェック用）
+        /// </summary>
+        /// <remarks>
+        /// Issue #334対応: CSVインポート時に既存の履歴をスキップするための重複チェックに使用。
+        /// キーは card_idm + date + summary + income + expense + balance の組み合わせ。
+        /// </remarks>
+        /// <param name="cardIdms">チェック対象のカードIDmリスト</param>
+        /// <returns>既存の履歴キーのセット</returns>
+        Task<HashSet<(string CardIdm, DateTime Date, string Summary, int Income, int Expense, int Balance)>> GetExistingLedgerKeysAsync(
+            IEnumerable<string> cardIdms);
     }
 }


### PR DESCRIPTION
## Summary

- 履歴データをCSVからインポートする際、既に存在するレコードを自動的にスキップする機能を追加
- プレビュー画面で重複レコードに「Skip」アクションを表示
- 効率的な重複チェックのため、対象カードの既存履歴キーを一括取得

## 重複判定の基準

以下の組み合わせが完全一致する場合、同一レコードとみなしスキップ:

| フィールド | 説明 |
|-----------|------|
| card_idm | カードIDm |
| date | 日時（秒まで） |
| summary | 摘要 |
| income | 受入金額 |
| expense | 払出金額 |
| balance | 残額 |

この組み合わせは、ICカードの取引履歴において一意性を保証できます。
（同一日時・同一カードで、同じ摘要・金額・残高の取引が複数回発生することは事実上ありません）

## 変更内容

### ILedgerRepository / LedgerRepository
```csharp
Task<HashSet<(string CardIdm, DateTime Date, string Summary, int Income, int Expense, int Balance)>> 
    GetExistingLedgerKeysAsync(IEnumerable<string> cardIdms);
```
- 複数カードの既存履歴キーを一括取得するメソッドを追加
- IN句を使用して1回のクエリで取得（パフォーマンス最適化）

### CsvImportService
- **ImportLedgersAsync**: インポート前に重複チェックを行い、既存履歴はスキップ
- **PreviewLedgersAsync**: プレビュー画面で重複レコードに`Skip`アクションを表示

## Test plan

- [ ] 新規履歴データのCSVインポートが正常に動作することを確認
- [ ] 既存履歴と重複するデータがスキップされることを確認
- [ ] プレビュー画面で「Skip」が正しく表示されることを確認
- [ ] 一部重複・一部新規のCSVで、新規のみがインポートされることを確認
- [ ] エクスポート→インポートで0件インポート（全スキップ）になることを確認

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)