### PR TITLE
feat: 操作ログに変更内容の詳細を表示 (#537)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
@@ -209,7 +209,7 @@
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
                 <DataGridTextColumn Header="対象" Binding="{Binding TargetTableDisplay}" Width="80"/>
-                <DataGridTextColumn Header="対象ID" Binding="{Binding TargetId}" Width="180"/>
+                <DataGridTextColumn Header="対象詳細" Binding="{Binding TargetDisplayName}" Width="250"/>
                 <DataGridTextColumn Header="操作者" Binding="{Binding OperatorName}" Width="100"/>
                 <DataGridTextColumn Header="詳細" Binding="{Binding DetailSummary}" Width="*"/>
             </DataGrid.Columns>


### PR DESCRIPTION
## Summary
- 操作ログの「詳細」列にUPDATE操作時の変更内容（変更前→変更後）を表示するようになりました
- 例: 「利用履歴を更新: 利用者: 田中太郎→山田花子、摘要: 鉄道（博多～天神）→バス（★）」

## Technical Details
**変更内容:**
- `GenerateDetailSummary`メソッドを拡張し、UPDATE操作時にJSONを解析して変更点を抽出
- `GetChangedFieldsDescription`メソッドを新規追加
- `GetJsonPropertyValue`ヘルパーメソッドを新規追加

**監視するフィールド:**
| テーブル | フィールド |
|----------|------------|
| ledger | 利用者(StaffName)、摘要(Summary)、備考(Note) |
| staff | 氏名(Name)、職員番号(Number)、備考(Note) |
| ic_card | カード種別(CardType)、カード番号(CardNumber)、備考(Note) |

**その他:**
- 値が30文字を超える場合は省略表示（...）
- 空の値は「（なし）」と表示
- JSON解析エラー時は従来の簡易表示にフォールバック

## Test plan
- [x] 利用履歴を変更して保存
- [x] 操作ログ画面を開く
- [ ] 「詳細」列に変更内容が表示されることを確認
- [ ] 例: 「利用履歴を更新: 利用者: 田中太郎→山田花子」
- [ ] 職員情報を変更して、操作ログに詳細が表示されることを確認
- [ ] カード情報を変更して、操作ログに詳細が表示されることを確認

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)