### PR TITLE
feat: 履歴編集画面で利用者の変更を可能に (#529)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerEditDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerEditDialog.xaml
@@ -12,7 +12,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         AutomationProperties.Name="利用履歴変更ダイアログ"
-        AutomationProperties.HelpText="選択した履歴の摘要と備考を変更できます。">
+        AutomationProperties.HelpText="選択した履歴の利用者、摘要、備考を変更できます。">
 
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
@@ -73,16 +73,21 @@
                                VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <!-- 利用者 -->
+                <!-- 利用者（選択可能 Issue #529） -->
                 <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,8,0,0">
                     <TextBlock Text="利用者:"
                                FontSize="{DynamicResource SmallFontSize}"
                                Foreground="Gray"
                                VerticalAlignment="Center"/>
-                    <TextBlock Text="{Binding StaffName}"
-                               FontSize="{DynamicResource SmallFontSize}"
-                               Margin="5,0,0,0"
-                               VerticalAlignment="Center"/>
+                    <ComboBox ItemsSource="{Binding StaffList}"
+                              SelectedItem="{Binding SelectedStaff}"
+                              DisplayMemberPath="Name"
+                              FontSize="{DynamicResource SmallFontSize}"
+                              Margin="5,0,0,0"
+                              MinWidth="150"
+                              VerticalAlignment="Center"
+                              AutomationProperties.Name="利用者を選択"
+                              ToolTip="利用者を変更できます（前の利用者が返却し忘れた場合など）"/>
                 </StackPanel>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary
- 履歴編集画面（「変更」ボタンから開くダイアログ）で利用者を変更できるようになりました
- 前の利用者が返却処理をし忘れた場合に、現在の利用者が代わりに返却処理を行う際などに利用できます

## Technical Details
**ViewModelの変更:**
- `IStaffRepository`をDIで注入
- `StaffList`プロパティで職員の選択肢を提供
- `SelectedStaff`プロパティで選択中の職員を管理
- `InitializeAsync()`で職員リストを読み込み、現在の利用者を選択状態に設定
- `Save()`で利用者の変更（`LenderIdm`と`StaffName`）も保存

**XAMLの変更:**
- 読み取り専用のTextBlockをComboBoxに置き換え
- 職員名で表示し、選択可能に

## Test plan
- [x] 履歴画面で「変更」ボタンをクリックしてダイアログを開く
- [x] 利用者のComboBoxに職員リストが表示されることを確認
- [x] 現在の利用者が選択されていることを確認
- [ ] 別の職員を選択して「保存」をクリック
- [ ] 履歴一覧で利用者が変更されていることを確認
- [ ] 操作ログに変更が記録されていることを確認

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)