### PR TITLE
fix: 同一日ではチャージを利用より先に表示 (#478)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -121,9 +121,11 @@ namespace ICCardManager.Services
                 return null;
             }
 
+            // Issue #478: 同一日ではチャージ（Income > 0）を利用より先に表示
             var ledgers = (await _ledgerRepository.GetByMonthAsync(cardIdm, year, month))
                 .Where(l => l.Summary != SummaryGenerator.GetLendingSummary())
                 .OrderBy(l => l.Date)
+                .ThenByDescending(l => l.Income)
                 .ThenBy(l => l.Id)
                 .ToList();
 

--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -211,9 +211,11 @@ namespace ICCardManager.Services
                 }
 
                 // 履歴を取得
+                // Issue #478: 同一日ではチャージ（Income > 0）を利用より先に表示
                 var ledgers = (await _ledgerRepository.GetByMonthAsync(cardIdm, year, month))
                     .Where(l => l.Summary != SummaryGenerator.GetLendingSummary()) // 貸出中レコードを除外
                     .OrderBy(l => l.Date)
+                    .ThenByDescending(l => l.Income)
                     .ThenBy(l => l.Id)
                     .ToList();
 
@@ -269,8 +271,10 @@ namespace ICCardManager.Services
                 var fiscalYearStartYear = month >= 4 ? year : year - 1;
                 var fiscalYearStart = new DateTime(fiscalYearStartYear, 4, 1);
                 var fiscalYearEnd = new DateTime(year, month, DateTime.DaysInMonth(year, month));
+                // Issue #478: 同一日ではチャージ（Income > 0）を利用より先に表示（一貫性のため）
                 var yearlyLedgers = (await _ledgerRepository.GetByDateRangeAsync(cardIdm, fiscalYearStart, fiscalYearEnd))
                     .OrderBy(l => l.Date)
+                    .ThenByDescending(l => l.Income)
                     .ThenBy(l => l.Id)
                     .ToList();
 
@@ -503,9 +507,11 @@ namespace ICCardManager.Services
             }
 
             // 前月の履歴を取得し、最後の残高を返す
+            // Issue #478: 同一日ではチャージ（Income > 0）を利用より先に表示（一貫性のため）
             var previousLedgers = (await _ledgerRepository.GetByMonthAsync(cardIdm, previousYear, previousMonth))
                 .Where(l => l.Summary != SummaryGenerator.GetLendingSummary())
                 .OrderBy(l => l.Date)
+                .ThenByDescending(l => l.Income)
                 .ThenBy(l => l.Id)
                 .ToList();
 


### PR DESCRIPTION
## Summary
- 同一日の履歴について、チャージ（受入）が利用（払出）より先に表示されるようにソート順を変更
- メイン画面、帳票出力、印刷プレビューすべてに適用

## 変更内容

### ソート順の変更
**変更前:** `Date ASC → Id ASC`（挿入順）
**変更後:** `Date ASC → Income DESC → Id ASC`（チャージ優先）

### LedgerRepository.cs
- `GetByDateRangeAsync()`: `ORDER BY date ASC, income DESC, id ASC`
- `GetPagedAsync()`: `ORDER BY l.date ASC, l.income DESC, l.id ASC`
- `GetDetailsAsync()`: `ORDER BY use_date ASC, is_charge DESC, is_point_redemption DESC, rowid ASC`

### ReportService.cs
- 3箇所のLINQソートに`.ThenByDescending(l => l.Income)`を追加

### PrintService.cs
- 印刷プレビュー用のLINQソートに同様の修正

### テスト
- TC024を追加: 同一日のチャージと利用が正しい順序で表示されることを確認
- TC006の説明を更新: 新しいソート順の説明を追加

## Test plan
- [ ] 同一日にチャージと利用がある場合、チャージが先に表示される
- [ ] 帳票出力でも同様の順序で出力される
- [ ] 印刷プレビューでも同様の順序で表示される
- [ ] 履歴詳細（ledger_detail）でもチャージが先に表示される
- [ ] dotnet test が全て通る

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)