### PR TITLE
fix: メインウィンドウのデフォルトサイズを調整

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -11,7 +11,9 @@
         d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
         Title="交通系ICカード管理システム"
         Height="700"
-        Width="1000"
+        Width="1150"
+        MinWidth="1100"
+        MinHeight="600"
         WindowStartupLocation="CenterScreen"
         AutomationProperties.Name="交通系ICカード管理システム メインウィンドウ"
         AutomationProperties.HelpText="職員証をタッチしてから交通系ICカードをタッチすると貸出または返却ができます">


### PR DESCRIPTION
## Summary

- インストール直後の状態でヘッダーのすべてのボタンが表示されるようにウィンドウサイズを調整

## 変更内容

| プロパティ | 変更前 | 変更後 |
|------------|--------|--------|
| Width | 1000 | 1150 |
| MinWidth | (なし) | 1100 |
| MinHeight | (なし) | 600 |

## 理由

ヘッダーには7つのボタンがあり、特に「交通系ICカード管理 (F3)」は長いテキストのため、幅1000pxでは収まりきらずはみ出していました。

MinWidth/MinHeightを設定することで、ユーザーがウィンドウを小さくしすぎてボタンが隠れることを防止します。

## Test plan

- [x] ビルド成功を確認
- [ ] 手動確認：アプリ起動時にすべてのボタンが表示されることを確認

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)