### PR TITLE
feat: アプリの画面上にバージョン番号を表示する (#475)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -78,6 +78,19 @@ namespace ICCardManager
             }
         }
 
+        /// <summary>
+        /// アプリケーションのバージョン番号（XAMLからバインド可能: Issue #475）
+        /// </summary>
+        public static string AppVersion
+        {
+            get
+            {
+                var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+                // Major.Minor.Build 形式で返す（Revisionは省略）
+                return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "不明";
+            }
+        }
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -848,6 +848,16 @@
                     </Button>
                 </StackPanel>
             </StatusBarItem>
+            <Separator/>
+            <!-- バージョン表示（Issue #475） -->
+            <StatusBarItem HorizontalAlignment="Right"
+                           AutomationProperties.Name="アプリケーションバージョン">
+                <TextBlock Foreground="Gray"
+                           ToolTip="アプリケーションのバージョン番号">
+                    <Run Text="Ver. "/>
+                    <Run Text="{Binding Source={x:Static app:App.AppVersion}, Mode=OneTime}"/>
+                </TextBlock>
+            </StatusBarItem>
         </StatusBar>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- ステータスバーの右端にバージョン番号を表示する機能を追加
- バージョンは csproj の `<Version>` 要素から自動取得

## 変更内容

### App.xaml.cs
- `AppVersion` 静的プロパティを追加
- `Assembly.GetExecutingAssembly().GetName().Version` でバージョン取得
- `Major.Minor.Build` 形式で返す（例: `1.1.0`）

### MainWindow.xaml
- ステータスバーの右端にバージョン表示を追加
- グレー色で控えめに表示
- ツールチップあり

## 表示例
```
状態: 職員証待機中 | 登録カード: 5 枚 | 貸出中: 2 枚 | リーダー: 接続中 | Ver. 1.1.0
```

## Test plan
- [x] アプリ起動時にステータスバー右端にバージョンが表示されることを確認
- [x] バージョン番号が csproj の設定と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)