### PR TITLE
fix: 履歴の発着駅順序を修正 (Issue #336)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -98,6 +98,7 @@ namespace ICCardManager.Services
         /// }
         /// </code>
         /// </example>
+        /// <seealso cref="Generate"/>
         public List<DailySummary> GenerateByDate(IEnumerable<LedgerDetail> details)
         {
             var detailList = details.ToList();
@@ -208,11 +209,24 @@ namespace ICCardManager.Services
         /// <summary>
         /// 利用履歴詳細から摘要文字列を生成（従来メソッド・互換性のため維持）
         /// </summary>
-        /// <param name="details">利用履歴詳細のリスト</param>
+        /// <param name="details">利用履歴詳細のリスト（ICカードから取得した新しい順）</param>
         /// <returns>摘要文字列</returns>
+        /// <remarks>
+        /// <para>
+        /// ICカード履歴は新しい順で格納されているため、内部で古い順（時系列順）に
+        /// 変換してから処理します。これにより、往復検出時に出発点が正しく
+        /// 摘要の先頭に表示されます。
+        /// </para>
+        /// <para>
+        /// 例：薬院→博多→薬院の往復移動は「薬院～博多 往復」と表示されます。
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="GenerateByDate"/>
         public virtual string Generate(IEnumerable<LedgerDetail> details)
         {
-            var detailList = details.ToList();
+            // ICカード履歴は新しい順で格納されているため、
+            // 逆順にして古い順（時系列順）に変換する (Issue #336)
+            var detailList = details.Reverse().ToList();
 
             if (detailList.Count == 0)
             {
@@ -306,6 +320,20 @@ namespace ICCardManager.Services
         /// <summary>
         /// 往復を検出
         /// </summary>
+        /// <param name="routes">経路リスト（時系列順：古い順であること）</param>
+        /// <returns>往復経路のリスト。Startは出発点（往路の乗車駅）、Endは折り返し点（往路の降車駅）</returns>
+        /// <remarks>
+        /// <para>
+        /// 入力リストは必ず時系列順（古い順）であること。
+        /// 往復検出時は最初にマッチした経路（routes[i]）の方向を採用するため、
+        /// 順序が逆だと「帰りの経路」が先に来てしまい、摘要の駅順が逆転する。
+        /// </para>
+        /// <para>
+        /// 例：薬院→博多→薬院の移動
+        /// - 正しい順序: [(薬院,博多), (博多,薬院)] → "薬院～博多 往復"
+        /// - 逆順の場合: [(博多,薬院), (薬院,博多)] → "博多～薬院 往復" (不正)
+        /// </para>
+        /// </remarks>
         private List<(string Start, string End)> DetectRoundTrips(List<(string Entry, string Exit)> routes)
         {
             var roundTrips = new List<(string Start, string End)>();

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
@@ -914,13 +914,16 @@ public class SummaryGeneratorComprehensiveTests
     [Fact]
     public void TC032_Generate_鉄道往復()
     {
+        // ICカード履歴は新しい順：[0]帰り(新しい)、[1]行き(古い)
+        // 往復表示は古い方（行き）を基準にする（TC008と同じ結果になる）
         var details = new List<LedgerDetail>
         {
             CreateRailwayUsage(new DateTime(2024, 12, 9), "博多", "天神", 210, 4580),
             CreateRailwayUsage(new DateTime(2024, 12, 9), "天神", "博多", 210, 4790)
         };
         var result = _generator.Generate(details);
-        result.Should().Be("鉄道（博多～天神 往復）");
+        // Issue #336修正: 行き（天神→博多）を基準に表示する
+        result.Should().Be("鉄道（天神～博多 往復）");
         _output.WriteLine($"Generate() = \"{result}\"");
     }
 


### PR DESCRIPTION
## Summary

- ICカード履歴は新しい順で格納されているため、`Generate` メソッドで往復検出時に「帰りの経路」が先に処理されてしまい、摘要の駅順が逆転していた問題を修正
- `Generate` メソッドで入力リストを逆順にして時系列順に変換するように修正
- `DetectRoundTrips` メソッドのドキュメントを拡充し、入力データの順序要件を明確化

## Problem

Issue #336 で報告された問題：

> 薬院から博多へ行って帰りましたが、博多～薬院 往復と出ます。
> 薬院→博多と出て欲しいのです。

### 原因分析

ICカード履歴は「新しい順」で格納されています：
- [0] 博多→薬院（帰り、新しい）
- [1] 薬院→博多（行き、古い）

`Generate` メソッドは入力をそのまま処理していたため、往復検出時に：
1. routes[0] = (博多, 薬院) ← 帰り
2. routes[1] = (薬院, 博多) ← 行き

となり、`routes[0]` の方向（博多→薬院）が使われてしまっていました。

### 修正内容

`Generate` メソッドで入力リストを `Reverse()` して時系列順（古い順）に変換：

```csharp
// ICカード履歴は新しい順で格納されているため、
// 逆順にして古い順（時系列順）に変換する (Issue #336)
var detailList = details.Reverse().ToList();
```

これにより `GenerateByDate` メソッドと同じ動作になります。

## Test plan

- [x] 既存のテストを実際のICカード履歴順序（新しい順）に合わせて更新
- [ ] `SummaryGeneratorTests` の往復・乗継・複数区間テストが修正後の期待値で成功することを確認
- [ ] `SummaryGeneratorComprehensiveTests` の全テストが成功することを確認
- [ ] 実機での往復移動テスト（薬院→博多→薬院）

## Files changed

| File | Change |
|------|--------|
| `SummaryGenerator.cs` | `Generate` メソッドで入力を逆順に変換、ドキュメント拡充 |
| `SummaryGeneratorTests.cs` | テストデータを新しい順に更新 |
| `SummaryGeneratorComprehensiveTests.cs` | TC032の期待値を修正後の正しい値に更新 |

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)