### PR TITLE
docs: CLAUDE.mdの参照切れと記載漏れを修正 (#367)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,17 @@ ICCardManager/
 │       │   │   ├── SettingsDialog.xaml
 │       │   │   ├── ReportDialog.xaml
 │       │   │   └── ...
+│       │   ├── Converters/             # WPF値コンバーター
+│       │   │   └── VisibilityConverters.cs
 │       │   └── Controls/
 │       ├── ViewModels/                 # ViewModel
 │       │   ├── ViewModelBase.cs
 │       │   ├── MainViewModel.cs
+│       │   └── ...
+│       ├── Dtos/                       # DTOクラス
+│       │   ├── CardDto.cs
+│       │   ├── StaffDto.cs
+│       │   ├── LedgerDto.cs
 │       │   └── ...
 │       ├── Models/                     # エンティティ
 │       │   ├── Staff.cs
@@ -52,13 +59,26 @@ ICCardManager/
 │       │   ├── CardReader/
 │       │   │   ├── ICardReader.cs
 │       │   │   └── PcScCardReader.cs
-│       │   └── Sound/
-│       │       └── SoundPlayer.cs
+│       │   ├── Sound/
+│       │   │   └── SoundPlayer.cs
+│       │   ├── Caching/                # キャッシング機能
+│       │   │   ├── ICacheService.cs
+│       │   │   └── CacheService.cs
+│       │   └── Logging/                # ログ機能
+│       │       ├── FileLogger.cs
+│       │       └── FileLoggerProvider.cs
 │       ├── Common/                     # 共通ユーティリティ
 │       │   ├── WarekiConverter.cs
-│       │   └── Enums.cs
+│       │   ├── Enums.cs
+│       │   ├── Converters.cs           # WPF値コンバーター
+│       │   └── Exceptions/             # カスタム例外クラス
+│       │       ├── AppException.cs
+│       │       ├── BusinessException.cs
+│       │       └── ...
 │       └── Resources/
 │           ├── Sounds/
+│           ├── Styles/                 # WPF用スタイル定義
+│           │   └── AccessibilityStyles.xaml
 │           └── Templates/
 │               └── 物品出納簿テンプレート.xlsx
 └── docs/                               # ドキュメント
@@ -185,7 +205,7 @@ THEN
 
 ## 参照ドキュメント
 
-- `プロンプト.md` - 詳細な要件定義
+- `初期プロンプト.md` - 詳細な要件定義
 - `docs/design/` - 設計書一式
 - `docs/manual/` - マニュアル（ユーザー・管理者・開発者）
 - `Resources/Templates/物品出納簿テンプレート.xlsx` - 月次帳票テンプレート


### PR DESCRIPTION
## Summary

- `プロンプト.md` への参照を `初期プロンプト.md` に修正（ファイルがリネームされていた）
- ディレクトリ構成に記載されていなかった6つのディレクトリを追加

## 変更内容

### 1. 参照切れの修正
| 修正前 | 修正後 |
|--------|--------|
| `プロンプト.md` | `初期プロンプト.md` |

### 2. 追加したディレクトリ

| ディレクトリ | 説明 | ファイル例 |
|-------------|------|-----------|
| `Dtos/` | DTOクラス | CardDto.cs, StaffDto.cs |
| `Common/Exceptions/` | カスタム例外クラス | AppException.cs, BusinessException.cs |
| `Common/Converters.cs` | WPF値コンバーター（ファイル） | - |
| `Infrastructure/Caching/` | キャッシング機能 | ICacheService.cs, CacheService.cs |
| `Infrastructure/Logging/` | ログ機能 | FileLogger.cs, FileLoggerProvider.cs |
| `Resources/Styles/` | WPF用スタイル定義 | AccessibilityStyles.xaml |
| `Views/Converters/` | WPF値コンバーター | VisibilityConverters.cs |

### 補足
Issue #367では`ViewModels/Converters/`の追加が提案されていましたが、実際のディレクトリは`Views/Converters/`でした。実態に合わせて修正しました。

## Test plan

- [x] CLAUDE.md内の参照先ファイル `初期プロンプト.md` が存在することを確認
- [x] 追加したディレクトリが実際に存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)