### PR TITLE
fix: 利用履歴詳細の表示順を修正 (#392)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -428,7 +428,7 @@ LIMIT @pageSize OFFSET @offset";
        bus_stops, amount, balance, is_charge, is_point_redemption, is_bus
 FROM ledger_detail
 WHERE ledger_id = @ledgerId
-ORDER BY use_date ASC";
+ORDER BY use_date ASC, balance DESC";
 
             command.Parameters.AddWithValue("@ledgerId", ledgerId);
 


### PR DESCRIPTION
## Summary
- PR #393 の追加修正
- 利用履歴詳細で同じ日時の取引が正しい順序で表示されない問題を修正

## 問題

利用履歴詳細ダイアログで、同じ日時の取引が新しい順（残高の低い順）で表示されていた。

**現在の表示（誤り）:**
| 日時 | 区間 | 残高 |
|------|------|------|
| 2026/02/02 00:00 | 博多〜薬院 | 6,916円 |
| 2026/02/02 00:00 | 薬院〜博多 | 7,126円 |

**正しい表示（古い順）:**
| 日時 | 区間 | 残高 |
|------|------|------|
| 2026/02/02 00:00 | 薬院〜博多 | 7,126円 |
| 2026/02/02 00:00 | 博多〜薬院 | 6,916円 |

## 原因

`GetDetailsAsync`メソッドの`ORDER BY use_date ASC`だけでは、同じ日時の取引の順序が不定だった。

## 修正内容

```sql
-- 修正前
ORDER BY use_date ASC

-- 修正後
ORDER BY use_date ASC, balance DESC
```

残高が高い = より古い取引（ICカードは使用するたびに残高が減る）なので、残高の降順をセカンダリソートキーとして追加。

## Test plan
- [ ] 同じ日に複数回利用した履歴の詳細を表示
- [ ] 古い取引（残高が高い方）が先に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)