### PR TITLE
fix: バックアップからのリストアが失敗する問題を修正 (#508)

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/DbContext.cs
+++ b/ICCardManager/src/ICCardManager/Data/DbContext.cs
@@ -122,6 +122,27 @@ namespace ICCardManager.Data
         }
 
         /// <summary>
+        /// データベース接続を一時的に閉じる（Issue #508: リストア用）
+        /// </summary>
+        /// <remarks>
+        /// リストア処理でDBファイルを置き換える前に呼び出す。
+        /// 接続を閉じることでファイルロックを解放する。
+        /// その後GetConnection()を呼ぶと自動的に再接続される。
+        /// </remarks>
+        public void CloseConnection()
+        {
+            if (_connection != null)
+            {
+                _connection.Close();
+                _connection.Dispose();
+                _connection = null;
+#if DEBUG
+                System.Diagnostics.Debug.WriteLine("[DbContext] 接続を閉じました（リストア準備）");
+#endif
+            }
+        }
+
+        /// <summary>
         /// データベースを初期化（マイグレーションを実行）
         /// </summary>
         public void InitializeDatabase()

--- a/ICCardManager/src/ICCardManager/Services/BackupService.cs
+++ b/ICCardManager/src/ICCardManager/Services/BackupService.cs
@@ -206,6 +206,11 @@ namespace ICCardManager.Services
                     return false;
                 }
 
+                // Issue #508: DBファイルを置き換える前に接続を閉じる
+                // SQLite接続が開いているとファイルがロックされ、置き換えに失敗する
+                _dbContext.CloseConnection();
+                _logger.LogDebug("リストア準備: DB接続を閉じました");
+
                 // 現在のDBを退避
                 if (File.Exists(targetPath))
                 {


### PR DESCRIPTION
## Summary
- リストア時にSQLite接続が開いたままのため、DBファイルがロックされて置き換えに失敗していた問題を修正
- `DbContext.CloseConnection()` メソッドを追加し、リストア前に接続を閉じるようにした

## 問題の原因
1. `DbContext` はシングルトンで、SQLite接続が開いたまま保持される
2. リストア時に `File.Move()` でファイルを移動しようとすると、ファイルがロックされているため失敗
3. 既存のテストは `DbContext.Dispose()` を呼んでから実行していたため、バグを検出できなかった

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `src/ICCardManager/Data/DbContext.cs` | `CloseConnection()` メソッドを追加 |
| `src/ICCardManager/Services/BackupService.cs` | リストア前に `CloseConnection()` を呼び出す |
| `tests/ICCardManager.Tests/Services/BackupServiceTests.cs` | 接続が開いた状態でのリストアテストを追加 |

## 技術詳細
```csharp
// DbContext.cs - 新規追加
public void CloseConnection()
{
    if (_connection != null)
    {
        _connection.Close();
        _connection.Dispose();
        _connection = null;
    }
}
```

```csharp
// BackupService.cs - RestoreFromBackup()内
// Issue #508: DBファイルを置き換える前に接続を閉じる
_dbContext.CloseConnection();
```

## Test plan
- [x] 全1000テストがパス
- [x] 接続が開いた状態でのリストアテストを追加・成功
- [ ] 実機でバックアップファイルからリストアし、職員・ICカード情報が復元されることを確認

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)