### PR TITLE
docs: README.mdのpublish出力パスを修正（#561）

### DIFF
--- a/ICCardManager/README.md
+++ b/ICCardManager/README.md
@@ -166,7 +166,7 @@ dotnet build
 # リリースビルド（配布用）
 dotnet publish src/ICCardManager/ICCardManager.csproj -c Release
 
-# 出力先: src/ICCardManager/bin/Release/net48/publish/
+# 出力先: src/ICCardManager/bin/Release/net48/
 ```
 
 ### インストーラーのビルド


### PR DESCRIPTION
## Summary
- README.md のリリースビルドコマンドの出力先パスを修正
- `src/ICCardManager/bin/Release/net48/publish/` → `src/ICCardManager/bin/Release/net48/`
- .NET Framework 4.8 では `-o` 未指定時に `publish/` サブディレクトリは作成されない（.NET Core/.NET 5+ との挙動差異）

Closes #561

## Test plan
- [x] 実際のビルド成果物ディレクトリ `src/ICCardManager/bin/Release/net48/` が存在し、`publish/` サブディレクトリは存在しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)