### PR TITLE
feat: 乗り継ぎ駅のエイリアスマッピング機能を追加

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -89,22 +89,7 @@ namespace ICCardManager.Services
             new HashSet<string> { "天神", "福岡（天神）" },
 
             // 千早グループ（JR・西鉄）
-            new HashSet<string> { "千早", "西鉄千早" },
-
-            // 空港グループ（出張の出発地/帰着地として同一視）
-            new HashSet<string>
-            {
-                "福岡空港",
-                "羽田空港第1ターミナル",
-                "羽田空港第2ターミナル",
-                "羽田空港第1・第2ターミナル",
-                "新千歳空港",
-                "仙台空港",
-                "成田空港",
-                "中部国際空港",
-                "関西空港",
-                "大阪空港"
-            }
+            new HashSet<string> { "千早", "西鉄千早" }
         };
 
         /// <summary>


### PR DESCRIPTION
## Summary
- 異なる事業者間で駅名が異なる乗り継ぎ駅を同一とみなして摘要を統合できるようにする
- エイリアスマッピング方式で乗り継ぎ駅グループを事前定義
- `AreTransferStations()` メソッドで同一グループ内かどうかを判定

## 対象グループ（2グループ）

### 天神グループ
| 事業者 | 駅名 |
|--------|------|
| 福岡市地下鉄 | 天神 |
| 西鉄 | 福岡（天神） |

### 千早グループ
| 事業者 | 駅名 |
|--------|------|
| JR | 千早 |
| 西鉄 | 西鉄千早 |

> **Note**: 空港グループは対象外。空港間の移動（飛行機）は乗り継ぎとして統合せず、「天神～福岡空港、羽田空港第1ターミナル～霞が関」のように各区間を明示的に表示する。

## 変更点

- `SummaryGenerator.cs`
  - `TransferStationGroups` 静的フィールドを追加（乗り継ぎ駅グループの定義）
  - `AreTransferStations()` メソッドを追加（2駅が同一グループかを判定）
  - `ConsolidateRoutes()` の判定条件を完全一致からエイリアス判定に変更

## Test plan
- [ ] 天神乗り継ぎ：薬院→天神、福岡（天神）→久留米 が「薬院～久留米」に統合されることを確認
- [ ] 千早乗り継ぎ：博多→千早、西鉄千早→西鉄香椎 が「博多～西鉄香椎」に統合されることを確認
- [ ] 空港経由出張：天神→福岡空港、羽田空港→霞が関 が「天神～福岡空港、羽田空港～霞が関」と各区間が表示されることを確認
- [ ] 従来の完全一致乗り継ぎが正常に動作することを確認
- [ ] 乗り継ぎでない場合は別々の経路として表示されることを確認

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)