### PR TITLE
fix: 手動新規登録時にカード残高を事前読み取り (#443)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -698,6 +698,19 @@ namespace ICCardManager.ViewModels
                 StatusMessage = "カードを読み取りました。カード種別を確認してください。";
                 IsStatusError = false;
 
+                // Issue #443対応: カード読み取り時点で残高を事前取得
+                // カードがリーダーにある間に残高を読み取り、保存時に使用する
+                // これにより、ユーザーがフォーム入力中にカードを離しても正しい残高で登録できる
+                try
+                {
+                    _preReadBalance = await _cardReader.ReadBalanceAsync(e.Idm);
+                }
+                catch
+                {
+                    // 残高読み取り失敗時はnullのまま（CreateNewPurchaseLedgerAsyncで再試行される）
+                    _preReadBalance = null;
+                }
+
                 // 注意: App.IsCardRegistrationActive はここで解除しない
                 // ダイアログが開いている間は常にフラグを維持し、
                 // CancelEdit() または Cleanup() でのみ解除する


### PR DESCRIPTION
## Summary
- カード管理画面で手動新規登録モードを開始した場合、カード読み取り時点で残高を事前取得するように修正
- ユーザーがフォーム入力中にカードをリーダーから離しても、正しい残高で新規購入レコードが作成される

## 問題の原因
手動新規登録フローでは、`OnCardRead()`時点で残高を読み取っていなかった。
保存時（`SaveAsync`）に`ReadBalanceAsync()`を呼び出すが、その時点でカードがリーダーにない可能性が高く、結果として新規購入レコードが作成されず残高が0になっていた。

## 修正内容
### CardManageViewModel.cs
- `OnCardRead()`で未登録カード検出時に`ReadBalanceAsync()`を呼び出し
- 取得した残高を`_preReadBalance`に保存
- 保存時に`CreateNewPurchaseLedgerAsync()`で使用

## Test plan
- [x] 全967件のテストがパス
- [x] 事前読み取り残高による新規購入レコード作成テスト追加
- [x] フォールバック（保存時読み取り）テスト追加  
- [x] 残高読み取り失敗時のテスト追加
- [ ] 実機での動作確認

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)