### PR TITLE
feat: 乗車履歴の統合・分割機能を追加 (#484)

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -224,6 +224,7 @@ namespace ICCardManager
             services.AddTransient<DataExportImportViewModel>();
             services.AddTransient<OperationLogSearchViewModel>();
             services.AddTransient<LedgerEditViewModel>();
+            services.AddTransient<LedgerDetailViewModel>();
             services.AddTransient<SystemManageViewModel>();
 
             // Views

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Data.SQLite;
+
+namespace ICCardManager.Data.Migrations
+{
+    /// <summary>
+    /// 乗車履歴の統合・分割機能のためのマイグレーション
+    /// </summary>
+    /// <remarks>
+    /// Issue #484: 乗車履歴の統合・分割機能の追加
+    /// ledger_detailテーブルにgroup_idカラムを追加し、手動でのグループ化を可能にする。
+    /// 同じgroup_idを持つ詳細は1つの乗り継ぎとして扱われる。
+    /// NULLの場合は従来通り自動判定される。
+    /// </remarks>
+    public class Migration_003_AddTripGroupId : IMigration
+    {
+        public int Version => 3;
+        public string Description => "乗車履歴グループ化機能追加（group_idカラム追加）";
+
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // ledger_detailテーブルにgroup_idカラムを追加
+            // NULL = 自動判定、同じ値 = 同一グループ（乗り継ぎ）として扱う
+            ExecuteNonQuery(connection, transaction,
+                "ALTER TABLE ledger_detail ADD COLUMN group_id INTEGER");
+        }
+
+        public void Down(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // SQLiteではALTER TABLE DROP COLUMNが使えないため、
+            // テーブル再作成で対応
+
+            // 一時テーブルにデータを退避
+            ExecuteNonQuery(connection, transaction, @"CREATE TABLE ledger_detail_backup (
+    ledger_id           INTEGER REFERENCES ledger(id) ON DELETE CASCADE,
+    use_date            TEXT,
+    entry_station       TEXT,
+    exit_station        TEXT,
+    bus_stops           TEXT,
+    amount              INTEGER,
+    balance             INTEGER,
+    is_charge           INTEGER DEFAULT 0,
+    is_point_redemption INTEGER DEFAULT 0,
+    is_bus              INTEGER DEFAULT 0
+)");
+
+            // データをコピー（group_idを除く）
+            ExecuteNonQuery(connection, transaction, @"INSERT INTO ledger_detail_backup
+    (ledger_id, use_date, entry_station, exit_station, bus_stops, amount, balance, is_charge, is_point_redemption, is_bus)
+    SELECT ledger_id, use_date, entry_station, exit_station, bus_stops, amount, balance, is_charge, is_point_redemption, is_bus
+    FROM ledger_detail");
+
+            // 元テーブルを削除
+            ExecuteNonQuery(connection, transaction, "DROP TABLE ledger_detail");
+
+            // バックアップテーブルをリネーム
+            ExecuteNonQuery(connection, transaction, "ALTER TABLE ledger_detail_backup RENAME TO ledger_detail");
+
+            // インデックスを再作成
+            ExecuteNonQuery(connection, transaction, "CREATE INDEX IF NOT EXISTS idx_detail_ledger ON ledger_detail(ledger_id)");
+            ExecuteNonQuery(connection, transaction, "CREATE INDEX IF NOT EXISTS idx_detail_bus ON ledger_detail(is_bus)");
+        }
+
+        private static void ExecuteNonQuery(SQLiteConnection connection, SQLiteTransaction transaction, string sql)
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = sql;
+            command.ExecuteNonQuery();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -138,5 +138,17 @@ namespace ICCardManager.Data.Repositories
         /// <returns>既存の履歴キーのセット</returns>
         Task<HashSet<(string CardIdm, DateTime Date, string Summary, int Income, int Expense, int Balance)>> GetExistingLedgerKeysAsync(
             IEnumerable<string> cardIdms);
+
+        /// <summary>
+        /// 利用履歴詳細を置き換え（全削除後に再登録）
+        /// </summary>
+        /// <remarks>
+        /// Issue #484対応: 乗車履歴の統合・分割機能で、グループIDを更新する際に使用。
+        /// 既存の詳細をすべて削除してから新しい詳細リストを登録する。
+        /// </remarks>
+        /// <param name="ledgerId">利用履歴ID</param>
+        /// <param name="details">新しい詳細リスト</param>
+        /// <returns>成功した場合true</returns>
+        Task<bool> ReplaceDetailsAsync(int ledgerId, IEnumerable<LedgerDetail> details);
     }
 }

--- a/ICCardManager/src/ICCardManager/Data/schema.sql
+++ b/ICCardManager/src/ICCardManager/Data/schema.sql
@@ -64,7 +64,8 @@ CREATE TABLE IF NOT EXISTS ledger_detail (
     balance             INTEGER,                 -- 残額
     is_charge           INTEGER DEFAULT 0,       -- チャージフラグ
     is_point_redemption INTEGER DEFAULT 0,       -- ポイント還元フラグ
-    is_bus              INTEGER DEFAULT 0        -- バス利用フラグ
+    is_bus              INTEGER DEFAULT 0,       -- バス利用フラグ
+    group_id            INTEGER                  -- グループID（乗り継ぎ統合用、NULLは自動判定）
 );
 
 -- ============================================

--- a/ICCardManager/src/ICCardManager/Models/LedgerDetail.cs
+++ b/ICCardManager/src/ICCardManager/Models/LedgerDetail.cs
@@ -66,6 +66,16 @@ namespace ICCardManager.Models
         public bool IsBus { get; set; }
 
         /// <summary>
+        /// グループID（乗り継ぎ統合用）
+        /// </summary>
+        /// <remarks>
+        /// Issue #484: 乗車履歴の統合・分割機能
+        /// 同じGroupIdを持つ詳細は1つの乗り継ぎとして摘要に統合される。
+        /// NULLの場合は従来通りSummaryGeneratorが自動判定する。
+        /// </remarks>
+        public int? GroupId { get; set; }
+
+        /// <summary>
         /// ICカードから読み取った生データ（16バイト）
         /// </summary>
         /// <remarks>

--- a/ICCardManager/src/ICCardManager/ViewModels/LedgerDetailViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/LedgerDetailViewModel.cs
@@ -1,0 +1,514 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ICCardManager.Common;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ICCardManager.ViewModels
+{
+    /// <summary>
+    /// 利用履歴詳細表示用のアイテム
+    /// </summary>
+    public partial class LedgerDetailItemViewModel : ObservableObject
+    {
+        /// <summary>
+        /// 元のLedgerDetail
+        /// </summary>
+        public LedgerDetail Detail { get; }
+
+        /// <summary>
+        /// リスト内のインデックス（選択操作用）
+        /// </summary>
+        public int Index { get; set; }
+
+        /// <summary>
+        /// 選択状態
+        /// </summary>
+        [ObservableProperty]
+        private bool _isSelected;
+
+        /// <summary>
+        /// グループID
+        /// </summary>
+        [ObservableProperty]
+        private int? _groupId;
+
+        /// <summary>
+        /// 利用日時表示
+        /// </summary>
+        public string UseDateDisplay => Detail.UseDate?.ToString("yyyy/MM/dd HH:mm") ?? "-";
+
+        /// <summary>
+        /// 区間表示
+        /// </summary>
+        public string RouteDisplay
+        {
+            get
+            {
+                if (Detail.IsCharge)
+                {
+                    return "チャージ";
+                }
+                if (Detail.IsPointRedemption)
+                {
+                    return "ポイント還元";
+                }
+                if (Detail.IsBus)
+                {
+                    return $"バス（{Detail.BusStops ?? "★"}）";
+                }
+                if (!string.IsNullOrEmpty(Detail.EntryStation) && !string.IsNullOrEmpty(Detail.ExitStation))
+                {
+                    return $"{Detail.EntryStation} → {Detail.ExitStation}";
+                }
+                return "-";
+            }
+        }
+
+        /// <summary>
+        /// 金額表示
+        /// </summary>
+        public string AmountDisplay
+        {
+            get
+            {
+                if (!Detail.Amount.HasValue)
+                {
+                    return "-";
+                }
+                if (Detail.IsCharge || Detail.IsPointRedemption)
+                {
+                    return $"+{Detail.Amount:N0}円";
+                }
+                return $"-{Detail.Amount:N0}円";
+            }
+        }
+
+        /// <summary>
+        /// 残高表示
+        /// </summary>
+        public string BalanceDisplay => Detail.Balance.HasValue ? $"{Detail.Balance:N0}円" : "-";
+
+        /// <summary>
+        /// チャージフラグ
+        /// </summary>
+        public bool IsCharge => Detail.IsCharge;
+
+        /// <summary>
+        /// バス利用フラグ
+        /// </summary>
+        public bool IsBus => Detail.IsBus;
+
+        /// <summary>
+        /// グループ表示色のインデックス（グループごとに異なる色を割り当てるため）
+        /// </summary>
+        [ObservableProperty]
+        private int _groupColorIndex;
+
+        public LedgerDetailItemViewModel(LedgerDetail detail, int index)
+        {
+            Detail = detail;
+            Index = index;
+            _groupId = detail.GroupId;
+        }
+    }
+
+    /// <summary>
+    /// 利用履歴詳細ダイアログ用ViewModel（Issue #484: 統合・分割機能対応）
+    /// </summary>
+    public partial class LedgerDetailViewModel : ObservableObject
+    {
+        private readonly ILedgerRepository _ledgerRepository;
+        private readonly SummaryGenerator _summaryGenerator;
+        private readonly OperationLogger _operationLogger;
+        private readonly ILogger<LedgerDetailViewModel> _logger;
+
+        private Ledger _ledger = null!;
+        private int _nextGroupId = 1;
+
+        /// <summary>
+        /// 詳細アイテムリスト
+        /// </summary>
+        public ObservableCollection<LedgerDetailItemViewModel> Items { get; } = new();
+
+        /// <summary>
+        /// 日付表示
+        /// </summary>
+        [ObservableProperty]
+        private string _dateDisplay = string.Empty;
+
+        /// <summary>
+        /// 摘要表示
+        /// </summary>
+        [ObservableProperty]
+        private string _summaryDisplay = string.Empty;
+
+        /// <summary>
+        /// 受入金額表示
+        /// </summary>
+        [ObservableProperty]
+        private string _incomeDisplay = string.Empty;
+
+        /// <summary>
+        /// 払出金額表示
+        /// </summary>
+        [ObservableProperty]
+        private string _expenseDisplay = string.Empty;
+
+        /// <summary>
+        /// 残高表示
+        /// </summary>
+        [ObservableProperty]
+        private string _balanceDisplay = string.Empty;
+
+        /// <summary>
+        /// 利用者名
+        /// </summary>
+        [ObservableProperty]
+        private string _staffName = string.Empty;
+
+        /// <summary>
+        /// 備考
+        /// </summary>
+        [ObservableProperty]
+        private string _note = string.Empty;
+
+        /// <summary>
+        /// 詳細件数表示
+        /// </summary>
+        [ObservableProperty]
+        private string _detailCountDisplay = string.Empty;
+
+        /// <summary>
+        /// 変更があるかどうか
+        /// </summary>
+        [ObservableProperty]
+        private bool _hasChanges;
+
+        /// <summary>
+        /// 処理中かどうか
+        /// </summary>
+        [ObservableProperty]
+        private bool _isBusy;
+
+        /// <summary>
+        /// ステータスメッセージ
+        /// </summary>
+        [ObservableProperty]
+        private string _statusMessage = string.Empty;
+
+        /// <summary>
+        /// 統合コマンドが実行可能か
+        /// </summary>
+        public bool CanMerge => Items.Count(i => i.IsSelected) >= 2;
+
+        /// <summary>
+        /// 分割コマンドが実行可能か
+        /// </summary>
+        public bool CanSplit => Items.Any(i => i.IsSelected && i.GroupId.HasValue);
+
+        /// <summary>
+        /// 保存完了時のコールバック
+        /// </summary>
+        public Action? OnSaveCompleted { get; set; }
+
+        /// <summary>
+        /// 操作者IDm（ログ記録用）
+        /// </summary>
+        private string? _operatorIdm;
+
+        public LedgerDetailViewModel(
+            ILedgerRepository ledgerRepository,
+            SummaryGenerator summaryGenerator,
+            OperationLogger operationLogger,
+            ILogger<LedgerDetailViewModel> logger)
+        {
+            _ledgerRepository = ledgerRepository;
+            _summaryGenerator = summaryGenerator;
+            _operationLogger = operationLogger;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// 初期化
+        /// </summary>
+        public async Task InitializeAsync(int ledgerId, string? operatorIdm = null)
+        {
+            _operatorIdm = operatorIdm;
+            _ledger = await _ledgerRepository.GetByIdAsync(ledgerId);
+
+            if (_ledger == null)
+            {
+                throw new InvalidOperationException($"Ledger ID {ledgerId} が見つかりません");
+            }
+
+            // ヘッダー情報を設定
+            DateDisplay = WarekiConverter.ToWareki(_ledger.Date);
+            SummaryDisplay = _ledger.Summary;
+            IncomeDisplay = _ledger.Income > 0 ? $"+{_ledger.Income:N0}円" : string.Empty;
+            ExpenseDisplay = _ledger.Expense > 0 ? $"-{_ledger.Expense:N0}円" : string.Empty;
+            BalanceDisplay = $"{_ledger.Balance:N0}円";
+            StaffName = _ledger.StaffName ?? "-";
+            Note = _ledger.Note ?? string.Empty;
+
+            // 詳細アイテムを設定
+            Items.Clear();
+            var index = 0;
+            foreach (var detail in _ledger.Details)
+            {
+                Items.Add(new LedgerDetailItemViewModel(detail, index++));
+            }
+
+            // 既存のGroupIdから次のGroupIdを決定
+            _nextGroupId = Items.Any(i => i.GroupId.HasValue)
+                ? Items.Where(i => i.GroupId.HasValue).Max(i => i.GroupId!.Value) + 1
+                : 1;
+
+            UpdateGroupColors();
+            UpdateDetailCountDisplay();
+            HasChanges = false;
+        }
+
+        /// <summary>
+        /// グループの色インデックスを更新
+        /// </summary>
+        private void UpdateGroupColors()
+        {
+            var groupIds = Items
+                .Where(i => i.GroupId.HasValue)
+                .Select(i => i.GroupId!.Value)
+                .Distinct()
+                .OrderBy(id => id)
+                .ToList();
+
+            foreach (var item in Items)
+            {
+                if (item.GroupId.HasValue)
+                {
+                    item.GroupColorIndex = groupIds.IndexOf(item.GroupId.Value) % 5 + 1; // 1-5の色
+                }
+                else
+                {
+                    item.GroupColorIndex = 0; // グループなし
+                }
+            }
+        }
+
+        /// <summary>
+        /// 詳細件数表示を更新
+        /// </summary>
+        private void UpdateDetailCountDisplay()
+        {
+            var groupCount = Items
+                .Where(i => i.GroupId.HasValue)
+                .Select(i => i.GroupId!.Value)
+                .Distinct()
+                .Count();
+
+            if (groupCount > 0)
+            {
+                DetailCountDisplay = $"{Items.Count}件の詳細（{groupCount}グループ）";
+            }
+            else
+            {
+                DetailCountDisplay = $"{Items.Count}件の詳細";
+            }
+        }
+
+        /// <summary>
+        /// 選択状態変更時の処理
+        /// </summary>
+        public void OnSelectionChanged()
+        {
+            OnPropertyChanged(nameof(CanMerge));
+            OnPropertyChanged(nameof(CanSplit));
+        }
+
+        /// <summary>
+        /// 選択した項目を統合（Ctrl+G）
+        /// </summary>
+        [RelayCommand]
+        private void Merge()
+        {
+            var selectedItems = Items.Where(i => i.IsSelected).ToList();
+            if (selectedItems.Count < 2)
+            {
+                StatusMessage = "2つ以上の項目を選択してください";
+                return;
+            }
+
+            // 新しいグループIDを割り当て
+            var newGroupId = _nextGroupId++;
+            foreach (var item in selectedItems)
+            {
+                item.GroupId = newGroupId;
+                item.IsSelected = false;
+            }
+
+            UpdateGroupColors();
+            UpdateDetailCountDisplay();
+            HasChanges = true;
+            StatusMessage = $"{selectedItems.Count}件を統合しました";
+
+            _logger.LogDebug("Merged {Count} items into group {GroupId}", selectedItems.Count, newGroupId);
+        }
+
+        /// <summary>
+        /// 選択した項目を分割（Ctrl+U）
+        /// </summary>
+        [RelayCommand]
+        private void Split()
+        {
+            var selectedItems = Items.Where(i => i.IsSelected && i.GroupId.HasValue).ToList();
+            if (selectedItems.Count == 0)
+            {
+                StatusMessage = "グループ化された項目を選択してください";
+                return;
+            }
+
+            // グループIDを解除
+            foreach (var item in selectedItems)
+            {
+                item.GroupId = null;
+                item.IsSelected = false;
+            }
+
+            UpdateGroupColors();
+            UpdateDetailCountDisplay();
+            HasChanges = true;
+            StatusMessage = $"{selectedItems.Count}件の統合を解除しました";
+
+            _logger.LogDebug("Split {Count} items from groups", selectedItems.Count);
+        }
+
+        /// <summary>
+        /// 自動検出に戻す
+        /// </summary>
+        [RelayCommand]
+        private void ResetToAutoDetect()
+        {
+            foreach (var item in Items)
+            {
+                item.GroupId = null;
+                item.IsSelected = false;
+            }
+
+            _nextGroupId = 1;
+            UpdateGroupColors();
+            UpdateDetailCountDisplay();
+            HasChanges = true;
+            StatusMessage = "自動検出モードに戻しました";
+
+            _logger.LogDebug("Reset all groups to auto-detect");
+        }
+
+        /// <summary>
+        /// 変更を保存
+        /// </summary>
+        [RelayCommand]
+        private async Task SaveAsync()
+        {
+            if (!HasChanges)
+            {
+                return;
+            }
+
+            IsBusy = true;
+            StatusMessage = "保存中...";
+
+            try
+            {
+                // 詳細のGroupIdを更新
+                var updatedDetails = Items.Select(item =>
+                {
+                    var detail = item.Detail;
+                    detail.GroupId = item.GroupId;
+                    return detail;
+                }).ToList();
+
+                // 詳細を置き換え
+                var success = await _ledgerRepository.ReplaceDetailsAsync(_ledger.Id, updatedDetails);
+                if (!success)
+                {
+                    StatusMessage = "保存に失敗しました";
+                    return;
+                }
+
+                // 摘要を再生成
+                var newSummary = _summaryGenerator.Generate(updatedDetails);
+                if (!string.IsNullOrEmpty(newSummary) && newSummary != _ledger.Summary)
+                {
+                    // 更新前の状態を保存
+                    var beforeLedger = new Ledger
+                    {
+                        Id = _ledger.Id,
+                        CardIdm = _ledger.CardIdm,
+                        Summary = _ledger.Summary,
+                        Date = _ledger.Date,
+                        Balance = _ledger.Balance
+                    };
+
+                    _ledger.Summary = newSummary;
+                    await _ledgerRepository.UpdateAsync(_ledger);
+                    SummaryDisplay = newSummary;
+
+                    // 操作ログを記録（operatorIdmを設定してGUI操作を区別）
+                    if (!string.IsNullOrEmpty(_operatorIdm))
+                    {
+                        await _operationLogger.LogLedgerUpdateAsync(_operatorIdm, beforeLedger, _ledger);
+                    }
+                }
+
+                HasChanges = false;
+                StatusMessage = "保存しました";
+                _logger.LogInformation("Saved ledger detail changes for ledger {LedgerId}", _ledger.Id);
+
+                OnSaveCompleted?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to save ledger detail changes");
+                StatusMessage = $"エラー: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// すべて選択
+        /// </summary>
+        [RelayCommand]
+        private void SelectAll()
+        {
+            foreach (var item in Items)
+            {
+                item.IsSelected = true;
+            }
+            OnSelectionChanged();
+        }
+
+        /// <summary>
+        /// 選択解除
+        /// </summary>
+        [RelayCommand]
+        private void DeselectAll()
+        {
+            foreach (var item in Items)
+            {
+                item.IsSelected = false;
+            }
+            OnSelectionChanged();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
@@ -3,24 +3,51 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ICCardManager.ViewModels"
         mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:LedgerDetailViewModel}"
         Title="利用履歴詳細"
-        Height="400"
-        Width="700"
+        Height="500"
+        Width="800"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         AutomationProperties.Name="利用履歴詳細ダイアログ"
-        AutomationProperties.HelpText="選択した履歴の詳細（個別の乗車記録）を表示します。">
+        AutomationProperties.HelpText="選択した履歴の詳細（個別の乗車記録）を表示・編集します。">
+
+    <Window.InputBindings>
+        <!-- Ctrl+G: 統合 -->
+        <KeyBinding Key="G" Modifiers="Control" Command="{Binding MergeCommand}"/>
+        <!-- Ctrl+U: 分割 -->
+        <KeyBinding Key="U" Modifiers="Control" Command="{Binding SplitCommand}"/>
+        <!-- Ctrl+A: すべて選択 -->
+        <KeyBinding Key="A" Modifiers="Control" Command="{Binding SelectAllCommand}"/>
+        <!-- Ctrl+S: 保存 -->
+        <KeyBinding Key="S" Modifiers="Control" Command="{Binding SaveCommand}"/>
+    </Window.InputBindings>
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+
+        <!-- グループ色のブラシ -->
+        <SolidColorBrush x:Key="GroupColor0" Color="Transparent"/>
+        <SolidColorBrush x:Key="GroupColor1" Color="#E3F2FD"/>
+        <SolidColorBrush x:Key="GroupColor2" Color="#E8F5E9"/>
+        <SolidColorBrush x:Key="GroupColor3" Color="#FFF3E0"/>
+        <SolidColorBrush x:Key="GroupColor4" Color="#F3E5F5"/>
+        <SolidColorBrush x:Key="GroupColor5" Color="#FFEBEE"/>
+    </Window.Resources>
 
     <Grid Margin="15">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- 親レコード情報ヘッダー -->
-        <Border Grid.Row="0" Background="#E3F2FD" CornerRadius="4" Padding="15" Margin="0,0,0,15">
+        <Border Grid.Row="0" Background="#E3F2FD" CornerRadius="4" Padding="15" Margin="0,0,0,10">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -33,34 +60,38 @@
 
                 <!-- 日付と摘要 -->
                 <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
-                    <TextBlock x:Name="DateText"
+                    <TextBlock Text="{Binding DateDisplay}"
                                FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                VerticalAlignment="Center"/>
-                    <TextBlock x:Name="SummaryText"
+                    <TextBlock Text="{Binding SummaryDisplay}"
                                FontSize="{DynamicResource BaseFontSize}"
                                Margin="20,0,0,0"
-                               VerticalAlignment="Center"/>
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="300"/>
                 </StackPanel>
 
                 <!-- 金額情報 -->
                 <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
-                    <TextBlock x:Name="IncomeText"
+                    <TextBlock Text="{Binding IncomeDisplay}"
                                FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                Foreground="Green"
                                VerticalAlignment="Center"
-                               Margin="0,0,15,0"/>
-                    <TextBlock x:Name="ExpenseText"
+                               Margin="0,0,15,0"
+                               Visibility="{Binding IncomeDisplay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    <TextBlock Text="{Binding ExpenseDisplay}"
                                FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                Foreground="OrangeRed"
                                VerticalAlignment="Center"
-                               Margin="0,0,15,0"/>
+                               Margin="0,0,15,0"
+                               Visibility="{Binding ExpenseDisplay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                     <TextBlock Text="残高:"
                                FontSize="{DynamicResource BaseFontSize}"
                                VerticalAlignment="Center"/>
-                    <TextBlock x:Name="BalanceText"
+                    <TextBlock Text="{Binding BalanceDisplay}"
                                FontSize="{DynamicResource LargeFontSize}"
                                FontWeight="Bold"
                                Foreground="#1565C0"
@@ -74,7 +105,7 @@
                                FontSize="{DynamicResource SmallFontSize}"
                                Foreground="Gray"
                                VerticalAlignment="Center"/>
-                    <TextBlock x:Name="StaffNameText"
+                    <TextBlock Text="{Binding StaffName}"
                                FontSize="{DynamicResource SmallFontSize}"
                                Margin="5,0,20,0"
                                VerticalAlignment="Center"/>
@@ -82,32 +113,164 @@
                                FontSize="{DynamicResource SmallFontSize}"
                                Foreground="Gray"
                                VerticalAlignment="Center"/>
-                    <TextBlock x:Name="NoteText"
+                    <TextBlock Text="{Binding Note}"
                                FontSize="{DynamicResource SmallFontSize}"
                                Margin="5,0,0,0"
-                               VerticalAlignment="Center"/>
+                               VerticalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="300"/>
                 </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- 統合・分割ツールバー -->
+        <Border Grid.Row="1" Background="#F5F5F5" CornerRadius="4" Padding="10" Margin="0,0,0,10">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="📦 統合 (Ctrl+G)"
+                            Command="{Binding MergeCommand}"
+                            Padding="12,6"
+                            Margin="0,0,8,0"
+                            ToolTip="選択した項目を1つの乗り継ぎとして統合します"
+                            AutomationProperties.Name="統合">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CanMerge}" Value="False">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                    <Button Content="📤 分割 (Ctrl+U)"
+                            Command="{Binding SplitCommand}"
+                            Padding="12,6"
+                            Margin="0,0,8,0"
+                            ToolTip="選択した項目の統合を解除します"
+                            AutomationProperties.Name="分割">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CanSplit}" Value="False">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                    <Button Content="🔄 自動検出に戻す"
+                            Command="{Binding ResetToAutoDetectCommand}"
+                            Padding="12,6"
+                            ToolTip="すべての統合を解除し、自動検出モードに戻します"
+                            AutomationProperties.Name="自動検出に戻す"/>
+                </StackPanel>
+
+                <TextBlock Grid.Column="1"
+                           Text="{Binding StatusMessage}"
+                           Foreground="#666666"
+                           VerticalAlignment="Center"
+                           FontSize="{DynamicResource SmallFontSize}"/>
             </Grid>
         </Border>
 
         <!-- 詳細一覧 -->
         <DataGrid x:Name="DetailsDataGrid"
-                  Grid.Row="1"
+                  Grid.Row="2"
+                  ItemsSource="{Binding Items}"
                   AutoGenerateColumns="False"
-                  IsReadOnly="True"
-                  SelectionMode="Single"
+                  IsReadOnly="False"
+                  SelectionMode="Extended"
                   CanUserAddRows="False"
                   CanUserDeleteRows="False"
                   GridLinesVisibility="Horizontal"
                   HeadersVisibility="Column"
                   RowHeaderWidth="0"
-                  AlternatingRowBackground="#FAFAFA"
                   AutomationProperties.Name="利用詳細一覧"
-                  AutomationProperties.HelpText="個別の乗車記録やチャージ記録の一覧です。">
+                  AutomationProperties.HelpText="チェックボックスで項目を選択し、統合または分割できます。">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="日時" Binding="{Binding UseDateDisplay}" Width="140"/>
-                <DataGridTextColumn Header="区間" Binding="{Binding RouteDisplay}" Width="*"/>
-                <DataGridTextColumn Header="金額" Width="100">
+                <!-- 選択チェックボックス -->
+                <DataGridTemplateColumn Header="選択" Width="50">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox IsChecked="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged}"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Click="CheckBox_Click"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
+                <!-- グループ表示 -->
+                <DataGridTemplateColumn Header="グループ" Width="70">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Border CornerRadius="3" Padding="4,2" HorizontalAlignment="Center">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="Transparent"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding GroupColorIndex}" Value="1">
+                                                <Setter Property="Background" Value="#1976D2"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding GroupColorIndex}" Value="2">
+                                                <Setter Property="Background" Value="#388E3C"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding GroupColorIndex}" Value="3">
+                                                <Setter Property="Background" Value="#F57C00"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding GroupColorIndex}" Value="4">
+                                                <Setter Property="Background" Value="#7B1FA2"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding GroupColorIndex}" Value="5">
+                                                <Setter Property="Background" Value="#D32F2F"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <TextBlock HorizontalAlignment="Center">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="-"/>
+                                            <Setter Property="Foreground" Value="Gray"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding GroupId}" Value="{x:Null}">
+                                                    <Setter Property="Text" Value="-"/>
+                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <Border.ToolTip>
+                                    <ToolTip>
+                                        <TextBlock>
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Text" Value="グループなし（自動検出）"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding GroupId}" Value="{x:Null}">
+                                                            <Setter Property="Text" Value="グループなし（自動検出）"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </ToolTip>
+                                </Border.ToolTip>
+                            </Border>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
+                <DataGridTextColumn Header="日時" Binding="{Binding UseDateDisplay}" Width="140" IsReadOnly="True"/>
+                <DataGridTextColumn Header="区間" Binding="{Binding RouteDisplay}" Width="*" IsReadOnly="True"/>
+                <DataGridTextColumn Header="金額" Width="100" IsReadOnly="True">
                     <DataGridTextColumn.Binding>
                         <Binding Path="AmountDisplay"/>
                     </DataGridTextColumn.Binding>
@@ -117,7 +280,7 @@
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
-                <DataGridTextColumn Header="残高" Width="100">
+                <DataGridTextColumn Header="残高" Width="100" IsReadOnly="True">
                     <DataGridTextColumn.Binding>
                         <Binding Path="BalanceDisplay"/>
                     </DataGridTextColumn.Binding>
@@ -129,12 +292,27 @@
                 </DataGridTextColumn>
             </DataGrid.Columns>
 
-            <!-- チャージ行のスタイル -->
+            <!-- 行スタイル（グループ色） -->
             <DataGrid.RowStyle>
                 <Style TargetType="DataGridRow">
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsCharge}" Value="True">
+                        <DataTrigger Binding="{Binding GroupColorIndex}" Value="1">
+                            <Setter Property="Background" Value="#E3F2FD"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding GroupColorIndex}" Value="2">
                             <Setter Property="Background" Value="#E8F5E9"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding GroupColorIndex}" Value="3">
+                            <Setter Property="Background" Value="#FFF3E0"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding GroupColorIndex}" Value="4">
+                            <Setter Property="Background" Value="#F3E5F5"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding GroupColorIndex}" Value="5">
+                            <Setter Property="Background" Value="#FFEBEE"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding IsCharge}" Value="True">
+                            <Setter Property="FontWeight" Value="Bold"/>
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsBus}" Value="True">
                             <Setter Property="FontStyle" Value="Italic"/>
@@ -144,20 +322,61 @@
             </DataGrid.RowStyle>
         </DataGrid>
 
+        <!-- 操作説明 -->
+        <Border Grid.Row="3" Background="#FFFDE7" CornerRadius="4" Padding="10" Margin="0,10,0,0">
+            <TextBlock TextWrapping="Wrap" FontSize="{DynamicResource SmallFontSize}">
+                <Run FontWeight="Bold">操作方法:</Run>
+                <Run Text=" チェックボックスで複数選択 → [統合] で1つの乗り継ぎに / [分割] で個別に戻す"/>
+                <LineBreak/>
+                <Run Text="同じ色の行は1つの乗り継ぎとして摘要に統合されます。色がない行は自動検出されます。"/>
+            </TextBlock>
+        </Border>
+
         <!-- フッター -->
-        <Grid Grid.Row="2" Margin="0,15,0,0">
+        <Grid Grid.Row="4" Margin="0,15,0,0">
             <StackPanel Orientation="Horizontal">
-                <TextBlock x:Name="DetailCountText"
+                <TextBlock Text="{Binding DetailCountDisplay}"
                            Foreground="Gray"
                            VerticalAlignment="Center"/>
+                <TextBlock Text=" | " Foreground="Gray" VerticalAlignment="Center"
+                           Visibility="{Binding HasChanges, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                <TextBlock Text="未保存の変更があります"
+                           Foreground="#D32F2F"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding HasChanges, Converter={StaticResource BoolToVisibilityConverter}}"/>
             </StackPanel>
-            <Button Content="閉じる"
-                    Click="CloseButton_Click"
-                    HorizontalAlignment="Right"
-                    Padding="20,8"
-                    IsCancel="True"
-                    AutomationProperties.Name="閉じる"
-                    ToolTip="ダイアログを閉じる (Escape)"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="保存 (Ctrl+S)"
+                        Command="{Binding SaveCommand}"
+                        Padding="15,8"
+                        Margin="0,0,10,0"
+                        Background="#4CAF50"
+                        Foreground="White"
+                        AutomationProperties.Name="保存"
+                        ToolTip="変更を保存します"
+                        Visibility="{Binding HasChanges, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                <Button Content="閉じる"
+                        Click="CloseButton_Click"
+                        Padding="20,8"
+                        IsCancel="True"
+                        AutomationProperties.Name="閉じる"
+                        ToolTip="ダイアログを閉じる (Escape)"/>
+            </StackPanel>
         </Grid>
+
+        <!-- 処理中オーバーレイ -->
+        <Border Grid.RowSpan="5"
+                Background="#80000000"
+                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
+                <TextBlock Text="保存中..."
+                           Foreground="White"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           Margin="0,10,0,0"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml.cs
@@ -3,63 +3,68 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using ICCardManager.Dtos;
+using ICCardManager.Models;
+using ICCardManager.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ICCardManager.Views.Dialogs
 {
     /// <summary>
     /// 利用履歴詳細ダイアログ
-    /// 選択した履歴の詳細（個別の乗車記録）を表示します。
+    /// 選択した履歴の詳細（個別の乗車記録）を表示・編集します。
+    /// Issue #484: 乗車履歴の統合・分割機能に対応。
     /// </summary>
     public partial class LedgerDetailDialog : Window
     {
+        private LedgerDetailViewModel? _viewModel;
+
         public LedgerDetailDialog()
         {
             InitializeComponent();
         }
 
         /// <summary>
-        /// 履歴データで初期化
+        /// 利用履歴詳細を表示（新しいViewModel使用）
+        /// </summary>
+        /// <param name="ledgerId">利用履歴ID</param>
+        /// <param name="operatorIdm">操作者IDm（ログ記録用、オプション）</param>
+        public async Task InitializeAsync(int ledgerId, string? operatorIdm = null)
+        {
+            _viewModel = App.Current.ServiceProvider.GetRequiredService<LedgerDetailViewModel>();
+            DataContext = _viewModel;
+
+            _viewModel.OnSaveCompleted = () =>
+            {
+                // 保存完了時は何もしない（ダイアログは開いたまま）
+            };
+
+            await _viewModel.InitializeAsync(ledgerId, operatorIdm);
+        }
+
+        /// <summary>
+        /// 履歴データで初期化（レガシー互換）
         /// </summary>
         /// <param name="ledger">表示する履歴データ</param>
+        /// <remarks>
+        /// 既存のコードとの互換性のために維持。
+        /// 新しいコードではInitializeAsync(int ledgerId)を使用してください。
+        /// </remarks>
         public void Initialize(LedgerDto ledger)
         {
             if (ledger == null) return;
 
-            // 親レコード情報を設定
-            DateText.Text = ledger.DateDisplay;
-            SummaryText.Text = ledger.Summary;
+            // 新しいViewModel方式で初期化
+            _ = InitializeAsync(ledger.Id);
+        }
 
-            // 金額を設定
-            if (ledger.HasIncome)
-            {
-                IncomeText.Text = ledger.IncomeDisplay;
-            }
-            else
-            {
-                IncomeText.Visibility = Visibility.Collapsed;
-            }
-
-            if (ledger.HasExpense)
-            {
-                ExpenseText.Text = ledger.ExpenseDisplay;
-            }
-            else
-            {
-                ExpenseText.Visibility = Visibility.Collapsed;
-            }
-
-            BalanceText.Text = ledger.BalanceDisplay + "円";
-
-            // 利用者と備考
-            StaffNameText.Text = ledger.StaffName ?? "-";
-            NoteText.Text = string.IsNullOrEmpty(ledger.Note) ? "-" : ledger.Note;
-
-            // 詳細一覧を設定
-            DetailsDataGrid.ItemsSource = ledger.Details;
-
-            // 件数表示
-            DetailCountText.Text = $"詳細 {ledger.Details?.Count ?? 0} 件";
+        /// <summary>
+        /// チェックボックスクリック時の処理
+        /// </summary>
+        private void CheckBox_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel?.OnSelectionChanged();
         }
 
         /// <summary>
@@ -67,6 +72,20 @@ namespace ICCardManager.Views.Dialogs
         /// </summary>
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
+            if (_viewModel?.HasChanges == true)
+            {
+                var result = MessageBox.Show(
+                    "保存されていない変更があります。破棄してよろしいですか？",
+                    "確認",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+
+                if (result != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+            }
+
             Close();
         }
     }

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/DbContextMigrationTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/DbContextMigrationTests.cs
@@ -120,8 +120,8 @@ CREATE TABLE settings (
         _dbContext.InitializeDatabase();
 
         // Assert
-        // レガシーDBはバージョン1として認識され、その後Migration_002も適用されるので最終バージョンは2
-        _dbContext.GetDatabaseVersion().Should().Be(2);
+        // レガシーDBはバージョン1として認識され、その後Migration_002, Migration_003も適用されるので最終バージョンは3
+        _dbContext.GetDatabaseVersion().Should().Be(3);
         TableShouldExist(connection, "schema_migrations");
 
         // バージョン1（既存DB認識）の記録が存在することを確認
@@ -149,8 +149,8 @@ CREATE TABLE settings (
         var count = Convert.ToInt32(cmd.ExecuteScalar());
 
         // 現在のマイグレーション数と一致するはず（重複していないこと）
-        // Migration_001_Initial + Migration_002_AddPointRedemption = 2
-        count.Should().Be(2);
+        // Migration_001_Initial + Migration_002_AddPointRedemption + Migration_003_AddTripGroupId = 3
+        count.Should().Be(3);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- 同日の複数の乗車履歴を手動で統合・分割できる機能を追加
- 自動検出が適切でないケース（飛行機移動など）に対応

## 背景
例：一日のうちに以下の移動があった場合
1. 天神 → 福岡空港（地下鉄）
2. 羽田空港第一ターミナル → 浜松町（東京モノレール）
3. 浜松町 → 東京（JR東日本）
4. 東京 → 霞が関（東京メトロ）

2〜4は自動で乗り継ぎとして統合できるが、1と2以降は飛行機移動を挟んでいるため別扱いが適切。

## 変更内容

### データベース
- `ledger_detail` テーブルに `group_id` カラムを追加（Migration_003）
- 同じ `group_id` を持つ詳細は1つの乗り継ぎとして扱う
- NULL の場合は従来通り自動判定

### UI（LedgerDetailDialog）
| 操作 | ショートカット | 説明 |
|------|--------------|------|
| 統合 | Ctrl+G | 選択した項目を1グループにまとめる |
| 分割 | Ctrl+U | グループを解除して個別に戻す |
| 自動検出に戻す | - | すべてのグループ化を解除 |

- グループごとに異なる背景色（青/緑/オレンジ/紫/赤）で視覚的に表示
- 変更時は「未保存の変更があります」と警告表示

### SummaryGenerator
- `group_id` が設定されている場合はそのグループ化を優先
- `group_id` がない場合は従来の自動判定ロジックを使用

## Test plan
- [ ] 履歴詳細ダイアログで複数選択→統合が機能することを確認
- [ ] 統合した項目を分割できることを確認
- [ ] 保存後、摘要が正しく再生成されることを確認
- [ ] 「自動検出に戻す」で元に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)