### PR TITLE
fix: インストーラービルド時にマニュアルを自動変換 (#480)

### DIFF
--- a/ICCardManager/installer/build-installer.bat
+++ b/ICCardManager/installer/build-installer.bat
@@ -42,7 +42,7 @@ if "%ISCC%"=="" (
 echo バージョン: %VERSION%
 echo.
 
-echo [1/4] アプリケーションのビルド...
+echo [1/5] アプリケーションのビルド...
 pushd "%SRC_DIR%"
 dotnet publish -c Release -r win-x64 --self-contained true -o "%PUBLISH_DIR%" -v q
 if errorlevel 1 (
@@ -55,7 +55,7 @@ popd
 echo   ビルド完了
 
 echo.
-echo [2/4] リソースファイルのコピー...
+echo [2/5] リソースファイルのコピー...
 :: Soundsフォルダのコピー
 if not exist "%PUBLISH_DIR%\Resources\Sounds" mkdir "%PUBLISH_DIR%\Resources\Sounds"
 xcopy /Y /Q "%SRC_DIR%\Resources\Sounds\*" "%PUBLISH_DIR%\Resources\Sounds\" >nul 2>&1
@@ -65,7 +65,7 @@ xcopy /Y /Q "%SRC_DIR%\Resources\Templates\*" "%PUBLISH_DIR%\Resources\Templates
 echo   リソースコピー完了
 
 echo.
-echo [3/4] ファイルの確認...
+echo [3/5] ファイルの確認...
 if not exist "%PUBLISH_DIR%\ICCardManager.exe" (
     echo エラー: ICCardManager.exe が見つかりません。
     pause
@@ -74,7 +74,28 @@ if not exist "%PUBLISH_DIR%\ICCardManager.exe" (
 echo   実行ファイル: OK
 
 echo.
-echo [4/4] インストーラーの作成...
+echo [4/5] マニュアルの変換...
+:: pandocがインストールされているか確認
+where pandoc >nul 2>&1
+if errorlevel 1 (
+    echo   警告: pandocがインストールされていません。マニュアル変換をスキップします。
+    echo   インストール: winget install pandoc または https://pandoc.org/installing.html
+    goto skip_manual
+)
+:: 変換スクリプトの存在確認
+if not exist "%PROJECT_ROOT%\docs\manual\convert-to-docx.bat" (
+    echo   警告: 変換スクリプトが見つかりません。マニュアル変換をスキップします。
+    goto skip_manual
+)
+:: マニュアル変換を実行（更新が必要なもののみ）
+pushd "%PROJECT_ROOT%\docs\manual"
+call convert-to-docx.bat
+popd
+echo   マニュアル変換完了
+:skip_manual
+
+echo.
+echo [5/5] インストーラーの作成...
 if not exist "%OUTPUT_DIR%" mkdir "%OUTPUT_DIR%"
 "%ISCC%" /DMyAppVersion=%VERSION% "%SCRIPT_DIR%ICCardManager.iss"
 if errorlevel 1 (


### PR DESCRIPTION
## Summary
- インストーラー作成時に、.docxファイルが.mdファイルより古い場合、マニュアルを自動で再変換
- 既存の`convert-to-docx.ps1`/`convert-to-docx.bat`を活用（タイムスタンプチェック機能あり）
- pandocがインストールされていない場合は警告を表示してスキップ（ビルドは続行）

## 変更内容

### build-installer.ps1
- ステップ数を8→9に変更
- 新しいStep 7「マニュアルの変換」を追加
  - pandocの存在チェック
  - 変換スクリプトの存在チェック
  - `convert-to-docx.ps1 -NoMermaid`を実行
  - エラー時も警告を出してビルド続行

### build-installer.bat
- ステップ数を4→5に変更
- 新しいStep 4「マニュアルの変換」を追加
  - `where pandoc`で存在チェック
  - `convert-to-docx.bat`を呼び出し

## ビルドフロー（PowerShell版）
```
[1/9] Inno Setup の確認
[2/9] アイコンの生成
[3/9] アプリケーションのビルド
[4/9] デバッグツールのビルド
[5/9] リソースファイルのコピー
[6/9] 発行ファイルの確認
[7/9] マニュアルの変換 ← NEW
[8/9] インストーラーの作成
```

## Test plan
- [ ] pandocがインストールされた環境でビルドし、マニュアルが変換されることを確認
- [ ] pandocがない環境でビルドし、警告が出てもビルドが完了することを確認
- [ ] .mdを更新後にビルドし、.docxが再生成されることを確認
- [ ] .docxが最新の場合は変換がスキップされることを確認

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)