### PR TITLE
fix: 新規購入より前の月の物品出納簿を作成しない (#501)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -150,5 +150,16 @@ namespace ICCardManager.Data.Repositories
         /// <param name="details">新しい詳細リスト</param>
         /// <returns>成功した場合true</returns>
         Task<bool> ReplaceDetailsAsync(int ledgerId, IEnumerable<LedgerDetail> details);
+
+        /// <summary>
+        /// 指定カードの新規購入日を取得
+        /// </summary>
+        /// <remarks>
+        /// Issue #501対応: 物品出納簿の作成時に、新規購入より前の月をスキップするために使用。
+        /// summary = "新規購入" の最初のレコードの日付を返す。
+        /// </remarks>
+        /// <param name="cardIdm">ICカードIDm</param>
+        /// <returns>新規購入日、存在しない場合はnull</returns>
+        Task<DateTime?> GetPurchaseDateAsync(string cardIdm);
     }
 }

--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -610,5 +610,26 @@ WHERE card_idm IN ({string.Join(", ", parameters)})";
             // 新しい詳細を登録
             return await InsertDetailsAsync(ledgerId, details);
         }
+
+        /// <inheritdoc/>
+        public async Task<DateTime?> GetPurchaseDateAsync(string cardIdm)
+        {
+            var connection = _dbContext.GetConnection();
+
+            using var command = connection.CreateCommand();
+            // Issue #501: 新規購入レコードの最初の日付を取得
+            command.CommandText = @"SELECT MIN(date) FROM ledger
+WHERE card_idm = @cardIdm AND summary = '新規購入'";
+
+            command.Parameters.AddWithValue("@cardIdm", cardIdm);
+
+            var result = await command.ExecuteScalarAsync();
+            if (result != null && result != DBNull.Value)
+            {
+                return DateTime.Parse((string)result);
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- カードの新規購入日より前の月の物品出納簿シートを作成しないように変更
- 不要なシートの作成を防ぎ、ユーザー体験を向上

## Changes

### 新規追加
- `ILedgerRepository.GetPurchaseDateAsync()` - 新規購入日を取得するメソッド
- `LedgerRepository.GetPurchaseDateAsync()` - summary = "新規購入" の最初のレコード日付を返す
- `ReportGenerationResult.Skipped` プロパティ - スキップ結果を示すフラグ
- `ReportGenerationResult.SkippedResult()` ファクトリメソッド
- `BatchReportGenerationResult.SkippedCount` プロパティ

### 変更
- `ReportService.CreateMonthlyReportAsync()` - 購入月より前の月はスキップして早期リターン

## Test plan
- [ ] TC031: 新規購入より前の月でスキップ結果が返ることを確認
- [ ] TC032: 新規購入月は正常に帳票が作成されることを確認
- [ ] 6月に新規購入したカードで4月の帳票出力を試み、シートが作成されないことを確認
- [ ] 6月に新規購入したカードで6月の帳票出力を試み、正常に作成されることを確認

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)