### PR TITLE
feat: 重要な操作の前に職員証タッチを必須とする (#429)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -58,6 +58,12 @@ namespace ICCardManager
         public static bool IsCardRegistrationActive { get; set; }
 
         /// <summary>
+        /// 職員証認証モードが有効かどうか（MainViewModelでのカード処理を抑制するため）
+        /// Issue #429: 重要な操作の前に職員証タッチを必須とする
+        /// </summary>
+        public static bool IsAuthenticationActive { get; set; }
+
+        /// <summary>
         /// DEBUGビルドかどうか（XAMLからデバッグ用UIの表示制御に使用: Issue #289）
         /// </summary>
         public static bool IsDebugBuild
@@ -178,6 +184,7 @@ namespace ICCardManager
             services.AddSingleton<CsvImportService>();
             services.AddSingleton<IToastNotificationService, ToastNotificationService>();
             services.AddSingleton<IDialogService, DialogService>();
+            services.AddSingleton<IStaffAuthService, StaffAuthService>();
 
             // Infrastructure層
     #if DEBUG

--- a/ICCardManager/src/ICCardManager/Services/IStaffAuthService.cs
+++ b/ICCardManager/src/ICCardManager/Services/IStaffAuthService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 職員認証サービスのインターフェース
+    /// </summary>
+    public interface IStaffAuthService
+    {
+        /// <summary>
+        /// 職員証による認証を要求
+        /// </summary>
+        /// <param name="operationDescription">操作内容の説明（ダイアログに表示）</param>
+        /// <returns>認証結果（成功時はIDmと職員名、失敗/キャンセル時はnull）</returns>
+        Task<StaffAuthResult?> RequestAuthenticationAsync(string operationDescription);
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/StaffAuthResult.cs
+++ b/ICCardManager/src/ICCardManager/Services/StaffAuthResult.cs
@@ -1,0 +1,18 @@
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 職員認証の結果
+    /// </summary>
+    public class StaffAuthResult
+    {
+        /// <summary>
+        /// 認証された職員のIDm
+        /// </summary>
+        public string Idm { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 認証された職員の氏名
+        /// </summary>
+        public string StaffName { get; set; } = string.Empty;
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/StaffAuthService.cs
+++ b/ICCardManager/src/ICCardManager/Services/StaffAuthService.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using System.Windows;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.CardReader;
+using ICCardManager.Infrastructure.Sound;
+using ICCardManager.Views.Dialogs;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 職員認証サービスの実装
+    /// </summary>
+    /// <remarks>
+    /// Issue #429: 重要な操作の前に職員証タッチを必須とする
+    /// </remarks>
+    public class StaffAuthService : IStaffAuthService
+    {
+        private readonly IStaffRepository _staffRepository;
+        private readonly ICardReader _cardReader;
+        private readonly ISoundPlayer _soundPlayer;
+
+        public StaffAuthService(
+            IStaffRepository staffRepository,
+            ICardReader cardReader,
+            ISoundPlayer soundPlayer)
+        {
+            _staffRepository = staffRepository;
+            _cardReader = cardReader;
+            _soundPlayer = soundPlayer;
+        }
+
+        /// <inheritdoc/>
+        public Task<StaffAuthResult?> RequestAuthenticationAsync(string operationDescription)
+        {
+            var dialog = new StaffAuthDialog(_staffRepository, _cardReader, _soundPlayer)
+            {
+                Owner = Application.Current.MainWindow,
+                OperationDescription = operationDescription
+            };
+
+            if (dialog.ShowDialog() == true && dialog.IsAuthenticated)
+            {
+                return Task.FromResult<StaffAuthResult?>(new StaffAuthResult
+                {
+                    Idm = dialog.AuthenticatedIdm!,
+                    StaffName = dialog.AuthenticatedStaffName!
+                });
+            }
+
+            return Task.FromResult<StaffAuthResult?>(null);
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/LedgerEditViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/LedgerEditViewModel.cs
@@ -23,6 +23,11 @@ namespace ICCardManager.ViewModels
         private string _cardIdm = string.Empty;
 
         /// <summary>
+        /// 操作者の職員IDm（Issue #429: 認証済み職員のIDm）
+        /// </summary>
+        private string? _operatorIdm;
+
+        /// <summary>
         /// ステータスメッセージ
         /// </summary>
         [ObservableProperty]
@@ -109,9 +114,13 @@ namespace ICCardManager.ViewModels
         /// <summary>
         /// 履歴データで初期化
         /// </summary>
-        public Task InitializeAsync(LedgerDto ledger)
+        /// <param name="ledger">編集対象の履歴データ</param>
+        /// <param name="operatorIdm">操作者の職員IDm（Issue #429: 認証済み職員のIDm）</param>
+        public Task InitializeAsync(LedgerDto ledger, string? operatorIdm = null)
         {
             if (ledger == null) return Task.CompletedTask;
+
+            _operatorIdm = operatorIdm;
 
             IsBusy = true;
             BusyMessage = "読み込み中...";
@@ -197,8 +206,8 @@ namespace ICCardManager.ViewModels
 
                 if (result)
                 {
-                    // 操作ログを記録（GUI操作のためoperatorIdmはnull）
-                    await _operationLogger.LogLedgerUpdateAsync(null, beforeLedger, ledger);
+                    // 操作ログを記録（Issue #429: 認証済み職員のIDmを使用）
+                    await _operationLogger.LogLedgerUpdateAsync(_operatorIdm, beforeLedger, ledger);
 
                     IsSaved = true;
                 }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerEditDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerEditDialog.xaml.cs
@@ -43,6 +43,16 @@ namespace ICCardManager.Views.Dialogs
         }
 
         /// <summary>
+        /// 認証済みIDmを含めて履歴データで初期化
+        /// </summary>
+        /// <param name="ledger">編集対象の履歴データ</param>
+        /// <param name="operatorIdm">認証済み職員のIDm（Issue #429）</param>
+        public async Task InitializeWithAuthAsync(LedgerDto ledger, string operatorIdm)
+        {
+            await _viewModel.InitializeAsync(ledger, operatorIdm);
+        }
+
+        /// <summary>
         /// キャンセルボタンクリック
         /// </summary>
         private void CancelButton_Click(object sender, RoutedEventArgs e)

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
@@ -1,0 +1,85 @@
+<Window x:Class="ICCardManager.Views.Dialogs.StaffAuthDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="職員証による認証"
+        Height="320"
+        Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        AutomationProperties.Name="職員証認証ダイアログ"
+        AutomationProperties.HelpText="重要な操作を行うために職員証による認証が必要です">
+
+    <Grid Margin="25">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- アイコンとタイトル -->
+        <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,20">
+            <TextBlock Text="🔐" FontSize="48" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+            <TextBlock Text="職員証をタッチしてください"
+                       FontSize="{DynamicResource LargeFontSize}"
+                       FontWeight="Bold"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
+        <!-- 操作内容の説明 -->
+        <Border Grid.Row="1" Background="#E3F2FD" CornerRadius="4" Padding="12" Margin="0,0,0,15">
+            <StackPanel>
+                <TextBlock Text="操作内容:"
+                           FontSize="{DynamicResource SmallFontSize}"
+                           Foreground="#666"
+                           Margin="0,0,0,3"/>
+                <TextBlock x:Name="OperationDescriptionText"
+                           Text="履歴の編集"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           FontWeight="SemiBold"
+                           Foreground="#1565C0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- ステータスメッセージ -->
+        <Border x:Name="StatusBorder" Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,0,0,15"
+                Background="#FFF3E0" Visibility="Collapsed">
+            <TextBlock x:Name="StatusText"
+                       Text=""
+                       FontSize="{DynamicResource BaseFontSize}"
+                       TextWrapping="Wrap"
+                       Foreground="#E65100"
+                       HorizontalAlignment="Center"/>
+        </Border>
+
+        <!-- タイムアウト表示 -->
+        <StackPanel Grid.Row="3" HorizontalAlignment="Center" Margin="0,0,0,20">
+            <TextBlock Text="残り時間:"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       Foreground="#666"
+                       HorizontalAlignment="Center"/>
+            <TextBlock x:Name="TimeoutText"
+                       Text="60秒"
+                       FontSize="{DynamicResource LargeFontSize}"
+                       FontWeight="Bold"
+                       Foreground="#1976D2"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
+        <!-- キャンセルボタン -->
+        <Button x:Name="CancelButton"
+                Grid.Row="4"
+                Content="キャンセル"
+                Width="120"
+                Height="40"
+                HorizontalAlignment="Center"
+                FontSize="{DynamicResource BaseFontSize}"
+                IsCancel="True"
+                Click="CancelButton_Click"
+                AutomationProperties.Name="キャンセル"
+                AutomationProperties.HelpText="認証をキャンセルします"
+                ToolTip="認証をキャンセル (Escape)"/>
+    </Grid>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.CardReader;
+using ICCardManager.Infrastructure.Sound;
+
+namespace ICCardManager.Views.Dialogs
+{
+    /// <summary>
+    /// 職員証認証ダイアログ
+    /// </summary>
+    /// <remarks>
+    /// Issue #429: 重要な操作の前に職員証タッチを必須とする
+    /// </remarks>
+    public partial class StaffAuthDialog : Window
+    {
+        private readonly IStaffRepository _staffRepository;
+        private readonly ICardReader _cardReader;
+        private readonly ISoundPlayer _soundPlayer;
+        private readonly DispatcherTimer _timeoutTimer;
+        private int _remainingSeconds = 60;
+
+        /// <summary>
+        /// 認証成功時の職員IDm
+        /// </summary>
+        public string? AuthenticatedIdm { get; private set; }
+
+        /// <summary>
+        /// 認証成功時の職員名
+        /// </summary>
+        public string? AuthenticatedStaffName { get; private set; }
+
+        /// <summary>
+        /// 認証が成功したかどうか
+        /// </summary>
+        public bool IsAuthenticated => !string.IsNullOrEmpty(AuthenticatedIdm);
+
+        /// <summary>
+        /// 操作内容の説明
+        /// </summary>
+        public string OperationDescription
+        {
+            get => OperationDescriptionText.Text;
+            set => OperationDescriptionText.Text = value;
+        }
+
+        public StaffAuthDialog(
+            IStaffRepository staffRepository,
+            ICardReader cardReader,
+            ISoundPlayer soundPlayer)
+        {
+            InitializeComponent();
+
+            _staffRepository = staffRepository;
+            _cardReader = cardReader;
+            _soundPlayer = soundPlayer;
+
+            // タイムアウトタイマーの設定
+            _timeoutTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(1)
+            };
+            _timeoutTimer.Tick += OnTimeoutTick;
+
+            // イベント購読
+            Loaded += OnLoaded;
+            Closed += OnClosed;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            // 認証モードを有効化（MainViewModelのカード処理を抑制）
+            App.IsAuthenticationActive = true;
+
+            // カード読み取りイベントを購読
+            _cardReader.CardRead += OnCardRead;
+
+            // タイムアウトタイマー開始
+            _timeoutTimer.Start();
+        }
+
+        private void OnClosed(object? sender, EventArgs e)
+        {
+            // タイマー停止
+            _timeoutTimer.Stop();
+
+            // カード読み取りイベントを解除
+            _cardReader.CardRead -= OnCardRead;
+
+            // 認証モードを解除
+            App.IsAuthenticationActive = false;
+        }
+
+        private void OnTimeoutTick(object? sender, EventArgs e)
+        {
+            _remainingSeconds--;
+            TimeoutText.Text = $"{_remainingSeconds}秒";
+
+            if (_remainingSeconds <= 10)
+            {
+                // 10秒以下は赤色で表示
+                TimeoutText.Foreground = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xD3, 0x2F, 0x2F));
+            }
+
+            if (_remainingSeconds <= 0)
+            {
+                // タイムアウト
+                _timeoutTimer.Stop();
+                _soundPlayer.Play(SoundType.Warning);
+                ShowStatus("認証がタイムアウトしました", isError: true);
+
+                // 少し待ってから閉じる
+                var closeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                closeTimer.Tick += (s, args) =>
+                {
+                    closeTimer.Stop();
+                    DialogResult = false;
+                    Close();
+                };
+                closeTimer.Start();
+            }
+        }
+
+        private async void OnCardRead(object? sender, CardReadEventArgs e)
+        {
+            await Dispatcher.InvokeAsync(async () =>
+            {
+                try
+                {
+                    // 職員として登録されているか確認
+                    var staff = await _staffRepository.GetByIdmAsync(e.Idm);
+
+                    if (staff != null)
+                    {
+                        // 職員として登録されている → 認証成功
+                        AuthenticatedIdm = e.Idm;
+                        AuthenticatedStaffName = staff.Name;
+
+                        _soundPlayer.Play(SoundType.Lend);
+                        _timeoutTimer.Stop();
+
+                        DialogResult = true;
+                        Close();
+                    }
+                    else
+                    {
+                        // 職員として登録されていない → エラー
+                        _soundPlayer.Play(SoundType.Error);
+                        ShowStatus("このカードは職員証として登録されていません。\n登録済みの職員証をタッチしてください。", isError: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ShowStatus($"エラー: {ex.Message}", isError: true);
+                }
+            });
+        }
+
+        private void ShowStatus(string message, bool isError)
+        {
+            StatusText.Text = message;
+            StatusBorder.Visibility = Visibility.Visible;
+
+            if (isError)
+            {
+                StatusBorder.Background = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xFF, 0xEB, 0xEE));
+                StatusText.Foreground = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xC6, 0x28, 0x28));
+            }
+            else
+            {
+                StatusBorder.Background = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xE8, 0xF5, 0xE9));
+                StatusText.Foreground = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0x2E, 0x7D, 0x32));
+            }
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -29,6 +29,7 @@ public class CardManageViewModelTests
     private readonly Mock<IStaffRepository> _staffRepositoryMock;
     private readonly Mock<OperationLogger> _operationLoggerMock;
     private readonly Mock<IDialogService> _dialogServiceMock;
+    private readonly Mock<IStaffAuthService> _staffAuthServiceMock;
     private readonly CardTypeDetector _cardTypeDetector;
     private readonly CardManageViewModel _viewModel;
 
@@ -40,6 +41,7 @@ public class CardManageViewModelTests
         _validationServiceMock = new Mock<IValidationService>();
         _staffRepositoryMock = new Mock<IStaffRepository>();
         _dialogServiceMock = new Mock<IDialogService>();
+        _staffAuthServiceMock = new Mock<IStaffAuthService>();
         _cardTypeDetector = new CardTypeDetector();
 
         // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
@@ -55,6 +57,10 @@ public class CardManageViewModelTests
         _dialogServiceMock.Setup(d => d.ShowConfirmation(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
         _dialogServiceMock.Setup(d => d.ShowWarningConfirmation(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 
+        // 認証はデフォルトで成功を返す（Issue #429）
+        _staffAuthServiceMock.Setup(s => s.RequestAuthenticationAsync(It.IsAny<string>()))
+            .ReturnsAsync(new StaffAuthResult { Idm = "TEST_OPERATOR_IDM", StaffName = "テスト操作者" });
+
         _viewModel = new CardManageViewModel(
             _cardRepositoryMock.Object,
             _ledgerRepositoryMock.Object,
@@ -62,7 +68,8 @@ public class CardManageViewModelTests
             _cardTypeDetector,
             _validationServiceMock.Object,
             _operationLoggerMock.Object,
-            _dialogServiceMock.Object);
+            _dialogServiceMock.Object,
+            _staffAuthServiceMock.Object);
     }
 
     #region カード一覧読み込みテスト

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
@@ -27,6 +27,7 @@ public class StaffManageViewModelTests
     private readonly Mock<IValidationService> _validationServiceMock;
     private readonly Mock<OperationLogger> _operationLoggerMock;
     private readonly Mock<IDialogService> _dialogServiceMock;
+    private readonly Mock<IStaffAuthService> _staffAuthServiceMock;
     private readonly StaffManageViewModel _viewModel;
 
     public StaffManageViewModelTests()
@@ -35,6 +36,7 @@ public class StaffManageViewModelTests
         _cardReaderMock = new Mock<ICardReader>();
         _validationServiceMock = new Mock<IValidationService>();
         _dialogServiceMock = new Mock<IDialogService>();
+        _staffAuthServiceMock = new Mock<IStaffAuthService>();
 
         // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
@@ -48,12 +50,17 @@ public class StaffManageViewModelTests
         _dialogServiceMock.Setup(d => d.ShowConfirmation(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
         _dialogServiceMock.Setup(d => d.ShowWarningConfirmation(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
 
+        // 認証はデフォルトで成功を返す（Issue #429）
+        _staffAuthServiceMock.Setup(s => s.RequestAuthenticationAsync(It.IsAny<string>()))
+            .ReturnsAsync(new StaffAuthResult { Idm = "TEST_OPERATOR_IDM", StaffName = "テスト操作者" });
+
         _viewModel = new StaffManageViewModel(
             _staffRepositoryMock.Object,
             _cardReaderMock.Object,
             _validationServiceMock.Object,
             _operationLoggerMock.Object,
-            _dialogServiceMock.Object);
+            _dialogServiceMock.Object,
+            _staffAuthServiceMock.Object);
     }
 
     #region 職員一覧読み込みテスト


### PR DESCRIPTION
## Summary
- 操作履歴（operation_log）に「誰が操作したか」を正確に記録するため、重要な操作の前に職員証タッチによる認証を必須とする機能を追加
- 認証成功時は職員IDmがoperation_logに記録される（従来は「GUI操作」として記録されていた）

## 認証が必要な操作（バランス重視）

| 操作 | 対象 | 認証タイミング |
|------|------|----------------|
| 履歴の編集 | LedgerEditDialog | ダイアログを開く時 |
| 履歴の削除 | LedgerEditDialog内 | (編集と同時に認証済み) |
| 職員の削除 | StaffManageDialog内 | 削除ボタン押下時 |
| ICカードの削除 | CardManageDialog内 | 削除ボタン押下時 |

## 新規ファイル

| ファイル | 説明 |
|----------|------|
| `StaffAuthDialog.xaml/.cs` | 職員証認証ダイアログ（60秒タイムアウト付き） |
| `IStaffAuthService.cs` | 認証サービスインターフェース |
| `StaffAuthService.cs` | 認証サービス実装 |
| `StaffAuthResult.cs` | 認証結果クラス |

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `App.xaml.cs` | IsAuthenticationActiveフラグ追加、DI登録 |
| `MainViewModel.cs` | EditLedgerコマンドに認証追加、カード読み取り制御 |
| `LedgerEditViewModel.cs` | operatorIdm対応 |
| `StaffManageViewModel.cs` | DeleteAsyncに認証追加 |
| `CardManageViewModel.cs` | DeleteAsyncに認証追加 |

## Test plan
- [x] 履歴を選択して編集ボタン → 認証ダイアログが表示される
- [x] 職員証をタッチ → 編集ダイアログが開く
- [ ] 編集を保存 → operation_logに職員IDmが記録される
- [ ] 職員管理で職員を選択して削除 → 認証ダイアログが表示される
- [ ] カード管理でカードを選択して削除 → 認証ダイアログが表示される
- [ ] 認証ダイアログでキャンセル → 操作が中断される
- [ ] 60秒待機 → タイムアウトで操作が中断される
- [x] 職員証以外のカードをタッチ → エラーメッセージが表示される

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)