### PR TITLE
fix: リリース版にテストデータを含めない (#351)

### DIFF
--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if DEBUG
 using ICCardManager.Models;
 
 namespace ICCardManager.Infrastructure.CardReader
 {
 /// <summary>
-    /// テスト用のモックICカードリーダー
+    /// テスト用のモックICカードリーダー（DEBUGビルド専用）
     /// </summary>
     public class MockCardReader : ICardReader
     {
@@ -305,3 +306,4 @@ namespace ICCardManager.Infrastructure.CardReader
         public Dictionary<string, int> CustomBalances { get; } = new();
     }
 }
+#endif

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -615,6 +615,7 @@ namespace ICCardManager.ViewModels
             }
         }
 
+#if DEBUG
         /// <summary>
         /// デバッグ用: カード読み取りをシミュレート
         /// </summary>
@@ -630,6 +631,7 @@ namespace ICCardManager.ViewModels
                 mockReader.SimulateCardRead(newIdm);
             }
         }
+#endif
 
         /// <summary>
         /// 新規購入レコードを作成

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -562,6 +562,7 @@ namespace ICCardManager.ViewModels
             }
         }
 
+#if DEBUG
         /// <summary>
         /// デバッグ用: カード読み取りをシミュレート
         /// </summary>
@@ -577,6 +578,7 @@ namespace ICCardManager.ViewModels
                 mockReader.SimulateCardRead(newIdm);
             }
         }
+#endif
 
         /// <summary>
         /// クリーンアップ


### PR DESCRIPTION
## Summary
- `MockCardReader.cs` を `#if DEBUG` で囲んでReleaseビルドから除外
- `CardManageViewModel.SimulateCardRead()` を `#if DEBUG` で囲む
- `StaffManageViewModel.SimulateCardRead()` を `#if DEBUG` で囲む

## 背景
Releaseビルドに以下のテストデータ/デバッグ機能が含まれていた：
- `MockCardReader` クラス（テスト用カードリーダー）
- `MockHistorySettings` クラス
- テスト用IDmデータ（職員証5名分、ICカード6枚分）
- カード読み取りシミュレート機能

## 変更後の動作

| ビルド | MockCardReader | SimulateCardRead | デバッグボタン |
|--------|----------------|------------------|---------------|
| Debug | ✅ 含まれる | ✅ 含まれる | ✅ 表示される |
| Release | ❌ 除外される | ❌ 除外される | ❌ 非表示 |

## 既存の対策（変更なし）
以下は既に `#if DEBUG` で保護されていた：
- `DebugDataService.cs` （ファイル全体）
- `App.xaml.cs` の `RegisterTestDataAsync()` 呼び出し
- `MainViewModel.cs` の `SimulateStaffCard()`/`SimulateIcCard()`

## Test plan
- [ ] Debugビルドでカード読み取りシミュレートが動作することを確認
- [ ] Releaseビルドでコンパイルが成功することを確認
- [ ] Releaseビルドでデバッグボタンが表示されないことを確認

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)