### PR TITLE
fix: 月次繰越の受入欄を空欄に変更 (#481)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -463,10 +463,11 @@ namespace ICCardManager.Services
             var previousMonth = month == 1 ? 12 : month - 1;
 
             // 列配置: A=出納年月日, B-D=摘要(結合), E=受入金額, F=払出金額, G=残額, H=氏名, I-L=備考(結合)
+            // Issue #481: 月次繰越の受入欄は記載しない（年度繰越のみ受入欄に記載）
             var carryoverDate = new DateTime(year, month, 1);
             worksheet.Cell(row, 1).Value = WarekiConverter.ToWareki(carryoverDate); // 出納年月日 (A列)
             worksheet.Cell(row, 2).Value = SummaryGenerator.GetCarryoverFromPreviousMonthSummary(previousMonth); // 摘要 (B-D列)
-            worksheet.Cell(row, 5).Value = balance; // 受入金額 (E列)
+            worksheet.Cell(row, 5).Value = "";      // 受入金額 (E列) - 月次繰越は空欄
             worksheet.Cell(row, 6).Value = "";      // 払出金額 (F列)
             worksheet.Cell(row, 7).Value = balance; // 残額 (G列)
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
@@ -156,9 +156,10 @@ public class ReportServiceTests : IDisposable
         worksheet.Cell("H2").GetString().Should().Be("001");
 
         // 前月繰越行の検証（行5）- Issue #451で追加
+        // Issue #481: 月次繰越の受入欄は空欄（年度繰越のみ受入欄に記載）
         worksheet.Cell(5, 1).GetString().Should().Be("R6.6.1");
         worksheet.Cell(5, 2).GetString().Should().Be("5月より繰越");
-        worksheet.Cell(5, 5).GetValue<int>().Should().Be(5000);  // 受入金額 (E列)
+        worksheet.Cell(5, 5).IsEmpty().Should().BeTrue();        // 受入金額 (E列) - 月次繰越は空欄
         worksheet.Cell(5, 7).GetValue<int>().Should().Be(5000);  // 残額 (G列)
 
         // データ行の検証（行6から開始、列はE=受入, F=払出, G=残額, H=氏名）
@@ -293,8 +294,9 @@ public class ReportServiceTests : IDisposable
         var worksheet = workbook.Worksheets.First();
 
         // 前月繰越行の検証（行5）- Issue #451で追加
+        // Issue #481: 月次繰越の受入欄は空欄（年度繰越のみ受入欄に記載）
         worksheet.Cell(5, 2).GetString().Should().Be("2月より繰越");
-        worksheet.Cell(5, 5).GetValue<int>().Should().Be(9000);  // 受入金額 (E列)
+        worksheet.Cell(5, 5).IsEmpty().Should().BeTrue();        // 受入金額 (E列) - 月次繰越は空欄
         worksheet.Cell(5, 7).GetValue<int>().Should().Be(9000);  // 残額 (G列)
 
         // データ行の検証（行6から開始）
@@ -1268,8 +1270,9 @@ public class ReportServiceTests : IDisposable
         // Issue #451: 前月繰越行が追加されるため、行番号が+1
 
         // 前月繰越行（行5）- Issue #451で追加
+        // Issue #481: 月次繰越の受入欄は空欄（年度繰越のみ受入欄に記載）
         worksheet.Cell(5, 2).GetString().Should().Be("2月より繰越");
-        worksheet.Cell(5, 5).GetValue<int>().Should().Be(9200);  // 受入金額 (E列)
+        worksheet.Cell(5, 5).IsEmpty().Should().BeTrue();        // 受入金額 (E列) - 月次繰越は空欄
         worksheet.Cell(5, 7).GetValue<int>().Should().Be(9200);  // 残額 (G列)
 
         // 月計行（3月はデータなしなので0）- 行6、列配置: B=摘要, G=残額


### PR DESCRIPTION
## Summary

- 物品出納簿の月次繰越行（例: "5月より繰越"）の受入欄（E列）を空欄に変更
- 年度繰越行（"前年度より繰越"）は従来どおり受入欄に金額を記載
- 関連テストケース（TC001, TC003, TC017）を更新

## 変更の背景

物品出納簿の一般的な記載方法では:
- **年度繰越**: 新年度の最初に前年度からの繰越残高を「受入」として記載
- **月次繰越**: 前月からの繰り越しは「残額」欄のみに記載し、受入欄は空欄

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `Services/ReportService.cs` | `WriteMonthlyCarryoverRow`の受入欄を空欄に |
| `ReportServiceTests.cs` | TC001, TC003, TC017の受入欄検証を更新 |

## Test plan

- [ ] TC001: 5月分帳票の「5月より繰越」行で受入欄が空欄
- [ ] TC003: 3月分帳票の「2月より繰越」行で受入欄が空欄
- [ ] TC017: 複数月データの「2月より繰越」行で受入欄が空欄
- [ ] 年度繰越（TC002, TC010等）は受入欄に金額が記載される（変更なし）

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)