### PR TITLE
fix: 履歴画面の月選択ボタン順序を帳票画面と統一

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -86,20 +86,20 @@
                 </Border>
             </StackPanel>
 
-            <!-- 月選択ボタン -->
+            <!-- 月選択ボタン（使用頻度順: 先月 > 今月。帳票画面と同じ順序） -->
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Content="今月"
-                        Command="{Binding SetThisMonthCommand}"
-                        Padding="12,6"
-                        Margin="0,0,5,0"
-                        AutomationProperties.Name="今月の履歴を表示"
-                        ToolTip="今月の履歴を表示"/>
                 <Button Content="先月"
                         Command="{Binding SetLastMonthCommand}"
                         Padding="12,6"
                         Margin="0,0,5,0"
                         AutomationProperties.Name="先月の履歴を表示"
                         ToolTip="先月の履歴を表示"/>
+                <Button Content="今月"
+                        Command="{Binding SetThisMonthCommand}"
+                        Padding="12,6"
+                        Margin="0,0,5,0"
+                        AutomationProperties.Name="今月の履歴を表示"
+                        ToolTip="今月の履歴を表示"/>
                 <Button x:Name="OtherMonthButton"
                         Content="その他の月..."
                         Command="{Binding OpenMonthSelectorCommand}"


### PR DESCRIPTION
## Summary

- 履歴画面（HistoryDialog）の月選択ボタンの順序を変更
- 帳票画面（ReportDialog）と同じ順序に統一

closes #425

## Changes

| 変更前 | 変更後 |
|--------|--------|
| 今月 → 先月 → その他の月 | 先月 → 今月 → その他の月 |

## Reason

物品出納簿は月末締めのため、帳票作成時に最も使用頻度が高いのは「先月」です。
履歴照会画面も同様に、先月の利用履歴を確認することが多いと考えられるため、
帳票画面と統一した順序にすることでUIの一貫性を保ちます。

## Test plan

- [ ] 履歴画面で月選択ボタンが「先月」「今月」「その他の月」の順に表示されることを確認
- [ ] 帳票画面と同じ順序であることを確認
- [ ] 各ボタンが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)