### PR TITLE
fix: カード種別選択前に残高を読み取るように修正 (#482)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardTypeSelectionDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardTypeSelectionDialog.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="カード種別の選択"
-        Height="280"
+        Height="340"
         Width="420"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
@@ -33,14 +33,25 @@
         </StackPanel>
 
         <!-- 説明文 -->
-        <Border Grid.Row="1" Background="#FFF8E1" CornerRadius="4" Padding="12" Margin="0,0,0,20">
-            <TextBlock TextWrapping="Wrap"
-                       FontSize="{DynamicResource SmallFontSize}"
-                       Foreground="#795548">
-                <Run Text="💡 ヒント: "/>
-                <Run Text="職員の認証に使用するカードは「職員証」、交通費精算に使用するカードは「交通系ICカード」を選択してください。"/>
-            </TextBlock>
-        </Border>
+        <StackPanel Grid.Row="1">
+            <Border Background="#FFF8E1" CornerRadius="4" Padding="12" Margin="0,0,0,10">
+                <TextBlock TextWrapping="Wrap"
+                           FontSize="{DynamicResource SmallFontSize}"
+                           Foreground="#795548">
+                    <Run Text="💡 ヒント: "/>
+                    <Run Text="職員の認証に使用するカードは「職員証」、交通費精算に使用するカードは「交通系ICカード」を選択してください。"/>
+                </TextBlock>
+            </Border>
+            <!-- Issue #482: カードを離さないよう警告 -->
+            <Border Background="#FFEBEE" CornerRadius="4" Padding="12" Margin="0,0,0,10">
+                <TextBlock TextWrapping="Wrap"
+                           FontSize="{DynamicResource SmallFontSize}"
+                           Foreground="#C62828">
+                    <Run Text="⚠ 注意: "/>
+                    <Run Text="選択が完了するまでカードをリーダーから離さないでください。"/>
+                </TextBlock>
+            </Border>
+        </StackPanel>
 
         <!-- ボタン -->
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary

- 未登録カードタッチ時に、カード種別選択ダイアログを表示する**前**に残高を読み取るよう変更
- 残高読み取り中のエラーイベントを一時的に抑制し、混乱を招くエラーメッセージを防止
- カード種別選択ダイアログに「選択が完了するまでカードをリーダーから離さないでください」という警告を追加

## 問題の詳細

未登録カードをタッチして「職員証」か「交通系ICカード」かを選択する前にカードを離すと:
1. 残高が0円として登録されてしまう
2. 「カードリーダーエラー」のシステム警告メッセージが2件表示される

## 修正内容

| ファイル | 変更内容 |
|----------|----------|
| `ViewModels/MainViewModel.cs` | `ReadBalanceAsync`をダイアログ表示前に移動、エラーイベント抑制 |
| `Views/Dialogs/CardTypeSelectionDialog.xaml` | 警告メッセージ追加、高さ調整 |

## Before/After

**Before:**
1. カードタッチ → 選択ダイアログ表示
2. ユーザーが選択 → **この時点で残高読み取り**
3. カードが離れていると残高読み取り失敗 → 0円になる

**After:**
1. カードタッチ → **即座に残高読み取り** → 選択ダイアログ表示
2. ユーザーが選択
3. 事前に読み取った残高を使用 → 正しい残高で登録

## Test plan

- [ ] 未登録カードをタッチして「交通系ICカード」を選択
  - 選択前にカードを離しても正しい残高で登録される
- [ ] 選択ダイアログに警告メッセージ「⚠ 注意: 選択が完了するまでカードをリーダーから離さないでください。」が表示される
- [ ] エラーメッセージが表示されないことを確認

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)