### PR TITLE
fix: カード初期登録時に残高を事前読み取りするように修正 (#381)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -883,10 +883,22 @@ public partial class MainViewModel : ViewModelBase
                 break;
 
             case Views.Dialogs.CardTypeSelectionResult.IcCard:
+                // Issue #381対応: カードがリーダー上にある間に残高を読み取っておく
+                // ユーザーがフォームを入力している間にカードが離れても正しい残高で登録できる
+                int? preReadBalance = null;
+                try
+                {
+                    preReadBalance = await _cardReader.ReadBalanceAsync(idm);
+                }
+                catch
+                {
+                    // 残高読み取りエラーは無視（カード登録は続行可能）
+                }
+
                 // カード管理画面を開いて新規登録モードで開始
                 var cardDialog = App.Current.ServiceProvider.GetRequiredService<Views.Dialogs.CardManageDialog>();
                 cardDialog.Owner = System.Windows.Application.Current.MainWindow;
-                cardDialog.InitializeWithIdm(idm);
+                cardDialog.InitializeWithIdmAndBalance(idm, preReadBalance);
                 cardDialog.ShowDialog();
 
                 // ダイアログを閉じた後、貸出中カード一覧を更新

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
@@ -15,6 +15,7 @@ namespace ICCardManager.Views.Dialogs
     {
         private readonly CardManageViewModel _viewModel;
         private string _presetIdm;
+        private int? _presetBalance;
 
         public CardManageDialog(CardManageViewModel viewModel)
         {
@@ -35,6 +36,12 @@ namespace ICCardManager.Views.Dialogs
                 // IDmが事前に設定されている場合は新規登録モードで開始
                 if (!string.IsNullOrEmpty(_presetIdm))
                 {
+                    // Issue #381対応: 事前に読み取った残高をViewModelに設定
+                    if (_presetBalance.HasValue)
+                    {
+                        _viewModel.SetPreReadBalance(_presetBalance);
+                    }
+
                     // Issue #284対応: タッチ時点で削除済み/登録済みチェックを行う
                     var shouldClose = await _viewModel.StartNewCardWithIdmAsync(_presetIdm);
                     if (shouldClose)
@@ -57,6 +64,22 @@ namespace ICCardManager.Views.Dialogs
         public void InitializeWithIdm(string idm)
         {
             _presetIdm = idm;
+        }
+
+        /// <summary>
+        /// IDmと残高を指定して新規登録モードで初期化（Issue #381対応）
+        /// </summary>
+        /// <remarks>
+        /// カード検出時に残高を事前に読み取っておくことで、
+        /// ユーザーがフォーム入力中にカードがリーダーから離れても
+        /// 正しい残高で「新規購入」レコードを作成できる。
+        /// </remarks>
+        /// <param name="idm">カードのIDm</param>
+        /// <param name="balance">事前に読み取ったカード残高</param>
+        public void InitializeWithIdmAndBalance(string idm, int? balance)
+        {
+            _presetIdm = idm;
+            _presetBalance = balance;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- 未登録カード検出時に、MainViewModelで即座に残高を読み取るように変更
- 読み取った残高をCardManageDialogに渡し、ViewModelで保持
- CreateNewPurchaseLedgerAsyncで事前読み取り残高を優先的に使用

これにより、ユーザーがCardManageDialogでフォーム入力中にカードがリーダーから離れても、正しい残高で「新規購入」レコードが作成されるようになりました。

## 変更内容

### MainViewModel.cs
- HandleUnregisteredCardAsyncで、ICカード選択時にReadBalanceAsyncを呼び出して残高を事前読み取り
- InitializeWithIdmAndBalanceで残高をダイアログに渡すように変更

### CardManageDialog.xaml.cs
- _presetBalanceフィールドを追加
- InitializeWithIdmAndBalanceメソッドを追加
- ダイアログロード時にViewModelにSetPreReadBalanceで残高を設定

### CardManageViewModel.cs
- _preReadBalanceフィールドを追加
- SetPreReadBalanceメソッドを追加
- CreateNewPurchaseLedgerAsyncで事前読み取り残高を優先使用、使用後はクリア

## Test plan

- [ ] 新しいICカードをタッチし、すぐにリーダーから離す
- [ ] CardManageDialogでフォームを入力して保存
- [ ] 「新規購入」レコードが正しい残高で登録されることを確認
- [ ] 残高が0にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)