### PR TITLE
fix: インストーラーのバージョンを本体と自動同期 (#407)

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -1,9 +1,13 @@
 ; ICCardManager インストーラースクリプト
 ; Inno Setup 6.x 用
+; バージョンはコマンドラインから /DMyAppVersion=x.y.z で指定可能
 
 #define MyAppName "交通系ICカード管理システム"
 #define MyAppNameEn "ICCardManager"
-#define MyAppVersion "1.0.0"
+; コマンドラインでバージョンが指定されていない場合のデフォルト値
+#ifndef MyAppVersion
+  #define MyAppVersion "1.0.0"
+#endif
 #define MyAppPublisher "Your Organization"
 #define MyAppExeName "ICCardManager.exe"
 #define MyAppDescription "交通系ICカードの貸出管理システム"

--- a/ICCardManager/installer/build-installer.ps1
+++ b/ICCardManager/installer/build-installer.ps1
@@ -1,9 +1,10 @@
 ﻿# ICCardManager インストーラービルドスクリプト
 # 使用方法: .\build-installer.ps1 [-SkipBuild] [-Version "1.0.0"]
+# バージョンを指定しない場合、csprojファイルから自動的に読み取ります
 
 param(
     [switch]$SkipBuild,
-    [string]$Version = "1.0.0"
+    [string]$Version = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -15,6 +16,22 @@ $SrcDir = Join-Path $ProjectRoot "src\ICCardManager"
 $PublishDir = Join-Path $ProjectRoot "publish"
 $InstallerScript = Join-Path $ScriptDir "ICCardManager.iss"
 $OutputDir = Join-Path $ScriptDir "output"
+$CsprojPath = Join-Path $SrcDir "ICCardManager.csproj"
+
+# バージョンが指定されていない場合、csprojから読み取る
+if ([string]::IsNullOrEmpty($Version)) {
+    if (Test-Path $CsprojPath) {
+        [xml]$csproj = Get-Content $CsprojPath
+        $Version = $csproj.Project.PropertyGroup.Version | Where-Object { $_ } | Select-Object -First 1
+        if ([string]::IsNullOrEmpty($Version)) {
+            $Version = "1.0.0"
+            Write-Host "警告: csprojからバージョンを読み取れませんでした。デフォルト値を使用します: $Version" -ForegroundColor Yellow
+        }
+    } else {
+        $Version = "1.0.0"
+        Write-Host "警告: csprojファイルが見つかりません。デフォルト値を使用します: $Version" -ForegroundColor Yellow
+    }
+}
 
 # Inno Setup のパス（標準インストール場所）
 $InnoSetupPaths = @(
@@ -30,6 +47,8 @@ $InnoSetupPaths = @(
 Write-Host "======================================" -ForegroundColor Cyan
 Write-Host " ICCardManager インストーラービルド" -ForegroundColor Cyan
 Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "バージョン: $Version" -ForegroundColor Cyan
 Write-Host ""
 
 # Step 1: Inno Setup の確認

--- a/ICCardManager/src/ICCardManager/ICCardManager.csproj
+++ b/ICCardManager/src/ICCardManager/ICCardManager.csproj
@@ -12,9 +12,9 @@
     <PlatformTarget>x86</PlatformTarget>
 
     <!-- バージョン情報 -->
-    <Version>1.0.0</Version>
-    <FileVersion>1.0.0.0</FileVersion>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <Version>1.0.6</Version>
+    <FileVersion>1.0.6.0</FileVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
     <Company>Your Organization</Company>
     <Product>交通系ICカード管理システム</Product>
     <Description>交通系ICカードの貸出管理システム</Description>


### PR DESCRIPTION
## Summary
- インストーラーのバージョンがアプリケーション本体のバージョンと自動的に同期されるようにしました
- `ICCardManager_Setup_1.0.0.exe` → `ICCardManager_Setup_1.0.6.exe`

## 変更内容

### build-installer.ps1
- csprojファイルから`<Version>`タグを自動的に読み取り
- `-Version`パラメータで明示的に指定することも可能（従来通り）
- ビルド開始時に使用するバージョンを表示

### ICCardManager.csproj
- Version: 1.0.0 → 1.0.6
- FileVersion: 1.0.0.0 → 1.0.6.0
- AssemblyVersion: 1.0.0.0 → 1.0.6.0

## 使用方法

```powershell
# 自動（csprojからバージョンを読み取り）
.\build-installer.ps1

# 明示的にバージョン指定
.\build-installer.ps1 -Version "1.0.7"
```

## Test plan
- [ ] `.\build-installer.ps1` を実行
- [ ] 「バージョン: 1.0.6」と表示されることを確認
- [ ] `ICCardManager_Setup_1.0.6.exe` が生成されることを確認

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)