### PR TITLE
fix: 履歴詳細の表示順を時系列順に修正 (#393)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -424,11 +424,14 @@ LIMIT @pageSize OFFSET @offset";
             var details = new List<LedgerDetail>();
 
             using var command = connection.CreateCommand();
+            // Issue #393: 履歴詳細を古い順（時系列順）で表示
+            // use_dateだけでは同日の順序が不定になるため、rowid（挿入順序）で補完
+            // rowid昇順 = ICカードから読み取った順序 = 古い取引から順
             command.CommandText = @"SELECT ledger_id, use_date, entry_station, exit_station,
        bus_stops, amount, balance, is_charge, is_point_redemption, is_bus
 FROM ledger_detail
 WHERE ledger_id = @ledgerId
-ORDER BY use_date ASC";
+ORDER BY use_date ASC, rowid ASC";
 
             command.Parameters.AddWithValue("@ledgerId", ledgerId);
 


### PR DESCRIPTION
## Summary
- PR #393で履歴（ledger）の表示順は修正されたが、履歴詳細（ledger_detail）の表示順に問題が残っていた
- 同じ日付内での順序が不定で、チャージが間に入った場合に正しい時系列順にならなかった
- `rowid`（SQLiteの挿入順序）を第2ソートキーとして使用することで修正

## Technical Details
- `ORDER BY use_date ASC` → `ORDER BY use_date ASC, rowid ASC`
- rowidはICカードから読み取った順序（＝古い取引順）を保持している

## Test plan
- [ ] 履歴編集画面で詳細が古い順（時系列順）で表示されることを確認
- [ ] チャージが取引の間に入っている履歴でも正しい順序で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)