### PR TITLE
test: 金額表示テストの期待値から + 記号を削除

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Dtos/DtoMapperTests.cs
@@ -259,7 +259,7 @@ public class DtoMapperTests
     /// 受入金額の表示プロパティが正しいこと
     /// </summary>
     [Theory]
-    [InlineData(1000, "+1,000")]
+    [InlineData(1000, "1,000")]
     [InlineData(0, "")]
     public void LedgerDto_IncomeDisplay_ShouldFormatCorrectly(int income, string expected)
     {

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/HistoryViewModelTests.cs
@@ -669,7 +669,7 @@ public class HistoryViewModelTests
         // Assert
         displayItem.Income.Should().Be(3000);
         displayItem.HasExpense.Should().BeFalse();
-        displayItem.IncomeDisplay.Should().Be("+3,000");
+        displayItem.IncomeDisplay.Should().Be("3,000");
         displayItem.ExpenseDisplay.Should().BeEmpty();
     }
 


### PR DESCRIPTION
## Summary
- Issue #497 の変更（金額表示から符号を削除）に合わせてテストの期待値を修正

## Changes
- `DtoMapperTests.cs`: `IncomeDisplay` の期待値 `"+1,000"` → `"1,000"`
- `HistoryViewModelTests.cs`: `IncomeDisplay` の期待値 `"+3,000"` → `"3,000"`

## Test plan
- [x] `dotnet test` で全テストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)