### PR TITLE
docs: DB設計書のDBファイル保存場所を修正（#569）

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -331,10 +331,12 @@ PRAGMA foreign_keys = ON;
 ### 8.1 保存場所
 
 ```
-%LOCALAPPDATA%\ICCardManager\iccard.db
+%PROGRAMDATA%\ICCardManager\iccard.db
 ```
 
-例: `C:\Users\<username>\AppData\Local\ICCardManager\iccard.db`
+例: `C:\ProgramData\ICCardManager\iccard.db`
+
+> **設計理由**: CommonApplicationData（`%PROGRAMDATA%`）を使用することで、異なるWindowsユーザーがログインしても同じデータベースにアクセスでき、複数職員での共有利用に対応する。
 
 ### 8.2 バックアップ
 


### PR DESCRIPTION
## Summary
- DB設計書のデータベースファイル保存場所を実装に合わせて修正
- CommonApplicationDataを使用する設計理由を追記

## 変更内容

| 項目 | 修正前（誤り） | 修正後（実装と一致） |
|---|---|---|
| 環境変数 | `%LOCALAPPDATA%` | `%PROGRAMDATA%` |
| パス例 | `C:\Users\<username>\AppData\Local\ICCardManager\iccard.db` | `C:\ProgramData\ICCardManager\iccard.db` |

### 根拠

`Data/DbContext.cs` Lines 50-62:
```csharp
/// CommonApplicationData（C:\ProgramData）を使用することで、
/// 異なるユーザーがログインしても同じデータにアクセスできるようにする
private static string GetDefaultDatabasePath()
{
    var appDataPath = Path.Combine(
        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
        "ICCardManager");
    ...
    return Path.Combine(appDataPath, "iccard.db");
}
```

## Test plan
- [ ] 設計書のパスが `DbContext.cs` の `GetDefaultDatabasePath()` と一致していることを確認
- [ ] 管理者マニュアル（セクション 3.4）の記載とも整合していることを確認

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)