### PR TITLE
docs: 管理者マニュアルにカード種別デフォルト値の注釈を追加 (#413)

### DIFF
--- a/ICCardManager/docs/manual/管理者マニュアル.md
+++ b/ICCardManager/docs/manual/管理者マニュアル.md
@@ -172,7 +172,7 @@
 
 4. 「保存」ボタンをクリック
 
-> **補足**: カード種別はドロップダウンから選択します（はやかけん、nimoca、SUGOCA、Suica、PASMO、ICOCA、PiTaPa、Kitaca、TOICA、manaca、その他）。
+> **補足**: カード種別はドロップダウンから選択します（はやかけん、nimoca、SUGOCA、Suica、PASMO、ICOCA、PiTaPa、Kitaca、TOICA、manaca、その他）。デフォルトは「nimoca」が選択されていますので、登録するカードに合わせて適切な種別を選択してください。
 
 ### 5.3 ICカード情報の編集
 


### PR DESCRIPTION
## Summary
- 管理者マニュアルの「5.2 ICカードの登録」セクションに、カード種別のデフォルト値に関する注釈を追加

## 変更内容

### Before
> カード種別はドロップダウンから選択します（はやかけん、nimoca、SUGOCA...）。

### After
> カード種別はドロップダウンから選択します（はやかけん、nimoca、SUGOCA...）。**デフォルトは「nimoca」が選択されていますので、登録するカードに合わせて適切な種別を選択してください。**

## 背景
新規カード登録時にデフォルトで「nimoca」が選択されているため、ユーザーが意図せずnimocaとして登録してしまう可能性があります。マニュアルに明記することで、適切なカード種別を選択するよう促します。

## Test plan
- [ ] マニュアルの表示を確認

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)