### PR TITLE
feat: デバッグ用データビューアにDBファイル選択機能を追加 (#507)

### DIFF
--- a/ICCardManager/tools/DebugDataViewer/MainWindow.xaml
+++ b/ICCardManager/tools/DebugDataViewer/MainWindow.xaml
@@ -232,7 +232,14 @@
                        Foreground="Gray"
                        FontSize="11"
                        VerticalAlignment="Center"
-                       Margin="0,0,20,0"/>
+                       Margin="0,0,10,0"/>
+            <Button Content="選択..."
+                    Command="{Binding SelectDatabaseCommand}"
+                    Padding="10,5"
+                    FontSize="11"
+                    VerticalAlignment="Center"
+                    ToolTip="別のデータベースファイルを開く"
+                    Margin="0,0,20,0"/>
             <Button Content="閉じる"
                     Click="CloseButton_Click"
                     Padding="20,10"


### PR DESCRIPTION
## Summary
- デバッグ用データビューアのフッターに「選択...」ボタンを追加
- 任意のSQLiteデータベースファイル（*.db）を開いてデータを閲覧可能に
- DBファイル変更時、自動的に接続を切り替えてテーブルデータを再読み込み

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `tools/DebugDataViewer/MainViewModel.cs` | `SelectDatabaseCommand` と `ChangeDatabaseAsync` メソッドを追加 |
| `tools/DebugDataViewer/MainWindow.xaml` | フッターに「選択...」ボタンを追加 |

## UI変更
![フッター部分に「選択...」ボタンが追加されます]

```
DB: C:\ProgramData\ICCardManager\iccard.db  [選択...]  [閉じる]
```

## Test plan
- [ ] デバッグ用データビューアを起動
- [ ] フッターの「選択...」ボタンをクリック
- [ ] ファイルダイアログが開き、初期ディレクトリが現在のDBファイルのディレクトリであることを確認
- [ ] 別のDBファイルを選択
- [ ] DBパス表示が更新され、テーブルデータが再読み込みされることを確認
- [ ] 存在しないファイルを選択しようとした場合、ダイアログで選択できないことを確認

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)