### PR TITLE
fix: アプリのバージョン表示を1.4.0に更新 (#522)

### DIFF
--- a/ICCardManager/src/ICCardManager/ICCardManager.csproj
+++ b/ICCardManager/src/ICCardManager/ICCardManager.csproj
@@ -12,9 +12,9 @@
     <PlatformTarget>x86</PlatformTarget>
 
     <!-- バージョン情報 -->
-    <Version>1.3.0</Version>
-    <FileVersion>1.3.0.0</FileVersion>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <Version>1.4.0</Version>
+    <FileVersion>1.4.0.0</FileVersion>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
     <Company>Your Organization</Company>
     <Product>交通系ICカード管理システム</Product>
     <Description>交通系ICカードの貸出管理システム</Description>


### PR DESCRIPTION
## Summary

- csprojのバージョン情報を1.3.0から1.4.0に更新
- アプリ右下のステータスバーに正しいバージョン番号（1.4.0）が表示されるようになる

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| Version | 1.3.0 | 1.4.0 |
| FileVersion | 1.3.0.0 | 1.4.0.0 |
| AssemblyVersion | 1.3.0.0 | 1.4.0.0 |

## Test plan

- [x] アプリを起動し、右下のステータスバーに「v1.4.0」と表示されることを確認

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)