### PR TITLE
fix: メイン画面の月選択ボタン順序を帳票画面と統一

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -281,17 +281,18 @@
                                 </Border>
                             </StackPanel>
 
+                            <!-- 月選択ボタン（使用頻度順: 先月 > 今月。帳票画面と同じ順序） -->
                             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-                                <Button Content="今月"
-                                        Command="{Binding HistorySetThisMonthCommand}"
-                                        Padding="12,6"
-                                        Margin="0,0,5,0"
-                                        ToolTip="今月の履歴を表示"/>
                                 <Button Content="先月"
                                         Command="{Binding HistorySetLastMonthCommand}"
                                         Padding="12,6"
                                         Margin="0,0,5,0"
                                         ToolTip="先月の履歴を表示"/>
+                                <Button Content="今月"
+                                        Command="{Binding HistorySetThisMonthCommand}"
+                                        Padding="12,6"
+                                        Margin="0,0,5,0"
+                                        ToolTip="今月の履歴を表示"/>
                                 <Button x:Name="HistoryOtherMonthButton"
                                         Content="その他の月..."
                                         Command="{Binding HistoryOpenMonthSelectorCommand}"


### PR DESCRIPTION
## Summary

- メイン画面（MainWindow.xaml）の履歴表示エリアの月選択ボタン順序を変更
- 帳票画面（ReportDialog）、履歴ダイアログ（HistoryDialog）と同じ順序に統一

closes #425

## Background

Issue #425 では履歴画面の月選択順序を帳票画面と統一することが求められていました。
PR #430 で HistoryDialog.xaml を修正しましたが、メイン画面内の履歴表示エリア（MainWindow.xaml）にも同じUIがあり、そちらの修正が漏れていました。

## Changes

| 変更前 | 変更後 |
|--------|--------|
| 今月 → 先月 → その他の月 | 先月 → 今月 → その他の月 |

## Files Changed

- `src/ICCardManager/Views/MainWindow.xaml` - 履歴表示エリアの月選択ボタン順序を変更

## Test plan

- [x] メイン画面で月選択ボタンが「先月」「今月」「その他の月」の順に表示されることを確認
- [ ] 帳票画面、履歴ダイアログと同じ順序であることを確認
- [x] 各ボタンが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)