### PR TITLE
feat: デバッグ用データビューアにビット単位フィールド解析表示を追加

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj
+++ b/ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ICCardManager\ICCardManager.csproj" />
+    <ProjectReference Include="..\..\tools\DebugDataViewer\DebugDataViewer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ICCardManager/tests/ICCardManager.Tests/Tools/FelicaBlockParserTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Tools/FelicaBlockParserTests.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Linq;
+using DebugDataViewer;
+using FluentAssertions;
+using Xunit;
+
+namespace ICCardManager.Tests.Tools
+{
+    /// <summary>
+    /// FelicaBlockParser のユニットテスト
+    /// FeliCa履歴ブロック（16バイト）のビット単位フィールド解析を検証する
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class FelicaBlockParserTests
+    {
+        /// <summary>
+        /// テスト用の16バイトデータを生成するヘルパー
+        /// </summary>
+        private static byte[] CreateTestBlock(
+            byte machineType = 0x16,
+            byte usageType = 0x01,
+            byte paymentType = 0x00,
+            byte entryExitType = 0x00,
+            byte dateHigh = 0x32, byte dateLow = 0x2F,
+            byte entryHigh = 0x01, byte entryLow = 0x3A,
+            byte exitHigh = 0x01, byte exitLow = 0x45,
+            byte balanceLow = 0xE8, byte balanceHigh = 0x03,
+            byte reserved0 = 0x00, byte reserved1 = 0x00,
+            byte reserved2 = 0x00, byte reserved3 = 0x00)
+        {
+            return new byte[]
+            {
+                machineType, usageType, paymentType, entryExitType,
+                dateHigh, dateLow,
+                entryHigh, entryLow,
+                exitHigh, exitLow,
+                balanceLow, balanceHigh,
+                reserved0, reserved1, reserved2, reserved3
+            };
+        }
+
+        #region Parse - 基本テスト
+
+        [Fact]
+        public void Parse_ValidBlock_Returns9Fields()
+        {
+            // Arrange
+            var block = CreateTestBlock();
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+
+            // Assert
+            result.Should().HaveCount(9);
+        }
+
+        [Fact]
+        public void Parse_ValidBlock_FieldNamesAreCorrect()
+        {
+            // Arrange
+            var block = CreateTestBlock();
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+
+            // Assert
+            var fieldNames = result.Select(f => f.FieldName).ToList();
+            fieldNames.Should().ContainInOrder(
+                "機器種別", "利用種別", "支払種別", "入出場種別",
+                "日付", "入場駅コード", "出場駅コード", "残額", "予備");
+        }
+
+        [Fact]
+        public void Parse_NullInput_ReturnsEmptyList()
+        {
+            // Act
+            var result = FelicaBlockParser.Parse(null);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Parse_TooShortInput_ReturnsEmptyList()
+        {
+            // Arrange - 8バイトしかない
+            var shortBlock = new byte[] { 0x16, 0x01, 0x00, 0x00, 0x32, 0x2F, 0x01, 0x3A };
+
+            // Act
+            var result = FelicaBlockParser.Parse(shortBlock);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Parse_EmptyInput_ReturnsEmptyList()
+        {
+            // Act
+            var result = FelicaBlockParser.Parse(new byte[0]);
+
+            // Assert
+            result.Should().BeEmpty();
+        }
+
+        #endregion
+
+        #region Parse - 日付フィールド解析
+
+        [Theory]
+        [InlineData(0x32, 0x2F, "2025/01/15")]  // year=25, month=1, day=15
+        [InlineData(0x33, 0x01, "2025/08/01")]   // year=25, month=8, day=1
+        [InlineData(0x00, 0x21, "2000/01/01")]   // year=0, month=1, day=1
+        [InlineData(0xFF, 0x9F, "2127/12/31")]   // year=127, month=12, day=31 (最大値)
+        public void Parse_DateField_DecodesCorrectly(byte dateHigh, byte dateLow, string expectedDate)
+        {
+            // Arrange
+            var block = CreateTestBlock(dateHigh: dateHigh, dateLow: dateLow);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var dateField = result.First(f => f.FieldName == "日付");
+
+            // Assert
+            dateField.DecodedValue.Should().Be(expectedDate);
+        }
+
+        [Fact]
+        public void Parse_DateField_BinaryShowsBitGrouping()
+        {
+            // Arrange: 2025/01/15 → year=25(0011001), month=1(0001), day=15(01111)
+            var block = CreateTestBlock(dateHigh: 0x32, dateLow: 0x2F);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var dateField = result.First(f => f.FieldName == "日付");
+
+            // Assert - ビットグループが角括弧で表示されること
+            dateField.BinaryValue.Should().Contain("[");
+            dateField.BinaryValue.Should().Contain("]");
+            // [YYYYYYY][MMMM][DDDDD] 形式
+            dateField.BinaryValue.Should().Be("[0011001][0001][01111]");
+        }
+
+        [Fact]
+        public void Parse_DateField_DetailShowsComponents()
+        {
+            // Arrange: 2025/01/15
+            var block = CreateTestBlock(dateHigh: 0x32, dateLow: 0x2F);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var dateField = result.First(f => f.FieldName == "日付");
+
+            // Assert - 詳細にビット位置と値が含まれること
+            dateField.Detail.Should().Contain("年(bit15-9)=25");
+            dateField.Detail.Should().Contain("月(bit8-5)=1");
+            dateField.Detail.Should().Contain("日(bit4-0)=15");
+        }
+
+        [Fact]
+        public void Parse_DateField_InvalidDate_ShowsInvalidLabel()
+        {
+            // Arrange: month=0, day=0（無効な日付）
+            var block = CreateTestBlock(dateHigh: 0x32, dateLow: 0x00);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var dateField = result.First(f => f.FieldName == "日付");
+
+            // Assert
+            dateField.DecodedValue.Should().Contain("無効");
+        }
+
+        #endregion
+
+        #region Parse - 利用種別
+
+        [Fact]
+        public void Parse_ChargeUsageType_ShowsChargeLabel()
+        {
+            // Arrange: 利用種別 = 0x02（チャージ）
+            var block = CreateTestBlock(usageType: 0x02);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var usageField = result.First(f => f.FieldName == "利用種別");
+
+            // Assert
+            usageField.DecodedValue.Should().Contain("チャージ");
+        }
+
+        [Fact]
+        public void Parse_MerchandiseUsageType_ShowsMerchandiseLabel()
+        {
+            // Arrange: 利用種別 = 0x07（物販）
+            var block = CreateTestBlock(usageType: 0x07);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var usageField = result.First(f => f.FieldName == "利用種別");
+
+            // Assert
+            usageField.DecodedValue.Should().Contain("物販");
+        }
+
+        [Fact]
+        public void Parse_TransitUsageType_ShowsTransitLabel()
+        {
+            // Arrange: 利用種別 = 0x01（乗車）
+            var block = CreateTestBlock(usageType: 0x01);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var usageField = result.First(f => f.FieldName == "利用種別");
+
+            // Assert
+            usageField.DecodedValue.Should().Contain("乗車");
+        }
+
+        #endregion
+
+        #region Parse - 残額フィールド（リトルエンディアン）
+
+        [Theory]
+        [InlineData(0xE8, 0x03, 1000)]   // LE: 0x03E8 = 1000
+        [InlineData(0x00, 0x00, 0)]       // 0円
+        [InlineData(0xFF, 0xFF, 65535)]   // 最大値
+        [InlineData(0x50, 0x01, 336)]     // LE: 0x0150 = 336
+        public void Parse_BalanceField_LittleEndianDecodeCorrectly(byte low, byte high, int expectedBalance)
+        {
+            // Arrange
+            var block = CreateTestBlock(balanceLow: low, balanceHigh: high);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var balanceField = result.First(f => f.FieldName == "残額");
+
+            // Assert - 円記号と金額が含まれること
+            balanceField.DecodedValue.Should().Contain($"{expectedBalance:N0}");
+            balanceField.Detail.Should().Contain("LE");
+        }
+
+        #endregion
+
+        #region Parse - 駅コードフィールド（ビッグエンディアン）
+
+        [Theory]
+        [InlineData(0x01, 0x3A, "0x013A", 314)]
+        [InlineData(0x01, 0x45, "0x0145", 325)]
+        [InlineData(0x00, 0x00, null, 0)]  // コード0はなし
+        public void Parse_StationCode_BigEndianDecodeCorrectly(byte high, byte low, string expectedHex, int expectedDecimal)
+        {
+            // Arrange
+            var block = CreateTestBlock(entryHigh: high, entryLow: low);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var entryField = result.First(f => f.FieldName == "入場駅コード");
+
+            // Assert
+            if (expectedHex != null)
+            {
+                entryField.DecodedValue.Should().Contain(expectedHex);
+                entryField.DecodedValue.Should().Contain($"({expectedDecimal})");
+            }
+            else
+            {
+                entryField.DecodedValue.Should().Contain("なし");
+            }
+        }
+
+        #endregion
+
+        #region Parse - Hexフィールド表示
+
+        [Fact]
+        public void Parse_MachineType_HexValueIsCorrect()
+        {
+            // Arrange
+            var block = CreateTestBlock(machineType: 0xAB);
+
+            // Act
+            var result = FelicaBlockParser.Parse(block);
+            var machineField = result.First(f => f.FieldName == "機器種別");
+
+            // Assert
+            machineField.HexValue.Should().Be("AB");
+        }
+
+        #endregion
+
+        #region FormatBinary
+
+        [Theory]
+        [InlineData(0x00, "00000000")]
+        [InlineData(0xFF, "11111111")]
+        [InlineData(0xA5, "10100101")]
+        [InlineData(0x01, "00000001")]
+        [InlineData(0x80, "10000000")]
+        public void FormatBinary_ReturnsCorrect8BitString(byte input, string expected)
+        {
+            // Act
+            var result = FelicaBlockParser.FormatBinary(input);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        #endregion
+
+        #region FormatAsText
+
+        [Fact]
+        public void FormatAsText_ValidFields_ContainsHeader()
+        {
+            // Arrange
+            var block = CreateTestBlock();
+            var fields = FelicaBlockParser.Parse(block);
+
+            // Act
+            var text = FelicaBlockParser.FormatAsText(fields);
+
+            // Assert
+            text.Should().Contain("ビット単位フィールド解析");
+        }
+
+        [Fact]
+        public void FormatAsText_ValidFields_ContainsAllFieldNames()
+        {
+            // Arrange
+            var block = CreateTestBlock();
+            var fields = FelicaBlockParser.Parse(block);
+
+            // Act
+            var text = FelicaBlockParser.FormatAsText(fields);
+
+            // Assert
+            text.Should().Contain("機器種別");
+            text.Should().Contain("利用種別");
+            text.Should().Contain("支払種別");
+            text.Should().Contain("入出場種別");
+            text.Should().Contain("日付");
+            text.Should().Contain("入場駅コード");
+            text.Should().Contain("出場駅コード");
+            text.Should().Contain("残額");
+            text.Should().Contain("予備");
+        }
+
+        [Fact]
+        public void FormatAsText_NullFields_ReturnsNoDataMessage()
+        {
+            // Act
+            var text = FelicaBlockParser.FormatAsText(null);
+
+            // Assert
+            text.Should().Contain("解析データなし");
+        }
+
+        [Fact]
+        public void FormatAsText_EmptyFields_ReturnsNoDataMessage()
+        {
+            // Act
+            var text = FelicaBlockParser.FormatAsText(new System.Collections.Generic.List<FelicaFieldInfo>());
+
+            // Assert
+            text.Should().Contain("解析データなし");
+        }
+
+        #endregion
+
+        #region ParseDateField - 内部メソッド直接テスト
+
+        [Fact]
+        public void ParseDateField_HexValueIsCorrect()
+        {
+            // Arrange & Act
+            var field = FelicaBlockParser.ParseDateField(0x32, 0x2F);
+
+            // Assert
+            field.HexValue.Should().Be("32 2F");
+        }
+
+        [Fact]
+        public void ParseDateField_OffsetLabelIsCorrect()
+        {
+            // Act
+            var field = FelicaBlockParser.ParseDateField(0x32, 0x2F);
+
+            // Assert
+            field.OffsetLabel.Should().Be("[04-05]");
+        }
+
+        #endregion
+
+        #region ParseBalanceField - 内部メソッド直接テスト
+
+        [Fact]
+        public void ParseBalanceField_HexValueShowsOriginalByteOrder()
+        {
+            // Arrange & Act: LE format - low byte first in memory
+            var field = FelicaBlockParser.ParseBalanceField(0xE8, 0x03);
+
+            // Assert - Hex表示はメモリ上のバイト順序で表示
+            field.HexValue.Should().Be("E8 03");
+        }
+
+        [Fact]
+        public void ParseBalanceField_DetailShowsLEHexValue()
+        {
+            // Act
+            var field = FelicaBlockParser.ParseBalanceField(0xE8, 0x03);
+
+            // Assert
+            field.Detail.Should().Contain("LE");
+            field.Detail.Should().Contain("0x03E8");
+        }
+
+        #endregion
+    }
+}

--- a/ICCardManager/tools/DebugDataViewer/FelicaBlockParser.cs
+++ b/ICCardManager/tools/DebugDataViewer/FelicaBlockParser.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DebugDataViewer
+{
+    /// <summary>
+    /// FeliCa履歴ブロック（16バイト）の各フィールド解析結果
+    /// </summary>
+    public class FelicaFieldInfo
+    {
+        /// <summary>バイト位置の表示文字列（例: "[04-05]"）</summary>
+        public string OffsetLabel { get; set; }
+
+        /// <summary>フィールド名（日本語）</summary>
+        public string FieldName { get; set; }
+
+        /// <summary>16進数表現（例: "4A 2B"）</summary>
+        public string HexValue { get; set; }
+
+        /// <summary>2進数表現（例: "01001010 00101011"、日付フィールドはビットグループ表示）</summary>
+        public string BinaryValue { get; set; }
+
+        /// <summary>デコード結果（例: "2025/01/15"）</summary>
+        public string DecodedValue { get; set; }
+
+        /// <summary>補足説明（例: "年=25, 月=1, 日=15"）</summary>
+        public string Detail { get; set; }
+    }
+
+    /// <summary>
+    /// FeliCa履歴ブロック（16バイト）をフィールド単位にパースし、
+    /// ビット単位の表示データを生成するユーティリティ
+    /// </summary>
+    public static class FelicaBlockParser
+    {
+        /// <summary>
+        /// 16バイトの生データをフィールドごとに分解する
+        /// </summary>
+        /// <param name="rawBytes">FeliCa履歴ブロック（16バイト）</param>
+        /// <returns>フィールド解析結果のリスト（9項目）</returns>
+        public static List<FelicaFieldInfo> Parse(byte[] rawBytes)
+        {
+            if (rawBytes == null || rawBytes.Length < 16)
+            {
+                return new List<FelicaFieldInfo>();
+            }
+
+            var fields = new List<FelicaFieldInfo>();
+
+            // [00] 機器種別
+            fields.Add(new FelicaFieldInfo
+            {
+                OffsetLabel = "[00]",
+                FieldName = "機器種別",
+                HexValue = $"{rawBytes[0]:X2}",
+                BinaryValue = FormatBinary(rawBytes[0]),
+                DecodedValue = $"0x{rawBytes[0]:X2}",
+                Detail = ""
+            });
+
+            // [01] 利用種別
+            fields.Add(new FelicaFieldInfo
+            {
+                OffsetLabel = "[01]",
+                FieldName = "利用種別",
+                HexValue = $"{rawBytes[1]:X2}",
+                BinaryValue = FormatBinary(rawBytes[1]),
+                DecodedValue = DecodeUsageType(rawBytes[1]),
+                Detail = ""
+            });
+
+            // [02] 支払種別
+            fields.Add(new FelicaFieldInfo
+            {
+                OffsetLabel = "[02]",
+                FieldName = "支払種別",
+                HexValue = $"{rawBytes[2]:X2}",
+                BinaryValue = FormatBinary(rawBytes[2]),
+                DecodedValue = $"0x{rawBytes[2]:X2}",
+                Detail = ""
+            });
+
+            // [03] 入出場種別
+            fields.Add(new FelicaFieldInfo
+            {
+                OffsetLabel = "[03]",
+                FieldName = "入出場種別",
+                HexValue = $"{rawBytes[3]:X2}",
+                BinaryValue = FormatBinary(rawBytes[3]),
+                DecodedValue = $"0x{rawBytes[3]:X2}",
+                Detail = ""
+            });
+
+            // [04-05] 日付（ビットフィールド）
+            fields.Add(ParseDateField(rawBytes[4], rawBytes[5]));
+
+            // [06-07] 入場駅コード（ビッグエンディアン）
+            fields.Add(ParseStationCodeField("[06-07]", "入場駅コード", rawBytes[6], rawBytes[7]));
+
+            // [08-09] 出場駅コード（ビッグエンディアン）
+            fields.Add(ParseStationCodeField("[08-09]", "出場駅コード", rawBytes[8], rawBytes[9]));
+
+            // [0A-0B] 残額（リトルエンディアン）
+            fields.Add(ParseBalanceField(rawBytes[10], rawBytes[11]));
+
+            // [0C-0F] 予備
+            fields.Add(new FelicaFieldInfo
+            {
+                OffsetLabel = "[0C-0F]",
+                FieldName = "予備",
+                HexValue = $"{rawBytes[12]:X2} {rawBytes[13]:X2} {rawBytes[14]:X2} {rawBytes[15]:X2}",
+                BinaryValue = $"{FormatBinary(rawBytes[12])} {FormatBinary(rawBytes[13])} {FormatBinary(rawBytes[14])} {FormatBinary(rawBytes[15])}",
+                DecodedValue = "--",
+                Detail = ""
+            });
+
+            return fields;
+        }
+
+        /// <summary>
+        /// フィールド情報を整形されたテキストに変換する
+        /// </summary>
+        public static string FormatAsText(List<FelicaFieldInfo> fields)
+        {
+            if (fields == null || fields.Count == 0)
+            {
+                return "(解析データなし)";
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("=== ビット単位フィールド解析 ===");
+            sb.AppendLine();
+
+            // ヘッダー
+            sb.AppendLine(
+                $"{"Offset",-8}" +
+                $"{"フィールド",-14}" +
+                $"{"Hex",-14}" +
+                $"{"Binary",-40}" +
+                $"{"デコード値",-20}" +
+                "詳細");
+
+            sb.AppendLine(
+                $"{"------",-8}" +
+                $"{"----------",-14}" +
+                $"{"---",-14}" +
+                $"{"------",-40}" +
+                $"{"----------",-20}" +
+                "----");
+
+            foreach (var field in fields)
+            {
+                var line =
+                    $"{field.OffsetLabel,-8}" +
+                    $"{field.FieldName,-14}" +
+                    $"{field.HexValue,-14}" +
+                    $"{field.BinaryValue,-40}" +
+                    $"{field.DecodedValue,-20}" +
+                    field.Detail;
+
+                sb.AppendLine(line);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// バイト値を8桁の2進数文字列に変換する
+        /// </summary>
+        public static string FormatBinary(byte value)
+        {
+            return Convert.ToString(value, 2).PadLeft(8, '0');
+        }
+
+        /// <summary>
+        /// 利用種別をデコードする
+        /// </summary>
+        private static string DecodeUsageType(byte usageType)
+        {
+            switch (usageType)
+            {
+                case 0x02: return "チャージ (0x02)";
+                case 0x07: return "物販 (0x07)";
+                default: return $"乗車 (0x{usageType:X2})";
+            }
+        }
+
+        /// <summary>
+        /// 日付フィールド（バイト4-5）をビットフィールドとして解析する
+        /// </summary>
+        public static FelicaFieldInfo ParseDateField(byte high, byte low)
+        {
+            var dateValue = (high << 8) | low;
+            var yearOffset = (dateValue >> 9) & 0x7F;
+            var month = (dateValue >> 5) & 0x0F;
+            var day = dateValue & 0x1F;
+            var year = 2000 + yearOffset;
+
+            // ビットグループ表示: [YYYYYYY][MMMM][DDDDD]
+            var bits16 = Convert.ToString(dateValue, 2).PadLeft(16, '0');
+            var yearBits = bits16.Substring(0, 7);
+            var monthBits = bits16.Substring(7, 4);
+            var dayBits = bits16.Substring(11, 5);
+            var groupedBinary = $"[{yearBits}][{monthBits}][{dayBits}]";
+
+            // デコード値
+            string decodedValue;
+            if (month >= 1 && month <= 12 && day >= 1 && day <= 31)
+            {
+                decodedValue = $"{year}/{month:D2}/{day:D2}";
+            }
+            else
+            {
+                decodedValue = "(無効な日付)";
+            }
+
+            return new FelicaFieldInfo
+            {
+                OffsetLabel = "[04-05]",
+                FieldName = "日付",
+                HexValue = $"{high:X2} {low:X2}",
+                BinaryValue = groupedBinary,
+                DecodedValue = decodedValue,
+                Detail = $"年(bit15-9)={yearOffset}(+2000), 月(bit8-5)={month}, 日(bit4-0)={day}"
+            };
+        }
+
+        /// <summary>
+        /// 駅コードフィールド（ビッグエンディアン16bit）を解析する
+        /// </summary>
+        private static FelicaFieldInfo ParseStationCodeField(string offsetLabel, string fieldName, byte high, byte low)
+        {
+            var code = (high << 8) | low;
+
+            return new FelicaFieldInfo
+            {
+                OffsetLabel = offsetLabel,
+                FieldName = fieldName,
+                HexValue = $"{high:X2} {low:X2}",
+                BinaryValue = $"{FormatBinary(high)} {FormatBinary(low)}",
+                DecodedValue = code > 0 ? $"0x{code:X4} ({code})" : "なし (0)",
+                Detail = "BE"
+            };
+        }
+
+        /// <summary>
+        /// 残額フィールド（リトルエンディアン16bit）を解析する
+        /// </summary>
+        public static FelicaFieldInfo ParseBalanceField(byte low, byte high)
+        {
+            var balance = low + (high << 8);
+
+            return new FelicaFieldInfo
+            {
+                OffsetLabel = "[0A-0B]",
+                FieldName = "残額",
+                HexValue = $"{low:X2} {high:X2}",
+                BinaryValue = $"{FormatBinary(low)} {FormatBinary(high)}",
+                DecodedValue = $"\u00a5{balance:N0}",
+                Detail = $"LE (0x{balance:X4})"
+            };
+        }
+    }
+}

--- a/ICCardManager/tools/DebugDataViewer/MainWindow.xaml
+++ b/ICCardManager/tools/DebugDataViewer/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
         Title="ICカード管理システム - デバッグ用データビューア"
-        Height="750"
+        Height="850"
         Width="1000"
         WindowStartupLocation="CenterScreen"
         ResizeMode="CanResize">
@@ -108,34 +108,66 @@
                                  HorizontalScrollBarVisibility="Auto"/>
                     </GroupBox>
 
-                    <!-- 履歴データ（成形済み） -->
+                    <!-- 履歴データ（成形済み）+ ビット解析 -->
                     <GroupBox Grid.Row="3" Header="履歴データ（成形済み）" Padding="10">
-                        <DataGrid ItemsSource="{Binding CardHistoryItems}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserAddRows="False"
-                                  CanUserDeleteRows="False"
-                                  GridLinesVisibility="Horizontal"
-                                  HeadersVisibility="Column"
-                                  VerticalScrollBarVisibility="Auto">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="30"/>
-                                <DataGridTextColumn Header="利用日時" Binding="{Binding UseDate, StringFormat=yyyy/MM/dd HH:mm}" Width="120"/>
-                                <DataGridTextColumn Header="乗車駅" Binding="{Binding EntryStation}" Width="100"/>
-                                <DataGridTextColumn Header="降車駅" Binding="{Binding ExitStation}" Width="100"/>
-                                <DataGridTextColumn Header="金額" Binding="{Binding Amount, StringFormat=¥{0:N0}}" Width="70"/>
-                                <DataGridTextColumn Header="残高" Binding="{Binding Balance, StringFormat=¥{0:N0}}" Width="70"/>
-                                <DataGridTextColumn Header="種別" Binding="{Binding TransactionType}" Width="60"/>
-                                <DataGridTextColumn Header="生データ" Binding="{Binding RawData}" Width="*">
-                                    <DataGridTextColumn.ElementStyle>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="FontFamily" Value="Consolas, Courier New, monospace"/>
-                                            <Setter Property="FontSize" Value="10"/>
-                                        </Style>
-                                    </DataGridTextColumn.ElementStyle>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="2*"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- 履歴データグリッド -->
+                            <DataGrid Grid.Row="0"
+                                      ItemsSource="{Binding CardHistoryItems}"
+                                      SelectedItem="{Binding SelectedCardHistoryItem, Mode=TwoWay}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserAddRows="False"
+                                      CanUserDeleteRows="False"
+                                      GridLinesVisibility="Horizontal"
+                                      HeadersVisibility="Column"
+                                      VerticalScrollBarVisibility="Auto">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="30"/>
+                                    <DataGridTextColumn Header="利用日時" Binding="{Binding UseDate, StringFormat=yyyy/MM/dd HH:mm}" Width="120"/>
+                                    <DataGridTextColumn Header="乗車駅" Binding="{Binding EntryStation}" Width="100"/>
+                                    <DataGridTextColumn Header="降車駅" Binding="{Binding ExitStation}" Width="100"/>
+                                    <DataGridTextColumn Header="金額" Binding="{Binding Amount, StringFormat=¥{0:N0}}" Width="70"/>
+                                    <DataGridTextColumn Header="残高" Binding="{Binding Balance, StringFormat=¥{0:N0}}" Width="70"/>
+                                    <DataGridTextColumn Header="種別" Binding="{Binding TransactionType}" Width="60"/>
+                                    <DataGridTextColumn Header="生データ" Binding="{Binding RawData}" Width="*">
+                                        <DataGridTextColumn.ElementStyle>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="FontFamily" Value="Consolas, Courier New, monospace"/>
+                                                <Setter Property="FontSize" Value="10"/>
+                                            </Style>
+                                        </DataGridTextColumn.ElementStyle>
+                                    </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+
+                            <!-- リサイズ用スプリッター -->
+                            <GridSplitter Grid.Row="1"
+                                          Height="5"
+                                          HorizontalAlignment="Stretch"
+                                          VerticalAlignment="Center"
+                                          Background="#CCCCCC"/>
+
+                            <!-- ビット単位フィールド解析パネル -->
+                            <GroupBox Grid.Row="2"
+                                      Header="ビット単位フィールド解析（選択行）"
+                                      Padding="5"
+                                      Margin="0,5,0,0">
+                                <TextBox Text="{Binding SelectedItemBitDetail, Mode=OneWay}"
+                                         Style="{StaticResource MonospaceTextBoxStyle}"
+                                         FontSize="11"
+                                         TextWrapping="NoWrap"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto"
+                                         VerticalAlignment="Stretch"/>
+                            </GroupBox>
+                        </Grid>
                     </GroupBox>
                 </Grid>
             </TabItem>


### PR DESCRIPTION
## Summary
- FeliCa履歴ブロック（16バイト）の各フィールドをビット単位に分解して表示する `FelicaBlockParser` クラスを新規作成
- DebugDataViewerの履歴DataGridで行を選択すると、下部パネルにビット単位フィールド解析（日付ビットフィールド分解、駅コードBE/残額LE変換等）が表示される
- `FelicaBlockParser` のユニットテスト36件を追加（全件パス）

## 変更内容
| ファイル | 操作 | 内容 |
|---------|------|------|
| `tools/DebugDataViewer/FelicaBlockParser.cs` | 新規 | ビット単位解析ロジック（`FelicaFieldInfo` + `FelicaBlockParser`） |
| `tools/DebugDataViewer/MainViewModel.cs` | 修正 | 選択行バインド・ビット解析パネル連携 |
| `tools/DebugDataViewer/MainWindow.xaml` | 修正 | DataGrid下部にビット解析パネル追加（GridSplitter付き） |
| `tests/.../Tools/FelicaBlockParserTests.cs` | 新規 | テスト36件 |
| `tests/.../ICCardManager.Tests.csproj` | 修正 | DebugDataViewerプロジェクト参照追加 |

## 解析表示例
```
=== ビット単位フィールド解析 ===

Offset  フィールド      Hex            Binary                                  デコード値
[00]    機器種別        16             00010110                                0x16
[01]    利用種別        01             00000001                                乗車 (0x01)
[04-05] 日付            32 2F          [0011001][0001][01111]                   2025/01/15    年(bit15-9)=25(+2000), 月(bit8-5)=1, 日(bit4-0)=15
[0A-0B] 残額            E8 03          11101000 00000011                       ¥1,000        LE (0x03E8)
```

Closes #345

## Test plan
- [x] `dotnet build` でソリューション全体のビルド成功
- [x] `dotnet test --filter FelicaBlockParser` で新規テスト36件パス
- [x] `dotnet test` で既存テスト含む全テスト確認（既存のCSV関連テスト2件の失敗は今回の変更とは無関係）
- [x] DebugDataViewerを起動し、カードを読み取って履歴行を選択→ビット解析パネルに解析結果が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)