### PR TITLE
fix: バス停名入力画面でバス停名の入力ができないバグを修正（#593）

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -98,6 +98,13 @@ namespace ICCardManager.Data.Repositories
         Task<IEnumerable<(string BusStops, int UsageCount)>> GetBusStopSuggestionsAsync();
 
         /// <summary>
+        /// バス利用詳細のバス停名を更新
+        /// </summary>
+        /// <param name="ledgerId">利用履歴ID</param>
+        /// <param name="updates">更新対象（SequenceNumber=rowid, BusStops=バス停名）のリスト</param>
+        Task UpdateDetailBusStopsAsync(int ledgerId, IEnumerable<(int SequenceNumber, string BusStops)> updates);
+
+        /// <summary>
         /// 指定期間の利用履歴をページング付きで取得
         /// </summary>
         /// <param name="cardIdm">ICカードIDm（nullの場合は全カード）</param>

--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -359,6 +359,25 @@ LIMIT 100";
         }
 
         /// <inheritdoc/>
+        public async Task UpdateDetailBusStopsAsync(int ledgerId, IEnumerable<(int SequenceNumber, string BusStops)> updates)
+        {
+            var connection = _dbContext.GetConnection();
+
+            foreach (var (sequenceNumber, busStops) in updates)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = @"UPDATE ledger_detail SET bus_stops = @busStops
+WHERE ledger_id = @ledgerId AND rowid = @rowid";
+
+                command.Parameters.AddWithValue("@busStops", (object)busStops ?? DBNull.Value);
+                command.Parameters.AddWithValue("@ledgerId", ledgerId);
+                command.Parameters.AddWithValue("@rowid", sequenceNumber);
+
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        /// <inheritdoc/>
         public async Task<(IEnumerable<Ledger> Items, int TotalCount)> GetPagedAsync(
             string cardIdm,
             DateTime fromDate,

--- a/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
@@ -198,6 +198,12 @@ public partial class BusStopInputViewModel : ViewModelBase
                     : item.BusStops;
             }
 
+            // Issue #593: バス停名をledger_detailに保存（サジェスト候補の蓄積に必要）
+            var busStopUpdates = BusUsages
+                .Select(item => (item.Detail.SequenceNumber, item.Detail.BusStops))
+                .ToList();
+            await _ledgerRepository.UpdateDetailBusStopsAsync(Ledger.Id, busStopUpdates);
+
             // 摘要を再生成（バス停名を反映）
             var summaryGenerator = new SummaryGenerator();
             Ledger.Summary = summaryGenerator.Generate(Ledger.Details);
@@ -236,6 +242,12 @@ public partial class BusStopInputViewModel : ViewModelBase
                     item.Detail.BusStops = "★";
                 }
             }
+
+            // Issue #593: バス停名をledger_detailに保存
+            var busStopUpdates = BusUsages
+                .Select(item => (item.Detail.SequenceNumber, item.Detail.BusStops))
+                .ToList();
+            await _ledgerRepository.UpdateDetailBusStopsAsync(Ledger.Id, busStopUpdates);
 
             // 摘要を再生成（★マークを反映）
             var summaryGenerator = new SummaryGenerator();


### PR DESCRIPTION
## Summary
- バス停名入力ダイアログが空で表示され、バス停名の入力ができないバグを修正
- 2つの根本原因を同時に修正

### 原因1: 誤ったLedger選択（MainViewModel.cs）
- `LastOrDefault(l => !l.IsLentRecord)` が最後のLedgerのみ取得するため、バス利用が別日にある場合に鉄道のみのLedgerが選択されていた
- Summaryに「バス」を含むLedgerをフィルタし、複数日のバス利用にも対応

### 原因2: バス停名がledger_detailに保存されない（BusStopInputViewModel.cs）
- `SaveAsync` / `SkipAsync` は `ledger` テーブルのSummaryのみ更新し、`ledger_detail.bus_stops` を更新していなかった
- `UpdateDetailBusStopsAsync` メソッドを追加し、バス停名を `ledger_detail` にも永続化
- これにより、オートコンプリートのサジェスト候補が正しく蓄積されるようになる

## Test plan
- [x] `UpdateDetailBusStopsAsync_UpdatesBusStopsInDatabase` — バス停名がDBに保存される
- [x] `UpdateDetailBusStopsAsync_OnlyUpdatesSpecifiedDetails` — 指定したDetailのみ更新、他は不変
- [x] 全35テストがパス（`dotnet test --filter LedgerRepositoryTests`）
- [ ] カードを貸出→バス利用(1日)+鉄道利用(別日)→返却し、バス停入力ダイアログにバス利用が表示されることを確認
- [ ] バス停名を入力して保存→再度返却時にサジェスト候補に前回入力した名前が表示されることを確認

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)