### PR TITLE
feat: 職員管理画面とカード管理画面をESCキーで閉じられるように (#445)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -12,8 +12,9 @@
         Width="900"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        KeyDown="Window_KeyDown"
         AutomationProperties.Name="交通系ICカード管理ダイアログ"
-        AutomationProperties.HelpText="交通系ICカードの登録・編集・削除ができます。カードをタッチして新規登録できます。">
+        AutomationProperties.HelpText="交通系ICカードの登録・編集・削除ができます。カードをタッチして新規登録できます。Escキーで閉じます。">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Input;
 using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
@@ -88,6 +89,18 @@ namespace ICCardManager.Views.Dialogs
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             Close();
+        }
+
+        /// <summary>
+        /// キー入力処理（Issue #445対応: ESCキーで閉じる）
+        /// </summary>
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+                e.Handled = true;
+            }
         }
     }
 }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -13,8 +13,9 @@
         Width="850"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        KeyDown="Window_KeyDown"
         AutomationProperties.Name="職員管理ダイアログ"
-        AutomationProperties.HelpText="職員の登録・編集・削除ができます。職員証をタッチして新規登録できます。">
+        AutomationProperties.HelpText="職員の登録・編集・削除ができます。職員証をタッチして新規登録できます。Escキーで閉じます。">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Input;
 using ICCardManager.Common;
 using ICCardManager.ViewModels;
 
@@ -65,6 +66,18 @@ namespace ICCardManager.Views.Dialogs
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             Close();
+        }
+
+        /// <summary>
+        /// キー入力処理（Issue #445対応: ESCキーで閉じる）
+        /// </summary>
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+                e.Handled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- 職員管理画面（StaffManageDialog）をESCキーで閉じられるように対応
- 交通系ICカード管理画面（CardManageDialog）をESCキーで閉じられるように対応

## 変更内容

### StaffManageDialog
- `KeyDown="Window_KeyDown"` イベントハンドラを追加
- ESCキー押下時に `Close()` を呼び出す処理を追加
- アクセシビリティヘルプテキストに「Escキーで閉じます」を追加

### CardManageDialog
- `KeyDown="Window_KeyDown"` イベントハンドラを追加
- ESCキー押下時に `Close()` を呼び出す処理を追加
- アクセシビリティヘルプテキストに「Escキーで閉じます」を追加

## 実装方法
WPFの標準的なKeyDownイベント処理パターンを採用しました。ダイアログを閉じるというView固有の処理のため、MVVMのCommandパターンではなく、コードビハインドでの直接処理が適切と判断しました。

## Test plan
- [x] 職員管理画面を開き、ESCキーを押すと閉じることを確認
- [x] カード管理画面を開き、ESCキーを押すと閉じることを確認
- [ ] テキストボックスにフォーカスがある状態でもESCキーで閉じることを確認
- [ ] 完了ボタンでも従来通り閉じられることを確認

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)