### PR TITLE
fix: 新規購入カードの繰越行を非表示にする (#479)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -132,19 +132,23 @@ namespace ICCardManager.Services
 
             var rows = new List<ReportPrintRow>();
 
-            // 4月の場合は前年度繰越を追加
+            // 4月の場合は前年度繰越を追加（新規購入カードの場合は繰越行を出力しない）
             if (month == 4)
             {
                 var carryover = await _ledgerRepository.GetCarryoverBalanceAsync(cardIdm, year - 1);
-                var carryoverDate = new DateTime(year, 4, 1);
-                rows.Add(new ReportPrintRow
+                // 前年度のデータがある場合のみ繰越行を追加
+                if (carryover.HasValue)
                 {
-                    DateDisplay = WarekiConverter.ToWareki(carryoverDate),
-                    Summary = SummaryGenerator.GetCarryoverFromPreviousYearSummary(),
-                    Income = carryover ?? 0,
-                    Balance = carryover ?? 0,
-                    IsBold = true
-                });
+                    var carryoverDate = new DateTime(year, 4, 1);
+                    rows.Add(new ReportPrintRow
+                    {
+                        DateDisplay = WarekiConverter.ToWareki(carryoverDate),
+                        Summary = SummaryGenerator.GetCarryoverFromPreviousYearSummary(),
+                        Income = carryover.Value,
+                        Balance = carryover.Value,
+                        IsBold = true
+                    });
+                }
             }
 
             // 各履歴行


### PR DESCRIPTION
## Summary
- 新規購入したカードについて、前月や前年度からの繰越データがない場合は繰越行を出力しないように修正
- ReportServiceとPrintServiceの両方で対応
- 既存テストを修正し、新規テストを追加

## 変更内容
### ReportService.cs
- 4月の前年度繰越: `GetCarryoverBalanceAsync`がnullの場合は繰越行をスキップ
- 他の月の前月繰越: `GetPreviousMonthBalanceAsync`の返り値を`int?`に変更し、過去データがない場合はnullを返す

### PrintService.cs  
- 4月の前年度繰越: `GetCarryoverBalanceAsync`がnullの場合は繰越行をスキップ

### テスト
- TC014を「繰越残高が0の場合」用に修正（nullではなく0を返すようにモック設定変更）
- TC022を追加: 新規購入カードの4月には前年度繰越行を出力しないことを確認
- TC023を追加: 新規購入カードの5月以降でも繰越行を出力しないことを確認

## Test plan
- [ ] 既存カードの帳票出力で繰越行が正常に表示される
- [ ] 新規購入カードの帳票出力で繰越行が表示されない
- [ ] 印刷プレビューでも同様の動作を確認
- [ ] dotnet test が全て通る

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)