### PR TITLE
fix: デバッグビューアのDBパスをCommonApplicationDataに修正

### DIFF
--- a/ICCardManager/tools/DebugDataViewer/App.xaml.cs
+++ b/ICCardManager/tools/DebugDataViewer/App.xaml.cs
@@ -158,7 +158,7 @@ namespace DebugDataViewer
             // 優先順位:
             // 1. コマンドライン引数
             // 2. 実行ファイルと同じディレクトリ
-            // 3. メインアプリの標準パス
+            // 3. メインアプリの標準パス (CommonApplicationData = C:\ProgramData)
 
             var args = Environment.GetCommandLineArgs();
             if (args.Length > 1 && File.Exists(args[1]))
@@ -173,9 +173,10 @@ namespace DebugDataViewer
                 return localDb;
             }
 
-            // メインアプリの標準パス
+            // メインアプリの標準パス (C:\ProgramData\ICCardManager\iccard.db)
+            // メインアプリはCommonApplicationDataを使用して全ユーザーで共有している
             var appDataPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                 "ICCardManager",
                 "iccard.db");
             if (File.Exists(appDataPath))
@@ -183,8 +184,8 @@ namespace DebugDataViewer
                 return appDataPath;
             }
 
-            // 見つからない場合はデフォルトパスを返す（DbContextが初期化する）
-            return localDb;
+            // 見つからない場合はCommonApplicationDataのパスを返す（メインアプリと同じ場所）
+            return appDataPath;
         }
 
         protected override void OnExit(ExitEventArgs e)


### PR DESCRIPTION
## Summary
- DebugDataViewerのDBデータタブで「unable to open database file」エラーが発生する問題を修正
- データベースパスの参照先をメインアプリと同じ場所に修正

## 原因
| アプリ | 参照パス |
|--------|----------|
| メインアプリ (ICCardManager) | `C:\ProgramData\ICCardManager\iccard.db` (CommonApplicationData) |
| DebugDataViewer (修正前) | `C:\Users\{user}\AppData\Local\ICCardManager\iccard.db` (LocalApplicationData) |

パスの不一致により、DebugDataViewerがデータベースファイルを見つけられませんでした。

## 修正内容
`SpecialFolder.LocalApplicationData` を `SpecialFolder.CommonApplicationData` に変更し、メインアプリと同じ場所を参照するように修正。

## Test plan
- [x] DebugDataViewerを起動
- [x] 画面右下のDBパスが`C:\ProgramData\ICCardManager\iccard.db`になっていることを確認
- [x] DBデータタブでテーブルデータが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)