### PR TITLE
fix: 既存テスト失敗を修正 (#358)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvExportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvExportServiceTests.cs
@@ -292,7 +292,7 @@ public class CsvExportServiceTests : IDisposable
         // ファイル内容を確認
         var lines = await Task.Run(() => File.ReadAllLines(filePath, Encoding.UTF8));
         lines.Should().HaveCount(3); // ヘッダー + 2行
-        lines[0].Should().Be("日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考");
+        lines[0].Should().Be("ID,日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考");
     }
 
     /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -350,7 +350,7 @@ FEDCBA9876543210,PASMO,002,テスト2";
     }
 
     /// <summary>
-    /// 既存カードが更新としてプレビューされることを確認
+    /// 既存カードが更新としてプレビューされることを確認（データに変更がある場合）
     /// </summary>
     [Fact]
     public async Task PreviewCardsAsync_ExistingCardNoSkip_ShowsAsUpdate()
@@ -362,7 +362,8 @@ FEDCBA9876543210,PASMO,002,テスト2";
         var filePath = Path.Combine(_testDirectory, "cards_preview_update.csv");
         await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
 
-        var existingCard = new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "001" };
+        // 既存カードは管理番号が「000」なので、CSVの「001」と差異があり更新対象となる
+        var existingCard = new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "000" };
         _cardRepositoryMock.Setup(x => x.GetByIdmAsync("0123456789ABCDEF", true)).ReturnsAsync(existingCard);
 
         // Act


### PR DESCRIPTION
## Summary
- CsvExportServiceTests: CSVヘッダーの期待値に「ID」列を追加（実装との整合性を修正）
- CsvImportServiceTests: 既存カードの管理番号を変更してデータ差異を発生させ、更新検出が正しく動作することをテスト

## 修正内容の詳細

### CsvExportServiceTests
`ExportLedgersAsync_WithValidData_ExportsSuccessfully` テストで、エクスポートされるCSVヘッダーの期待値が古いフォーマットのままでした。
実装では `ID,日時,カードIDm,...` となっているため、テストの期待値も更新しました。

### CsvImportServiceTests  
`PreviewCardsAsync_ExistingCardNoSkip_ShowsAsUpdate` テストで、既存カードとCSVデータが完全に一致していたため、`DetectCardChanges` が変更なしと判定し、UpdateではなくSkipとなっていました。
既存カードの管理番号を `001` から `000` に変更し、CSVデータ（`001`）との差異を発生させることで、正しくUpdateとして検出されるようにしました。

## Test plan
- [x] `dotnet test` で全950件のテストがパス
- [x] 変更したテストが意図通り機能することを確認

Fixes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)