### PR TITLE
docs: 機能設計書からカード種別自動判別ロジックを削除

### DIFF
--- a/ICCardManager/docs/design/04_機能設計書.md
+++ b/ICCardManager/docs/design/04_機能設計書.md
@@ -294,68 +294,19 @@ IF charge.Balance == usage.Amount AND usage.Balance == 0:
 
 ---
 
-## 6. カード種別自動判別
+## 6. 残高警告機能
 
-### 6.1 判別ロジック
-
-IDmの先頭2バイト（発行者コード）でカード種別を判別する。
-
-| 発行者コード | カード種別 |
-|--------------|------------|
-| 01 | Suica |
-| 02 | PASMO |
-| 03 | ICOCA |
-| 04 | PiTaPa |
-| 05 | nimoca |
-| 06 | SUGOCA |
-| 07 | はやかけん |
-| 08 | Kitaca |
-| 09 | TOICA |
-| 0A | manaca |
-| その他 | Unknown（その他） |
-
-### 6.2 実装
-
-```csharp
-public static CardType DetectFromIdm(string idm)
-{
-    if (string.IsNullOrEmpty(idm) || idm.Length < 2)
-        return CardType.Unknown;
-
-    var issuerCode = idm[..2].ToUpperInvariant();
-
-    return issuerCode switch
-    {
-        "01" => CardType.Suica,
-        "02" => CardType.PASMO,
-        "03" => CardType.ICOCA,
-        "04" => CardType.PiTaPa,
-        "05" => CardType.Nimoca,
-        "06" => CardType.SUGOCA,
-        "07" => CardType.Hayakaken,
-        "08" => CardType.Kitaca,
-        "09" => CardType.TOICA,
-        "0A" => CardType.Manaca,
-        _ => CardType.Unknown
-    };
-}
-```
-
----
-
-## 7. 残高警告機能
-
-### 7.1 概要
+### 6.1 概要
 
 返却時にカード残高が設定された閾値を下回っている場合、警告を表示する。
 
-### 7.2 設定
+### 6.2 設定
 
 - 設定キー: `warning_balance`
 - デフォルト値: 10000円
 - 設定画面から変更可能
 
-### 7.3 警告表示
+### 6.3 警告表示
 
 - サイドバーの警告エリアに表示
 - 背景色: #FFF3E0（薄いオレンジ）
@@ -363,23 +314,23 @@ public static CardType DetectFromIdm(string idm)
 
 ---
 
-## 8. データ自動削除
+## 7. データ自動削除
 
-### 8.1 削除タイミング
+### 7.1 削除タイミング
 
 - アプリケーション起動時に自動実行
 
-### 8.2 削除対象
+### 7.2 削除対象
 
 - 6年以上経過した`ledger`レコード
 - 関連する`ledger_detail`レコード（CASCADE削除）
 
-### 8.3 実装
+### 7.3 実装
 
 ```sql
 DELETE FROM ledger WHERE date < date('now', '-6 years');
 ```
 
-### 8.4 最適化
+### 7.4 最適化
 
 削除後に`VACUUM`コマンドでデータベースファイルを最適化可能（手動実行）。


### PR DESCRIPTION
## Summary

- 機能設計書のセクション6「カード種別自動判別」を完全に削除
- IDmの先頭2バイトでカード種別を判別するという誤った記載を修正

closes #423

## Background

IDmの先頭2バイトは「製造者コード」（カードを製造した会社）であり、「カード種別」（Suica/PASMO等）ではありません。同じSuicaでも製造会社が異なれば先頭2バイトは異なるため、この方法での自動判別は技術的に不可能です。

現在の実装では、カード種別はユーザーが登録時に手動で選択する仕様となっています。

## Changes

| 変更前 | 変更後 |
|--------|--------|
| セクション6: カード種別自動判別 | （削除） |
| セクション7: 残高警告機能 | セクション6: 残高警告機能 |
| セクション8: データ自動削除 | セクション7: データ自動削除 |

## Test plan

- [ ] ドキュメントの整合性を確認（セクション番号の連続性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)