### PR TITLE
fix: 履歴画面の払出金額を正数で表示 (#441)

### DIFF
--- a/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
@@ -80,7 +80,7 @@ namespace ICCardManager.Dtos
         /// <summary>
         /// 表示用: 払出金額（金額がある場合のみ表示）
         /// </summary>
-        public string ExpenseDisplay => Expense > 0 ? $"-{Expense:N0}" : "";
+        public string ExpenseDisplay => Expense > 0 ? $"{Expense:N0}" : "";
 
         /// <summary>
         /// 表示用: 残額

--- a/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
@@ -274,7 +274,7 @@ public class DtoMapperTests
     /// 払出金額の表示プロパティが正しいこと
     /// </summary>
     [Theory]
-    [InlineData(210, "-210")]
+    [InlineData(210, "210")]
     [InlineData(0, "")]
     public void LedgerDto_ExpenseDisplay_ShouldFormatCorrectly(int expense, string expected)
     {

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
@@ -644,7 +644,7 @@ public class HistoryViewModelTests
         displayItem.StaffName.Should().Be("田中太郎");
         displayItem.Note.Should().Be("テスト");
         displayItem.IncomeDisplay.Should().BeEmpty();
-        displayItem.ExpenseDisplay.Should().Be("-260");
+        displayItem.ExpenseDisplay.Should().Be("260");
         displayItem.BalanceDisplay.Should().Be("1,240");
     }
 


### PR DESCRIPTION
## Summary
- 履歴画面の払出金額表示から負号を削除
- 物品出納簿との表示形式を統一

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| -210 | 210 |
| -1,500 | 1,500 |

### 修正ファイル
- `src/ICCardManager/Dtos/LedgerDto.cs`
  - `ExpenseDisplay` プロパティの書式変更: `$"-{Expense:N0}"` → `$"{Expense:N0}"`

### テスト更新
- `tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs`
- `tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs`

## 理由
- 払出金額（Expense）は既に正の値として保存されている
- UIでは色（OrangeRed）とフォント（Bold）で支出であることを表現済み
- 物品出納簿では正数で表示されており、整合性を取る必要がある

## Test plan
- [x] 履歴画面で払出金額が正数で表示されることを確認
- [x] 物品出納簿と同じ形式で表示されることを確認
- [x] 関連テストが通ることを確認

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)