### PR TITLE
feat: インストーラーにドキュメント類を追加 (#360)

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -68,8 +68,19 @@ Source: "..\publish\Resources\Sounds\*"; DestDir: "{app}\Resources\Sounds"; Flag
 ; テンプレートファイル
 Source: "..\publish\Resources\Templates\*"; DestDir: "{app}\Resources\Templates"; Flags: ignoreversion recursesubdirs createallsubdirs
 
+; ドキュメント（ユーザー向け・管理者向け）
+; markdown形式
+Source: "..\docs\manual\ユーザーマニュアル.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
+Source: "..\docs\manual\ユーザーマニュアル概要版.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
+Source: "..\docs\manual\管理者マニュアル.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
+; docx形式
+Source: "..\docs\manual\ユーザーマニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
+Source: "..\docs\manual\ユーザーマニュアル概要版（修正版）.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
+Source: "..\docs\manual\管理者マニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
+
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\app.ico"
+Name: "{group}\ドキュメント"; Filename: "{app}\Docs"
 Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\app.ico"; Tasks: desktopicon
 


### PR DESCRIPTION
## Summary
- インストーラーにユーザー向け・管理者向けドキュメントを追加
- markdown形式とdocx形式の両方を含める
- スタートメニューに「ドキュメント」フォルダへのショートカットを追加

## 追加されるファイル

| ファイル | 形式 | 対象 |
|---------|------|------|
| ユーザーマニュアル.md | Markdown | ユーザー向け |
| ユーザーマニュアル.docx | Word | ユーザー向け |
| ユーザーマニュアル概要版.md | Markdown | ユーザー向け |
| ユーザーマニュアル概要版（修正版）.docx | Word | ユーザー向け |
| 管理者マニュアル.md | Markdown | 管理者向け |
| 管理者マニュアル.docx | Word | 管理者向け |

## インストール先
`{app}\Docs` フォルダ（例: `C:\Program Files\ICCardManager\Docs`）

## Test plan
- [x] インストーラーをビルド（`build-installer.bat`）
- [x] インストール後、`Docs` フォルダに6つのドキュメントが存在することを確認
- [x] スタートメニューの「ドキュメント」ショートカットからDocsフォルダが開くことを確認

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)