### PR TITLE
docs: 管理者マニュアルのバックアップファイル名を修正（#567）

### DIFF
--- a/ICCardManager/docs/manual/管理者マニュアル.md
+++ b/ICCardManager/docs/manual/管理者マニュアル.md
@@ -483,7 +483,7 @@ A5: はい、CSVインポートはいつでも実行できます。「既存デ�
 2. 保存先を指定
 3. 「保存」をクリック
 
-バックアップファイル: `iccard_backup_YYYYMMDD_HHMMSS.db`
+バックアップファイル: `backup_YYYYMMDD_HHMMSS.db`
 
 #### 自動バックアップ
 


### PR DESCRIPTION
## Summary
- 管理者マニュアルのバックアップファイル名形式を実装に合わせて修正

## 変更内容

| 項目 | 修正前（誤り） | 修正後（実装と一致） |
|---|---|---|
| ファイル名形式 | `iccard_backup_YYYYMMDD_HHMMSS.db` | `backup_YYYYMMDD_HHMMSS.db` |

### 根拠

`Services/BackupService.cs`:
```csharp
private const string BackupFilePrefix = "backup_";       // Line 32
private const string BackupFileExtension = ".db";         // Line 37
var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss"); // Line 89
var backupFileName = $"{BackupFilePrefix}{timestamp}{BackupFileExtension}"; // Line 90
```

## Test plan
- [ ] マニュアルのファイル名形式が `BackupService.cs` の定数と一致していることを確認

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)