### PR TITLE
docs: クラス設計書に未記載の8サービスを追加

### DIFF
--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -87,6 +87,14 @@ graph TB
         SVC_SUMMARY[SummaryGenerator]
         SVC_CARDTYPE[CardTypeDetector]
         SVC_OPLOG[OperationLogger]
+        SVC_CSVEXP[CsvExportService]
+        SVC_CSVIMP[CsvImportService]
+        SVC_PRINT[PrintService]
+        SVC_SANITIZE[InputSanitizer]
+        SVC_STATION[StationMasterService]
+        SVC_TEMPLATE[TemplateResolver]
+        SVC_TOAST[ToastNotificationService]
+        SVC_DEBUG[DebugDataService]
     end
 
     subgraph "Data Access Layer"
@@ -169,6 +177,14 @@ graph TB
 | SummaryGenerator | 摘要文字列の生成 |
 | CardTypeDetector | IDmからカード種別を判別 |
 | OperationLogger | 操作ログの記録 |
+| CsvExportService | CSV形式でのデータエクスポート |
+| CsvImportService | CSV形式でのデータインポート |
+| PrintService | 帳票の印刷・FlowDocument生成 |
+| InputSanitizer | 入力値のサニタイズ処理（静的クラス） |
+| StationMasterService | 駅コードから駅名への解決（シングルトン） |
+| TemplateResolver | Excelテンプレートのパス解決（静的クラス） |
+| ToastNotificationService | トースト通知の表示 |
+| DebugDataService | テストデータの管理（DEBUGビルド専用） |
 
 ### 3.4 Repositories
 
@@ -390,6 +406,232 @@ classDiagram
     }
 ```
 
+### 5.6 CsvExportService
+
+```mermaid
+classDiagram
+    class CsvExportService {
+        -IStaffRepository _staffRepository
+        -ICardRepository _cardRepository
+        -ILedgerRepository _ledgerRepository
+        +ExportStaffAsync(filePath, includeDeleted) Task~int~
+        +ExportCardsAsync(filePath, includeDeleted) Task~int~
+        +ExportLedgersAsync(filePath, startDate, endDate) Task~int~
+        -WriteCsvLine(writer, fields) void
+        -EscapeCsvField(field) string
+    }
+```
+
+### 5.7 CsvImportService
+
+```mermaid
+classDiagram
+    class CsvImportService {
+        -IStaffRepository _staffRepository
+        -ICardRepository _cardRepository
+        +PreviewStaffImportAsync(filePath) Task~List~ImportPreviewItem~~
+        +PreviewCardImportAsync(filePath) Task~List~ImportPreviewItem~~
+        +ImportStaffAsync(filePath, skipExisting) Task~ImportResult~
+        +ImportCardsAsync(filePath, skipExisting) Task~ImportResult~
+        -ParseCsvLine(line) List~string~
+        -ValidateStaffRow(fields) string?
+        -ValidateCardRow(fields) string?
+    }
+
+    class ImportPreviewItem {
+        +int RowNumber
+        +string Idm
+        +string Name
+        +string AdditionalInfo
+        +ImportAction Action
+        +string? Changes
+        +string? Error
+    }
+
+    class ImportResult {
+        +int InsertedCount
+        +int UpdatedCount
+        +int SkippedCount
+        +int ErrorCount
+        +List~string~ Errors
+    }
+
+    CsvImportService --> ImportPreviewItem
+    CsvImportService --> ImportResult
+```
+
+### 5.8 PrintService
+
+```mermaid
+classDiagram
+    class PrintService {
+        -ICardRepository _cardRepository
+        -ILedgerRepository _ledgerRepository
+        +GetReportDataAsync(cardIdm, year, month) Task~ReportPrintData?~
+        +CreateFlowDocument(data, orientation) FlowDocument
+        +CreateCombinedFlowDocumentAsync(cardIdms, year, month) Task~FlowDocument~
+        +CreateFlowDocumentForMultipleCards(dataList, orientation) FlowDocument
+        +Print(document, documentName) bool
+        +PrintWithSettings(document, documentName, orientation) bool
+        -CreateHeaderTable(data) Table
+        -CreateDataTable(data) Table
+        -GroupRowsByPage(rows, pageWidth, pageHeight, summaryRowCount, isFirstCard) List~List~~
+        -AddPageContent(doc, data, rows, addPageBreakBefore, hideSummary) void
+    }
+
+    class ReportPrintData {
+        +string CardType
+        +string CardNumber
+        +int Year
+        +int Month
+        +string WarekiYearMonth
+        +List~ReportPrintRow~ Rows
+        +ReportPrintTotal MonthlyTotal
+        +ReportPrintTotal? CumulativeTotal
+        +int? CarryoverToNextYear
+    }
+
+    class ReportPrintRow {
+        +string DateDisplay
+        +string Summary
+        +int? Income
+        +int? Expense
+        +int? Balance
+        +string StaffName
+        +string Note
+        +bool IsBold
+    }
+
+    PrintService --> ReportPrintData
+    ReportPrintData --> ReportPrintRow
+```
+
+### 5.9 InputSanitizer
+
+```mermaid
+classDiagram
+    class InputSanitizer {
+        <<static>>
+        +Sanitize(input, options)$ string
+        +SanitizeName(name)$ string
+        +SanitizeStaffNumber(number)$ string
+        +SanitizeNote(note)$ string
+        +SanitizeBusStops(busStops)$ string
+        +SanitizeCardNumber(cardNumber)$ string
+        -RemoveInvalidSurrogates(input)$ string
+    }
+
+    class SanitizeOptions {
+        <<flags enumeration>>
+        None
+        Trim
+        RemoveControlCharacters
+        RemoveZeroWidthCharacters
+        RemoveInvalidSurrogates
+        NormalizeWhitespace
+        Standard
+    }
+
+    InputSanitizer --> SanitizeOptions
+```
+
+### 5.10 StationMasterService
+
+```mermaid
+classDiagram
+    class StationMasterService {
+        <<singleton>>
+        -Lazy~StationMasterService~ _instance$
+        -Dictionary _stations
+        -Dictionary _lineNames
+        -Dictionary _areaLineCodes
+        -bool _isLoaded
+        +Instance$ StationMasterService
+        +EnsureLoaded() void
+        +GetStationName(stationCode) string
+        +GetStationName(stationCode, cardType) string
+        +GetStationNameByArea(areaCode, lineCode, stationNum) string
+        +GetStationNameOrNull(lineCode, stationNum, cardType) string
+        +GetLineName(lineCode, cardType) string
+        +StationCount int
+        +LineCount int
+        -LoadFromEmbeddedResource() void
+        -LoadFallbackData() void
+        -GetAreaPriority(cardType)$ int[]
+    }
+```
+
+### 5.11 TemplateResolver
+
+```mermaid
+classDiagram
+    class TemplateResolver {
+        <<static>>
+        -string TemplateRelativePath$
+        -string EmbeddedResourceName$
+        -string TempFilePrefix$
+        +ResolveTemplatePath()$ string
+        +TemplateExists()$ bool
+        +CleanupTempFiles()$ void
+        -ExtractEmbeddedTemplate()$ string?
+    }
+
+    class TemplateNotFoundException {
+        +string TemplateName
+        +IReadOnlyList~string~ SearchedPaths
+        +GetDetailedMessage() string
+    }
+
+    TemplateResolver ..> TemplateNotFoundException : throws
+```
+
+### 5.12 ToastNotificationService
+
+```mermaid
+classDiagram
+    class IToastNotificationService {
+        <<interface>>
+        +ShowLendNotification(cardType, cardNumber) void
+        +ShowReturnNotification(cardType, cardNumber, balance, isLowBalance) void
+        +ShowStaffRecognizedNotification(staffName) void
+        +ShowInfo(title, message) void
+        +ShowWarning(title, message) void
+        +ShowError(title, message) void
+    }
+
+    class ToastNotificationService {
+        +ShowLendNotification(cardType, cardNumber) void
+        +ShowReturnNotification(cardType, cardNumber, balance, isLowBalance) void
+        +ShowStaffRecognizedNotification(staffName) void
+        +ShowInfo(title, message) void
+        +ShowWarning(title, message) void
+        +ShowError(title, message) void
+    }
+
+    ToastNotificationService ..|> IToastNotificationService
+```
+
+### 5.13 DebugDataService
+
+```mermaid
+classDiagram
+    class DebugDataService {
+        <<DEBUG only>>
+        -IStaffRepository _staffRepository
+        -ICardRepository _cardRepository
+        -ILedgerRepository _ledgerRepository
+        +Staff[] TestStaffList$
+        +IcCard[] TestCardList$
+        +RegisterAllTestDataAsync() Task
+        +RegisterTestStaffAsync() Task
+        +RegisterTestCardsAsync() Task
+        +RegisterSampleHistoryAsync() Task
+        +ResetTestDataAsync() Task
+        +GenerateHistoryAsync(cardIdm, days, staffName) Task
+        +GetAllTestIdms()$ IEnumerable
+    }
+```
+
 ---
 
 ## 6. DIコンテナ設定
@@ -410,6 +652,16 @@ services.AddSingleton<LendingService>();
 services.AddSingleton<ReportService>();
 services.AddSingleton<BackupService>();
 services.AddSingleton<OperationLogger>();
+services.AddSingleton<CsvExportService>();
+services.AddSingleton<CsvImportService>();
+services.AddSingleton<PrintService>();
+services.AddSingleton<IToastNotificationService, ToastNotificationService>();
+#if DEBUG
+services.AddSingleton<DebugDataService>();
+#endif
+
+// 静的クラス（DI不要）: InputSanitizer, TemplateResolver
+// シングルトン（静的プロパティ）: StationMasterService.Instance
 
 services.AddSingleton<ICardReader, PcScCardReader>();
 services.AddSingleton<ISoundPlayer, SoundPlayer>();


### PR DESCRIPTION
## Summary
- クラス設計書(05_クラス設計書.md)に実装済みだがドキュメント化されていなかった8つのサービスクラスを追加
- レイヤー構成図(mermaid)にサービスノードを追加
- Servicesテーブルに8サービスを追加
- 各サービスの詳細クラス図（5.6〜5.13）を追加
- DIコンテナ設定に新規サービスの登録例を追加

## 追加したサービス
| クラス | 種類 | 概要 |
|--------|------|------|
| CsvExportService | 通常 | CSV形式でのデータエクスポート |
| CsvImportService | 通常 | CSV形式でのデータインポート |
| PrintService | 通常 | WPF FlowDocumentを使用した帳票印刷 |
| InputSanitizer | 静的クラス | 入力値のサニタイズ処理 |
| StationMasterService | シングルトン | 駅コードから駅名への解決 |
| TemplateResolver | 静的クラス | Excelテンプレートのパス解決 |
| ToastNotificationService | 通常 | トースト通知の表示 |
| DebugDataService | DEBUG専用 | テストデータの管理 |

## Test plan
- [ ] マークダウンのレンダリング確認
- [ ] mermaid図の正しい表示確認
- [ ] 実装コードとドキュメントの一致確認

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)