### PR TITLE
feat: 履歴一覧から複数エントリの統合機能を追加（#548）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -193,6 +193,7 @@ namespace ICCardManager
             services.AddSingleton<PrintService>();
             services.AddSingleton<BackupService>();
             services.AddSingleton<OperationLogger>();
+            services.AddSingleton<LedgerMergeService>();
             services.AddSingleton<CsvExportService>();
             services.AddSingleton<CsvImportService>();
             services.AddSingleton<IToastNotificationService, ToastNotificationService>();

--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -152,6 +152,19 @@ namespace ICCardManager.Data.Repositories
         Task<bool> ReplaceDetailsAsync(int ledgerId, IEnumerable<LedgerDetail> details);
 
         /// <summary>
+        /// 複数のLedgerレコードを1つに統合する
+        /// </summary>
+        /// <remarks>
+        /// Issue #548対応: 履歴一覧から複数のエントリを統合する機能。
+        /// トランザクション内で、ソースのdetailsをターゲットに移動し、ソースを削除する。
+        /// </remarks>
+        /// <param name="targetLedgerId">統合先のLedger ID</param>
+        /// <param name="sourceLedgerIds">統合元のLedger IDリスト（削除される）</param>
+        /// <param name="updatedTarget">更新後のターゲットLedger</param>
+        /// <returns>成功した場合true</returns>
+        Task<bool> MergeLedgersAsync(int targetLedgerId, IEnumerable<int> sourceLedgerIds, Ledger updatedTarget);
+
+        /// <summary>
         /// 指定カードの新規購入日（または繰越日）を取得
         /// </summary>
         /// <remarks>

--- a/ICCardManager/src/ICCardManager/Services/LedgerMergeService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LedgerMergeService.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using Microsoft.Extensions.Logging;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 履歴統合の結果
+    /// </summary>
+    public class LedgerMergeResult
+    {
+        public bool Success { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
+        public Ledger? MergedLedger { get; set; }
+    }
+
+    /// <summary>
+    /// 複数のLedgerレコードを統合するサービス
+    /// </summary>
+    /// <remarks>
+    /// Issue #548対応: 履歴一覧から隣接するエントリを1つに統合する。
+    /// 統合先は最も古い（最初の）エントリとし、他のエントリのDetailsを移動後に削除する。
+    /// </remarks>
+    public class LedgerMergeService
+    {
+        private readonly ILedgerRepository _ledgerRepository;
+        private readonly SummaryGenerator _summaryGenerator;
+        private readonly OperationLogger _operationLogger;
+        private readonly ILogger<LedgerMergeService> _logger;
+
+        public LedgerMergeService(
+            ILedgerRepository ledgerRepository,
+            SummaryGenerator summaryGenerator,
+            OperationLogger operationLogger,
+            ILogger<LedgerMergeService> logger)
+        {
+            _ledgerRepository = ledgerRepository;
+            _summaryGenerator = summaryGenerator;
+            _operationLogger = operationLogger;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// 複数のLedgerを統合する
+        /// </summary>
+        /// <param name="ledgerIds">統合するLedger IDのリスト（表示順＝古い順）</param>
+        /// <param name="operatorIdm">操作者IDm（GUI操作の場合はnull）</param>
+        /// <returns>統合結果</returns>
+        public async Task<LedgerMergeResult> MergeAsync(IReadOnlyList<int> ledgerIds, string? operatorIdm = null)
+        {
+            if (ledgerIds.Count < 2)
+            {
+                return new LedgerMergeResult
+                {
+                    Success = false,
+                    ErrorMessage = "統合するには2件以上の履歴を選択してください"
+                };
+            }
+
+            // 全対象Ledgerを取得（Details含む）
+            var ledgers = new List<Ledger>();
+            foreach (var id in ledgerIds)
+            {
+                var ledger = await _ledgerRepository.GetByIdAsync(id);
+                if (ledger == null)
+                {
+                    return new LedgerMergeResult
+                    {
+                        Success = false,
+                        ErrorMessage = $"履歴 ID={id} が見つかりません"
+                    };
+                }
+                ledgers.Add(ledger);
+            }
+
+            // バリデーション
+            var validationError = Validate(ledgers);
+            if (validationError != null)
+            {
+                return new LedgerMergeResult
+                {
+                    Success = false,
+                    ErrorMessage = validationError
+                };
+            }
+
+            // 統合先: 最初（最も古い）のエントリ
+            var target = ledgers[0];
+            var sources = ledgers.Skip(1).ToList();
+
+            // 統合前の状態を保存（ログ用）
+            var beforeLedgers = ledgers.ToList();
+
+            // フィールド再計算
+            var allDetails = ledgers.SelectMany(l => l.Details).ToList();
+            target.Income = ledgers.Sum(l => l.Income);
+            target.Expense = ledgers.Sum(l => l.Expense);
+
+            // 残高: 最新のDetailの残高を使用
+            var latestDetail = allDetails
+                .Where(d => d.Balance.HasValue)
+                .OrderBy(d => d.SequenceNumber > 0 ? d.SequenceNumber : int.MaxValue)
+                .ThenBy(d => d.UseDate ?? DateTime.MaxValue)
+                .LastOrDefault();
+            if (latestDetail != null)
+            {
+                target.Balance = latestDetail.Balance!.Value;
+            }
+
+            // 摘要を再生成
+            target.Summary = _summaryGenerator.Generate(allDetails);
+
+            // Noteの統合（非空のものを連結）
+            var notes = ledgers
+                .Where(l => !string.IsNullOrWhiteSpace(l.Note))
+                .Select(l => l.Note!)
+                .Distinct()
+                .ToList();
+            target.Note = notes.Count > 0 ? string.Join("、", notes) : null;
+
+            try
+            {
+                // リポジトリで統合実行（トランザクション）
+                var sourceIds = sources.Select(s => s.Id).ToList();
+                var success = await _ledgerRepository.MergeLedgersAsync(target.Id, sourceIds, target);
+
+                if (!success)
+                {
+                    return new LedgerMergeResult
+                    {
+                        Success = false,
+                        ErrorMessage = "統合処理に失敗しました"
+                    };
+                }
+
+                // 操作ログ記録
+                await _operationLogger.LogLedgerMergeAsync(operatorIdm, beforeLedgers, target);
+
+                _logger.LogInformation(
+                    "Merged {Count} ledgers into ledger {TargetId}: {Summary}",
+                    ledgers.Count, target.Id, target.Summary);
+
+                return new LedgerMergeResult
+                {
+                    Success = true,
+                    MergedLedger = target
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to merge ledgers: {Ids}", string.Join(", ", ledgerIds));
+                return new LedgerMergeResult
+                {
+                    Success = false,
+                    ErrorMessage = $"統合中にエラーが発生しました: {ex.Message}"
+                };
+            }
+        }
+
+        /// <summary>
+        /// 統合のバリデーション
+        /// </summary>
+        private static string? Validate(List<Ledger> ledgers)
+        {
+            // 同一カードチェック
+            var cardIdms = ledgers.Select(l => l.CardIdm).Distinct().ToList();
+            if (cardIdms.Count > 1)
+            {
+                return "異なるカードの履歴は統合できません";
+            }
+
+            // 貸出中レコードチェック
+            if (ledgers.Any(l => l.IsLentRecord))
+            {
+                return "貸出中のレコードは統合できません";
+            }
+
+            return null;
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -355,11 +355,10 @@ namespace ICCardManager.Services
             }
 
             // Issue #548: SequenceNumberを使って正しい時系列順にソート
-            // ICカード履歴は新しい順で読み取られ、その順でDBに挿入されるため、
-            // rowid（=SequenceNumber）が大きいほど古い（先に利用した）
+            // rowid（=SequenceNumber）が小さいほど古い（先に利用した）
             // SequenceNumberが0（未設定）の場合は従来のBalance降順を使用
             var sortedTrips = trips
-                .OrderByDescending(t => t.SequenceNumber > 0 ? t.SequenceNumber : 0)
+                .OrderBy(t => t.SequenceNumber > 0 ? t.SequenceNumber : int.MaxValue)
                 .ThenBy(t => t.UseDate ?? DateTime.MaxValue)
                 .ThenByDescending(t => t.Balance ?? 0)
                 .ToList();
@@ -397,9 +396,9 @@ namespace ICCardManager.Services
             foreach (var group in groupedTrips)
             {
                 // Issue #548: SequenceNumberを使って正しい時系列順にソート
-                // rowid（=SequenceNumber）が大きいほど古い（先に利用した）
+                // rowid（=SequenceNumber）が小さいほど古い（先に利用した）
                 var groupTrips = group
-                    .OrderByDescending(t => t.SequenceNumber > 0 ? t.SequenceNumber : 0)
+                    .OrderBy(t => t.SequenceNumber > 0 ? t.SequenceNumber : int.MaxValue)
                     .ThenBy(t => t.UseDate ?? DateTime.MaxValue)
                     .ThenByDescending(t => t.Balance ?? 0)
                     .ToList();

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -300,6 +300,15 @@
                                         Padding="12,6"
                                         ToolTip="任意の年月を選択"/>
 
+                                <!-- 統合ボタン（Issue #548） -->
+                                <Border Width="1" Background="#BDBDBD" Margin="10,2"/>
+                                <Button Content="📦 選択した履歴を統合"
+                                        Command="{Binding MergeHistoryLedgersCommand}"
+                                        Padding="12,6"
+                                        ToolTip="Ctrl+クリックで複数選択した履歴を1つに統合します"
+                                        AutomationProperties.Name="選択した履歴を統合"
+                                        AutomationProperties.HelpText="複数の履歴を選択して統合ボタンを押すと、1つの履歴にまとめます"/>
+
                                 <!-- 月選択ポップアップ -->
                                 <Popup IsOpen="{Binding IsHistoryMonthSelectorOpen}"
                                        PlacementTarget="{Binding ElementName=HistoryOtherMonthButton}"
@@ -348,17 +357,20 @@
 
                         <!-- 履歴一覧 -->
                         <DataGrid Grid.Row="2"
+                                  x:Name="HistoryDataGrid"
                                   ItemsSource="{Binding HistoryLedgers}"
                                   AutoGenerateColumns="False"
                                   IsReadOnly="True"
-                                  SelectionMode="Single"
+                                  SelectionMode="Extended"
+                                  SelectionChanged="HistoryDataGrid_SelectionChanged"
                                   CanUserAddRows="False"
                                   CanUserDeleteRows="False"
                                   GridLinesVisibility="Horizontal"
                                   HeadersVisibility="Column"
                                   RowHeaderWidth="0"
                                   AlternatingRowBackground="#FAFAFA"
-                                  AutomationProperties.Name="利用履歴一覧">
+                                  AutomationProperties.Name="利用履歴一覧"
+                                  AutomationProperties.HelpText="Ctrl+クリックで複数選択し、統合ボタンで1つにまとめられます">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="日付" Binding="{Binding DateDisplay}" Width="90"/>
                                 <DataGridTextColumn Header="摘要" Binding="{Binding Summary}" Width="*"/>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Interop;
 using ICCardManager.Common;
 using ICCardManager.Data.Repositories;
@@ -161,6 +162,17 @@ namespace ICCardManager.Views
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[MainWindow] ウィンドウ位置の復元に失敗: {ex.Message}");
 #endif
+            }
+        }
+
+        /// <summary>
+        /// 履歴DataGridの選択変更をViewModelに通知
+        /// </summary>
+        private void HistoryDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is DataGrid dg)
+            {
+                _viewModel.HistorySelectedItems = dg.SelectedItems;
             }
         }
 


### PR DESCRIPTION
## Summary

- 履歴一覧画面で複数のエントリを選択し、1つに統合する機能を追加
- `Ctrl+クリック`で隣接するエントリを複数選択→「選択した履歴を統合」ボタンで実行
- 統合後は摘要・金額・残高を自動再計算
- 時系列順序の修正（`rowid ASC`）も含む

## 変更内容

| レイヤー | ファイル | 変更 |
|---------|---------|------|
| Repository | `ILedgerRepository.cs`, `LedgerRepository.cs` | `MergeLedgersAsync`メソッド追加（トランザクション対応） |
| Service | `LedgerMergeService.cs` (新規) | 統合ビジネスロジック＋バリデーション |
| Service | `OperationLogger.cs` | `MERGE`アクション＋`LogLedgerMergeAsync`追加 |
| ViewModel | `MainViewModel.cs` | 複数選択プロパティ＋統合コマンド＋隣接チェック |
| View | `MainWindow.xaml` | DataGrid複数選択化＋統合ボタン |
| View | `MainWindow.xaml.cs` | SelectionChangedハンドラ |
| DI | `App.xaml.cs` | `LedgerMergeService`登録 |
| Fix | `LedgerRepository.cs`, `SummaryGenerator.cs` | 時系列順序修正（`rowid DESC`→`ASC`） |

## バリデーションルール

- 2件以上の選択が必要
- 同一カードのエントリのみ統合可能
- 貸出中レコードは統合不可
- 隣接するエントリのみ統合可能（飛ばし選択不可）

## Test plan

- [x] アプリを起動し、履歴が2件以上あるカードを選択
- [x] Ctrl+クリックで隣接する2件以上を選択
- [ ] 「選択した履歴を統合」ボタンをクリック
- [ ] 確認ダイアログが表示されること
- [ ] 統合後の摘要・金額・残高が正しいこと
- [ ] 操作ログにMERGE記録があること
- [ ] 非隣接選択時にエラーメッセージが出ること
- [ ] 異なるカードのエントリ選択時にボタンが無効であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)