### PR TITLE
fix: 未使用変数の警告（CS0168）を解消

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/DbContext.cs
+++ b/ICCardManager/src/ICCardManager/Data/DbContext.cs
@@ -93,6 +93,7 @@ namespace ICCardManager.Data
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // 権限設定に失敗してもディレクトリ作成は試みる
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[DbContext] ディレクトリ権限設定エラー: {ex.Message}");
@@ -238,6 +239,7 @@ namespace ICCardManager.Data
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // アクセス権限の設定に失敗してもアプリケーションは続行
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[DbContext] アクセス権限の設定に失敗: {ex.Message}");

--- a/ICCardManager/src/ICCardManager/Data/Migrations/MigrationRunner.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/MigrationRunner.cs
@@ -346,6 +346,7 @@ VALUES (@operator_idm, @operator_name, @target_table, @target_id, @action, @afte
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // ログ記録の失敗はマイグレーション自体には影響させない
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[Migration] Failed to log migration action: {ex.Message}");

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
@@ -732,6 +732,7 @@ namespace ICCardManager.Infrastructure.CardReader
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"再接続試行エラー: {ex.Message}");
 #endif
@@ -846,6 +847,7 @@ namespace ICCardManager.Infrastructure.CardReader
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"Pollingコマンドエラー: {ex.Message}");
 #endif
@@ -937,6 +939,7 @@ namespace ICCardManager.Infrastructure.CardReader
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"ブロック{blockIndex}読み取り失敗: {ex.Message}");
 #endif
@@ -1055,6 +1058,7 @@ namespace ICCardManager.Infrastructure.CardReader
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"履歴データのパースエラー: {ex.Message}");
 #endif

--- a/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
@@ -112,6 +112,7 @@ namespace ICCardManager.Infrastructure.Logging
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[FileLogger] Failed to write log: {ex.Message}");
 #endif
@@ -192,6 +193,7 @@ namespace ICCardManager.Infrastructure.Logging
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[FileLogger] Failed to cleanup old logs: {ex.Message}");
 #endif
@@ -228,6 +230,7 @@ namespace ICCardManager.Infrastructure.Logging
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // 権限設定に失敗してもディレクトリ作成は試みる
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[FileLogger] ディレクトリ権限設定エラー: {ex.Message}");

--- a/ICCardManager/src/ICCardManager/Services/StationMasterService.cs
+++ b/ICCardManager/src/ICCardManager/Services/StationMasterService.cs
@@ -100,6 +100,7 @@ namespace ICCardManager.Services
                 }
                 catch (Exception ex)
                 {
+                    _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                     System.Diagnostics.Debug.WriteLine($"駅マスタ読み込みエラー: {ex.Message}");
 #endif

--- a/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
@@ -163,6 +163,7 @@ public partial class BusStopInputViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
+            _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
             System.Diagnostics.Debug.WriteLine($"[BusStopInput] サジェスト候補の読み込みに失敗: {ex.Message}");
 #endif

--- a/ICCardManager/src/ICCardManager/ViewModels/PrintPreviewViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/PrintPreviewViewModel.cs
@@ -229,6 +229,7 @@ public partial class PrintPreviewViewModel : ViewModelBase
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // ドキュメントがまだビジュアルツリーにアタッチされていない場合など
                 // ページ数の取得に失敗することがある
 #if DEBUG

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
@@ -56,6 +56,7 @@ namespace ICCardManager.Views
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
                 // 終了時のエラーは警告のみ（アプリ終了を妨げない）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] 終了時エラー: {ex.Message}");
@@ -99,6 +100,7 @@ namespace ICCardManager.Views
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置の保存に失敗: {ex.Message}");
 #endif
@@ -155,6 +157,7 @@ namespace ICCardManager.Views
             }
             catch (Exception ex)
             {
+                _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置の復元に失敗: {ex.Message}");
 #endif


### PR DESCRIPTION
## Summary

- インストーラー作成時に発生していた16件のCS0168警告を解消

## 問題の原因

`catch (Exception ex)` で例外をキャッチし、`#if DEBUG` ブロック内でのみ `ex.Message` を使用していたため、Releaseビルドでは `ex` 変数が未使用となり警告が発生していました。

## 修正方法

各catchブロックの先頭に `_ = ex;` を追加し、例外変数をdiscardとして扱うことで警告を抑制しました。

```csharp
catch (Exception ex)
{
    _ = ex; // 警告抑制（DEBUGビルドでのみ使用）
#if DEBUG
    System.Diagnostics.Debug.WriteLine($"エラー: {ex.Message}");
#endif
}
```

## 修正ファイル（8ファイル、16箇所）

| ファイル | 箇所数 |
|----------|--------|
| Data/DbContext.cs | 2 |
| Data/Migrations/MigrationRunner.cs | 1 |
| Infrastructure/CardReader/PcScCardReader.cs | 4 |
| Infrastructure/Logging/FileLoggerProvider.cs | 3 |
| Services/StationMasterService.cs | 1 |
| ViewModels/BusStopInputViewModel.cs | 1 |
| ViewModels/PrintPreviewViewModel.cs | 1 |
| Views/MainWindow.xaml.cs | 3 |

## Test plan

- [x] `dotnet build -c Release` で警告0件を確認

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)