### PR TITLE
fix: ReleaseビルドでPDBファイルを除外 (#371)

### DIFF
--- a/ICCardManager/installer/build-installer.ps1
+++ b/ICCardManager/installer/build-installer.ps1
@@ -86,6 +86,13 @@ if (-not $SkipBuild) {
         if ($LASTEXITCODE -ne 0) { throw "ビルドに失敗しました" }
 
         Write-Host "  ビルド完了: $PublishDir" -ForegroundColor Green
+
+        # PDBファイルを削除（リリースビルドでは不要）
+        $PdbFiles = Get-ChildItem $PublishDir -Filter "*.pdb" -ErrorAction SilentlyContinue
+        if ($PdbFiles) {
+            $PdbFiles | Remove-Item -Force
+            Write-Host "  PDBファイル: $($PdbFiles.Count) 個削除" -ForegroundColor Green
+        }
     }
     finally {
         Pop-Location

--- a/ICCardManager/src/ICCardManager/ICCardManager.csproj
+++ b/ICCardManager/src/ICCardManager/ICCardManager.csproj
@@ -31,6 +31,12 @@
     <InternalsVisibleTo>ICCardManager.Tests</InternalsVisibleTo>
   </PropertyGroup>
 
+  <!-- リリースビルド時はPDBファイルを生成しない -->
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>ICCardManager.Tests</_Parameter1>

--- a/ICCardManager/tools/DebugDataViewer/DebugDataViewer.csproj
+++ b/ICCardManager/tools/DebugDataViewer/DebugDataViewer.csproj
@@ -24,6 +24,12 @@
     <NoWarn>$(NoWarn);CS1591;CS8632</NoWarn>
   </PropertyGroup>
 
+  <!-- リリースビルド時はPDBファイルを生成しない -->
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- メインプロジェクトを参照 -->
     <ProjectReference Include="..\..\src\ICCardManager\ICCardManager.csproj" />


### PR DESCRIPTION
## Summary
- ReleaseビルドでPDBファイルを生成しないように設定
- ビルドスクリプトにPDBファイル削除処理を追加（安全策）

## 変更内容

### .csproj ファイル
以下の設定を追加:
```xml
<PropertyGroup Condition="'$(Configuration)'=='Release'">
  <DebugType>none</DebugType>
  <DebugSymbols>false</DebugSymbols>
</PropertyGroup>
```

対象ファイル:
- `src/ICCardManager/ICCardManager.csproj`
- `tools/DebugDataViewer/DebugDataViewer.csproj`

### build-installer.ps1
ビルド後にpublishディレクトリ内のPDBファイルを削除する処理を追加

## なぜPDBを除外するか
- **セキュリティ**: ソースコードのパス、行番号、変数名等のデバッグ情報が含まれる
- **ファイルサイズ**: 不要なファイルによるインストーラーサイズ増加を防止

## Test plan
- [x] `dotnet build -c Release` でビルド成功
- [x] Releaseビルド後に `bin/Release/net48/*.pdb` が存在しないことを確認
- [ ] `build-installer.ps1` でインストーラービルド時にPDB削除メッセージが表示されることを確認

Fixes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)