### PR TITLE
fix: カード登録後にダッシュボードを更新するよう修正 (#483)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -915,8 +915,10 @@ public partial class MainViewModel : ViewModelBase
                 cardDialog.InitializeWithIdmAndBalance(idm, preReadBalance);
                 cardDialog.ShowDialog();
 
-                // ダイアログを閉じた後、貸出中カード一覧を更新
+                // ダイアログを閉じた後、貸出中カード一覧とダッシュボードを更新
+                // Issue #483: RefreshDashboardAsync を追加してカード一覧を更新
                 await RefreshLentCardsAsync();
+                await RefreshDashboardAsync();
                 break;
 
             case Views.Dialogs.CardTypeSelectionResult.Cancel:


### PR DESCRIPTION
## Summary

- 未登録カードタッチ → 「交通系ICカード」選択 → 登録後、メイン画面右側のカード一覧（ダッシュボード）が更新されない問題を修正
- `HandleUnregisteredCardAsync()` に `RefreshDashboardAsync()` を追加

## 問題の詳細

未登録カードをタッチして「交通系ICカード」を選択・登録した後、メイン画面右側のカード一覧部分に新しいカードが表示されない。

## 原因

`HandleUnregisteredCardAsync()` で CardManageDialog を閉じた後、`RefreshLentCardsAsync()` のみが呼ばれ、`RefreshDashboardAsync()` が呼ばれていなかった。

一方、`OpenCardManageAsync()` コマンドでは両方が呼ばれており、動作に不整合があった。

## 修正内容

```csharp
// Before
await RefreshLentCardsAsync();

// After
await RefreshLentCardsAsync();
await RefreshDashboardAsync();  // 追加
```

## Test plan

- [ ] 未登録カードをタッチして「交通系ICカード」を選択
- [ ] カード情報を入力して登録
- [ ] メイン画面右側のカード一覧に新しいカードが表示されることを確認

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)