### PR TITLE
fix: インストーラーとログパスの問題を修正

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -50,14 +50,17 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-; メインアプリケーション
-Source: "..\publish\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+; メインアプリケーションと依存DLL（すべてのDLL/EXE/config/pdbを含める）
+Source: "..\publish\*.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\publish\*.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\publish\*.config"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+Source: "..\publish\*.json"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
+
+; x86ネイティブDLL（SQLite Interop等）
+Source: "..\publish\x86\*"; DestDir: "{app}\x86"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
 
 ; アイコンファイル（「設定」→「アプリ」で表示されるアイコン）
 Source: "app.ico"; DestDir: "{app}"; Flags: ignoreversion
-
-; 設定ファイル
-Source: "..\publish\appsettings.json"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
 ; サウンドファイル
 Source: "..\publish\Resources\Sounds\*"; DestDir: "{app}\Resources\Sounds"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/ICCardManager/installer/build-installer.ps1
+++ b/ICCardManager/installer/build-installer.ps1
@@ -120,6 +120,15 @@ if (Test-Path $TemplatesSource) {
     Write-Host "  テンプレートファイル: $TemplateCount 個コピー" -ForegroundColor Green
 }
 
+# SQLite.Interop.dll のコピー（x86ネイティブDLL）
+$SqliteInteropSource = Join-Path $SrcDir "bin\Release\net48\x86"
+$SqliteInteropDest = Join-Path $PublishDir "x86"
+if (Test-Path $SqliteInteropSource) {
+    if (-not (Test-Path $SqliteInteropDest)) { New-Item -ItemType Directory -Path $SqliteInteropDest -Force | Out-Null }
+    Copy-Item -Path "$SqliteInteropSource\*" -Destination $SqliteInteropDest -Force -ErrorAction SilentlyContinue
+    Write-Host "  SQLite.Interop.dll: x86 フォルダにコピー" -ForegroundColor Green
+}
+
 # Step 5: 発行ファイルの確認
 Write-Host ""
 Write-Host "[5/6] 発行ファイルの確認..." -ForegroundColor Yellow

--- a/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
@@ -33,9 +33,10 @@ namespace ICCardManager.Infrastructure.Logging
         {
             Options = options.Value;
 
-            // ログディレクトリを決定
-            var appDirectory = AppContext.BaseDirectory;
-            _logDirectory = Path.Combine(appDirectory, Options.Path);
+            // ログディレクトリを決定（ユーザーデータはLocalAppDataに保存）
+            // Program Filesは管理者権限が必要なため、%LOCALAPPDATA%\ICCardManager\Logsを使用
+            var appDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            _logDirectory = Path.Combine(appDataDirectory, "ICCardManager", Options.Path);
 
             if (Options.Enabled)
             {


### PR DESCRIPTION
## Summary
- インストーラーにすべてのDLLファイルとx86ネイティブDLLを含めるよう修正
- ビルドスクリプトにSQLite.Interop.dllのコピー処理を追加
- ログディレクトリを`C:\Program Files\`から`%LOCALAPPDATA%\ICCardManager\Logs`に変更
  - Program Filesへの書き込みは管理者権限が必要なため、アクセス拒否エラーが発生していた

## 変更ファイル
- `installer/ICCardManager.iss` - DLLとx86フォルダの含め方を修正
- `installer/build-installer.ps1` - SQLite.Interop.dllコピー処理追加
- `src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs` - ログパスを%LOCALAPPDATA%に変更

## Test plan
- [ ] Windowsでインストーラーをビルド (`powershell -ExecutionPolicy Bypass -File .\build-installer.ps1`)
- [ ] 作成されたインストーラーでアプリをインストール
- [ ] アプリが正常に起動することを確認
- [ ] ログが`%LOCALAPPDATA%\ICCardManager\Logs`に出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)