### PR TITLE
feat: カード一覧とシステム警告の高さ比率を7:3に調整 (#541)

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -505,9 +505,10 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
+                        <!-- Issue #541: カード一覧とシステム警告の高さ比率を7:3に調整 -->
+                        <RowDefinition Height="7*" MinHeight="100"/>
                         <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="3*" MaxHeight="200"/>
                     </Grid.RowDefinitions>
 
                     <!-- ダッシュボードヘッダー -->
@@ -697,19 +698,23 @@
                                Foreground="#F44336"
                                Visibility="{Binding WarningMessages.Count, Converter={StaticResource IntToVisibilityConverter}, Mode=OneWay}"/>
 
-                    <ItemsControl Grid.Row="4"
-                                  ItemsSource="{Binding WarningMessages}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Border Background="#FFF3E0" CornerRadius="4"
-                                        Margin="0,2" Padding="10,8">
-                                    <TextBlock Text="{Binding}"
-                                               TextWrapping="Wrap"
-                                               FontSize="{DynamicResource SmallFontSize}"/>
-                                </Border>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                    <!-- Issue #541: 警告エリアにスクロール機能を追加（高さ制限対応） -->
+                    <ScrollViewer Grid.Row="4"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding WarningMessages}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border Background="#FFF3E0" CornerRadius="4"
+                                            Margin="0,2" Padding="10,8">
+                                        <TextBlock Text="{Binding}"
+                                                   TextWrapping="Wrap"
+                                                   FontSize="{DynamicResource SmallFontSize}"/>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
                 </Grid>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- 画面右側のカード一覧とシステム警告の高さ比率を最大7:3に設定
- カード一覧がスクロールなしで見やすくなるようレイアウトを改善
- システム警告が多い場合もスクロール可能に

## 変更内容

### Grid.RowDefinitions の変更
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| カード一覧 | `Height="*"` | `Height="7*" MinHeight="100"` |
| 警告エリア | `Height="Auto"` | `Height="3*" MaxHeight="200"` |

### 警告エリア
- `ScrollViewer` で囲んで、警告が多い場合もスクロール可能に

## レイアウト動作

```
┌─────────────────────┐
│ 💳 カード残高       │ ← Auto
├─────────────────────┤
│ 並び順: [...]       │ ← Auto
├─────────────────────┤
│                     │
│   カード一覧        │ ← 7* (MinHeight: 100px)
│   (スクロール可)    │
│                     │
├─────────────────────┤
│ ⚠ システム警告      │ ← Auto
├─────────────────────┤
│   警告メッセージ    │ ← 3* (MaxHeight: 200px)
│   (スクロール可)    │
└─────────────────────┘
```

## Test plan
- [ ] カードが多い場合（10枚以上）、カード一覧が7割程度の高さになることを確認
- [ ] カードが少ない場合（2-3枚）、カード一覧が適切な高さに縮小されることを確認
- [x] システム警告が多い場合、スクロールで全て確認できることを確認
- [ ] システム警告がない場合、カード一覧が画面いっぱいに表示されることを確認
- [ ] 文字サイズを「特大」にしても表示が崩れないことを確認

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)