### PR TITLE
fix: 払い戻しボタンが機能しない問題を修正 (#446)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -725,6 +725,7 @@ namespace ICCardManager.ViewModels
             // コマンドの実行可否を再評価
             StartEditCommand.NotifyCanExecuteChanged();
             DeleteCommand.NotifyCanExecuteChanged();
+            RefundCommand.NotifyCanExecuteChanged();  // Issue #446対応: 払い戻しボタンの状態も更新
 
             // 新規登録モード中は選択変更を無視
             if (IsNewCard) return;


### PR DESCRIPTION
## Summary
交通系ICカード管理画面の「払い戻し」ボタンがカードを選択しても有効にならない問題を修正しました。

## 原因
`OnSelectedCardChanged`メソッドで、`StartEditCommand`と`DeleteCommand`の`NotifyCanExecuteChanged()`は呼び出されていましたが、`RefundCommand`の`NotifyCanExecuteChanged()`が呼び出されていませんでした。

これにより、`SelectedCard`が変更されても`RefundCommand`の`CanExecute`が再評価されず、払い戻しボタンが常に無効のままになっていました。

## 修正内容
`OnSelectedCardChanged`に`RefundCommand.NotifyCanExecuteChanged()`の呼び出しを追加しました。

```csharp
partial void OnSelectedCardChanged(CardDto? value)
{
    // コマンドの実行可否を再評価
    StartEditCommand.NotifyCanExecuteChanged();
    DeleteCommand.NotifyCanExecuteChanged();
    RefundCommand.NotifyCanExecuteChanged();  // Issue #446対応: 払い戻しボタンの状態も更新
    ...
}
```

## Test plan
- [x] カード管理画面を開く
- [x] カードを選択する
- [x] 「払い戻し」ボタンが有効になることを確認
- [ ] 貸出中のカードを選択した場合、「払い戻し」ボタンが無効のままであることを確認
- [x] 「払い戻し」ボタンをクリックして、確認ダイアログが表示されることを確認

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)