### PR TITLE
feat: 物品出納簿を年度ファイル・月別シート構成に変更 (#477)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
@@ -325,12 +325,14 @@ public partial class ReportViewModel : ViewModelBase
         }
 
         // 上書き確認: 既存ファイルをチェック
+        // Issue #477: 年度ファイル名に変更
         var existingFiles = new List<string>();
         var outputPaths = new Dictionary<string, string>(); // cardIdm -> outputPath
+        var fiscalYear = ReportService.GetFiscalYear(SelectedYear, SelectedMonth);
 
         foreach (var card in SelectedCards)
         {
-            var fileName = $"物品出納簿_{card.CardType}_{card.CardNumber}_{SelectedYear}年{SelectedMonth}月.xlsx";
+            var fileName = ReportService.GetFiscalYearFileName(card.CardType, card.CardNumber, fiscalYear);
             var outputPath = Path.Combine(OutputFolder, fileName);
             outputPaths[card.CardIdm] = outputPath;
 
@@ -341,6 +343,7 @@ public partial class ReportViewModel : ViewModelBase
         }
 
         // 既存ファイルがある場合は確認ダイアログを表示
+        // Issue #477: 年度ファイルの該当月シートのみ更新
         var useAlternativeNames = false;
         if (existingFiles.Count > 0)
         {
@@ -349,11 +352,13 @@ public partial class ReportViewModel : ViewModelBase
                 : string.Join("\n", existingFiles.Take(5).Select(f => $"・{f}")) + $"\n・...他 {existingFiles.Count - 5} 件";
 
             var result = MessageBox.Show(
-                $"以下のファイルが既に存在します:\n\n{fileList}\n\n上書きしますか？\n\n" +
-                "「はい」: 上書きする\n" +
+                $"以下のファイルが既に存在します:\n\n{fileList}\n\n" +
+                $"{SelectedMonth}月のシートを更新しますか？\n" +
+                $"（他の月のシートは変更されません）\n\n" +
+                "「はい」: 更新する\n" +
                 "「いいえ」: 別名で保存する（日時を付加）\n" +
                 "「キャンセル」: 中止する",
-                "ファイル上書き確認",
+                "ファイル更新確認",
                 MessageBoxButton.YesNoCancel,
                 MessageBoxImage.Question);
 


### PR DESCRIPTION
## Summary

- 物品出納簿を**年度ごとに1つのExcelファイル**に変更
- **月ごとにワークシートを分離**（シート名: 4月, 5月, ... 3月）
- 上書き時は**当該月のシートのみ更新**（他の月は保持）

## 変更前後の比較

### Before
```
物品出納簿_はやかけん_H001_2024年4月.xlsx
物品出納簿_はやかけん_H001_2024年5月.xlsx
物品出納簿_はやかけん_H001_2024年6月.xlsx
...
```

### After
```
物品出納簿_はやかけん_H001_2024年度.xlsx
  ├── 4月 (シート)
  ├── 5月 (シート)
  ├── 6月 (シート)
  └── ...
```

## 技術的な変更内容

| ファイル | 変更内容 |
|----------|----------|
| `Services/ReportService.cs` | 年度ファイルへの月別シート作成/更新ロジック追加 |
| `ViewModels/ReportViewModel.cs` | ファイル名を年度形式に変更、確認メッセージ更新 |
| `ReportServiceTests.cs` | 新機能のテストケース追加（TC025-TC030） |

## 新しいメソッド

```csharp
// 年度計算
public static int GetFiscalYear(int year, int month)
// 例: (2024, 6) → 2024、(2025, 1) → 2024

// 年度ファイル名生成
public static string GetFiscalYearFileName(string cardType, string cardNumber, int fiscalYear)
// 例: "物品出納簿_はやかけん_H001_2024年度.xlsx"
```

## シート管理ロジック

1. **ファイルが存在しない場合**: テンプレートから新規作成、シート名を月名に変更
2. **ファイルが存在する場合**: ファイルを開く
   - 該当月のシートが存在する → データ部分をクリアして再出力
   - 該当月のシートが存在しない → テンプレートからシートを追加
3. シートを月順（4月〜3月）に並び替え

## Test plan

- [ ] TC025: 帳票作成でシート名が月名になる
- [ ] TC026: 同一ファイルに複数月のシートを追加できる
- [ ] TC027: 既存シートを上書き更新できる
- [ ] TC028: シートが月順（4月〜3月）に並ぶ
- [ ] TC029: GetFiscalYear が正しく年度を計算する
- [ ] TC030: GetFiscalYearFileName が正しいファイル名を生成する
- [ ] 既存の帳票作成テスト（TC001-TC024）が引き続きパスする

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)