### PR TITLE
docs: 残額警告閾値の設定値範囲を修正 (#417)

### DIFF
--- a/ICCardManager/docs/manual/管理者マニュアル.md
+++ b/ICCardManager/docs/manual/管理者マニュアル.md
@@ -291,7 +291,7 @@
 | 項目 | 説明 | 設定値 |
 |------|------|--------|
 | FontSize | 文字サイズ | Small / Medium / Large / ExtraLarge |
-| WarningBalance | 残額警告閾値 | 0～10000 |
+| WarningBalance | 残額警告閾値 | 0～20000 |
 | SoundEnabled | 操作音 | true / false |
 | AutoBackup.Enabled | 自動バックアップ | true / false |
 | AutoBackup.Path | バックアップ保存先 | フォルダパス |


### PR DESCRIPTION
## Summary
- 管理者マニュアルの残額警告閾値（WarningBalance）の設定値範囲を修正

## 変更内容

| 項目 | Before | After |
|------|--------|-------|
| WarningBalance | 0～10000 | 0～20000 |

## 該当箇所
管理者マニュアル「7.2 設定項目一覧」

## Test plan
- [ ] マニュアルの表示を確認

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)