### PR TITLE
fix: ログ設定を本番環境向けに変更 (#363)

### DIFF
--- a/ICCardManager/src/ICCardManager/appsettings.json
+++ b/ICCardManager/src/ICCardManager/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "ICCardManager": "Debug",
+      "ICCardManager": "Information",
       "Microsoft": "Warning"
     },
     "File": {
@@ -12,7 +12,7 @@
       "MaxFileSizeMB": 10
     },
     "Debug": {
-      "Enabled": true
+      "Enabled": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- ログ設定を本番環境向けに変更
- 組織名の変更は別途対応予定

## 変更内容

| 設定項目 | 変更前 | 変更後 |
|---------|-------|-------|
| ICCardManager LogLevel | Debug | Information |
| Debug.Enabled | true | false |

### 変更理由
- **Debug LogLevel**: 開発時は詳細なトレース情報が必要だが、本番環境では不要
- **Debug.Enabled**: Visual Studioのデバッグ出力ウィンドウへの出力を無効化

### 効果
- ログファイルの肥大化を防止
- 本番環境でのパフォーマンス向上
- 不要な情報漏洩リスクの低減

## 未対応項目
以下は別途対応予定：
- 組織名・発行元名の変更（`Your Organization` → 正式名称）

## Test plan
- [x] アプリケーションが正常に起動することを確認
- [ ] ログファイルに Information レベル以上のログのみ出力されることを確認

Partially fixes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)