### PR TITLE
feat: データエクスポート完了時に保存完了メッセージを表示 (#512)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -85,6 +85,7 @@ public partial class DataExportImportViewModel : ViewModelBase
 {
     private readonly CsvExportService _exportService;
     private readonly CsvImportService _importService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private DataType _selectedExportType = DataType.Cards;
@@ -162,10 +163,12 @@ public partial class DataExportImportViewModel : ViewModelBase
 
     public DataExportImportViewModel(
         CsvExportService exportService,
-        CsvImportService importService)
+        CsvImportService importService,
+        IDialogService dialogService)
     {
         _exportService = exportService;
         _importService = importService;
+        _dialogService = dialogService;
     }
 
     partial void OnSelectedExportTypeChanged(DataType value)
@@ -220,10 +223,16 @@ public partial class DataExportImportViewModel : ViewModelBase
                 {
                     LastExportedFile = result.FilePath;
                     StatusMessage = $"エクスポート完了: {result.ExportedCount}件を出力しました";
+
+                    // Issue #512: 保存完了メッセージを表示
+                    _dialogService.ShowInformation(
+                        $"CSVファイルを保存しました。\n\n出力先: {result.FilePath}\n出力件数: {result.ExportedCount}件",
+                        "エクスポート完了");
                 }
                 else
                 {
                     StatusMessage = $"エクスポートエラー: {result.ErrorMessage}";
+                    _dialogService.ShowError($"エクスポートに失敗しました。\n\n{result.ErrorMessage}", "エクスポートエラー");
                 }
             }
             catch (Exception ex)

--- a/ICCardManager/src/ICCardManager/ViewModels/OperationLogSearchViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/OperationLogSearchViewModel.cs
@@ -71,6 +71,7 @@ public class OperationLogDisplayItem
 public partial class OperationLogSearchViewModel : ViewModelBase
 {
     private readonly IOperationLogRepository _operationLogRepository;
+    private readonly IDialogService _dialogService;
 
     // 検索条件
     [ObservableProperty]
@@ -158,9 +159,12 @@ public partial class OperationLogSearchViewModel : ViewModelBase
         ? $"{TotalCount}件中 {(CurrentPage - 1) * PageSize + 1}～{Math.Min(CurrentPage * PageSize, TotalCount)}件を表示"
         : "0件";
 
-    public OperationLogSearchViewModel(IOperationLogRepository operationLogRepository)
+    public OperationLogSearchViewModel(
+        IOperationLogRepository operationLogRepository,
+        IDialogService dialogService)
     {
         _operationLogRepository = operationLogRepository;
+        _dialogService = dialogService;
 
         // デフォルトは今月
         var today = DateTime.Today;
@@ -346,10 +350,16 @@ public partial class OperationLogSearchViewModel : ViewModelBase
 
                 LastExportedFile = dialog.FileName;
                 StatusMessage = $"エクスポート完了: {logs.Count()}件を出力しました";
+
+                // Issue #512: 保存完了メッセージを表示
+                _dialogService.ShowInformation(
+                    $"CSVファイルを保存しました。\n\n出力先: {dialog.FileName}\n出力件数: {logs.Count()}件",
+                    "エクスポート完了");
             }
             catch (Exception ex)
             {
                 StatusMessage = $"エクスポートエラー: {ex.Message}";
+                _dialogService.ShowError($"エクスポートに失敗しました。\n\n{ex.Message}", "エクスポートエラー");
             }
         }
     }


### PR DESCRIPTION
## Summary
- データエクスポート完了後、ダイアログで保存完了メッセージを表示するようにした
- エラー発生時もダイアログでエラーメッセージを表示

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `DataExportImportViewModel.cs` | `IDialogService` を追加、エクスポート完了/失敗時にダイアログ表示 |
| `OperationLogSearchViewModel.cs` | 同上 |

## 表示メッセージ

### 成功時
```
タイトル: エクスポート完了
内容: CSVファイルを保存しました。

出力先: C:\...\cards_20260206_123456.csv
出力件数: 10件
```

### 失敗時
```
タイトル: エクスポートエラー
内容: エクスポートに失敗しました。

{エラーメッセージ}
```

## Test plan
- [x] 全1000テストがパス
- [x] データエクスポート/インポート画面でCSVエクスポートを実行し、完了ダイアログが表示されることを確認
- [ ] 操作ログ検索画面でCSVエクスポートを実行し、完了ダイアログが表示されることを確認
- [ ] 書き込み権限のないフォルダにエクスポートしようとした場合、エラーダイアログが表示されることを確認

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)