### PR TITLE
fix: 繰越レコードの日付を繰越月の翌月1日に修正（#599）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -740,6 +740,32 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 年度途中導入の繰越レコード日付を計算（Issue #599）
+        /// </summary>
+        /// <param name="carryoverMonth">繰越元の月（1-12）</param>
+        /// <param name="registrationDate">登録日</param>
+        /// <returns>繰越月の翌月1日</returns>
+        /// <remarks>
+        /// 繰越レコードの日付は「繰越月の翌月1日」とする。
+        /// 例: 2月9日に「1月から繰越」→ 2月1日、1月15日に「12月から繰越」→ 1月1日。
+        /// 翌月が登録月より後の場合は前年のデータとみなす。
+        /// 例: 2月15日に「11月から繰越」→ 前年12月1日。
+        /// </remarks>
+        public static DateTime GetMidYearCarryoverDate(int carryoverMonth, DateTime registrationDate)
+        {
+            var nextMonth = (carryoverMonth % 12) + 1;
+            var recordYear = registrationDate.Year;
+
+            // 翌月が登録月より後の場合、前年のデータ
+            if (nextMonth > registrationDate.Month)
+            {
+                recordYear--;
+            }
+
+            return new DateTime(recordYear, nextMonth, 1);
+        }
+
+        /// <summary>
         /// 摘要が年度途中導入の繰越かどうかを判定（Issue #510）
         /// </summary>
         /// <param name="summary">摘要文字列</param>

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -855,7 +855,10 @@ namespace ICCardManager.ViewModels
                     {
                         CardIdm = cardIdm,
                         LenderIdm = null,  // 新規購入/繰越時は貸出者なし
-                        Date = now,
+                        // Issue #599: 繰越モードの場合は繰越月の翌月1日をレコード日付とする
+                        Date = modeResult.IsNewPurchase
+                            ? now
+                            : SummaryGenerator.GetMidYearCarryoverDate(modeResult.CarryoverMonth!.Value, now),
                         Summary = summary,
                         Income = balance.Value,  // 受入金額 = カード残額
                         Expense = 0,

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
@@ -355,4 +355,60 @@ public class SummaryGeneratorTests
     }
 
     #endregion
+
+    #region Issue #599: 繰越レコード日付計算
+
+    [Fact]
+    public void GetMidYearCarryoverDate_BasicCase_ReturnsFirstDayOfNextMonth()
+    {
+        // Arrange: 2月9日に「1月から繰越」→ 2月1日
+        var registrationDate = new DateTime(2026, 2, 9);
+
+        // Act
+        var result = SummaryGenerator.GetMidYearCarryoverDate(1, registrationDate);
+
+        // Assert
+        result.Should().Be(new DateTime(2026, 2, 1));
+    }
+
+    [Fact]
+    public void GetMidYearCarryoverDate_DecemberCarryover_ReturnsJanuaryFirstSameYear()
+    {
+        // Arrange: 1月15日に「12月から繰越」→ 1月1日（同年）
+        var registrationDate = new DateTime(2026, 1, 15);
+
+        // Act
+        var result = SummaryGenerator.GetMidYearCarryoverDate(12, registrationDate);
+
+        // Assert
+        result.Should().Be(new DateTime(2026, 1, 1));
+    }
+
+    [Fact]
+    public void GetMidYearCarryoverDate_FarPastMonth_ReturnsPreviousYear()
+    {
+        // Arrange: 2月15日に「11月から繰越」→ 前年12月1日
+        var registrationDate = new DateTime(2026, 2, 15);
+
+        // Act
+        var result = SummaryGenerator.GetMidYearCarryoverDate(11, registrationDate);
+
+        // Assert
+        result.Should().Be(new DateTime(2025, 12, 1));
+    }
+
+    [Fact]
+    public void GetMidYearCarryoverDate_FiscalYearStart_ReturnsAprilFirst()
+    {
+        // Arrange: 4月1日に「3月から繰越」→ 4月1日
+        var registrationDate = new DateTime(2026, 4, 1);
+
+        // Act
+        var result = SummaryGenerator.GetMidYearCarryoverDate(3, registrationDate);
+
+        // Assert
+        result.Should().Be(new DateTime(2026, 4, 1));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- 「X月から繰越」で登録した際、物品出納簿の日付が登録日そのまま（例: 2/9）になるバグを修正
- 繰越レコードの日付は繰越月の翌月1日（例: "1月から繰越" → 2月1日）に設定されるように変更
- `SummaryGenerator.GetMidYearCarryoverDate()` として日付計算ロジックを切り出し、単体テスト可能に

## 変更内容

| ファイル | 変更 |
|---------|------|
| `SummaryGenerator.cs` | `GetMidYearCarryoverDate(int, DateTime)` staticメソッド追加 |
| `CardManageViewModel.cs` | `CreateInitialLedgerAsync` 内の `Date = now` を繰越時に条件分岐 |
| `SummaryGeneratorTests.cs` | 日付計算テスト4件追加 |

## 日付計算ルール

| 繰越月 | 登録日 | レコード日付 | 説明 |
|--------|--------|-------------|------|
| 1月 | 2/9 | 2月1日 | 1月まで紙→2月からアプリ |
| 12月 | 1/15 | 1月1日 | 12月まで紙→1月からアプリ |
| 11月 | 2/15 | 前年12月1日 | 11月まで紙→12月からアプリ |
| 3月 | 4/1 | 4月1日 | 3月まで紙→4月からアプリ |

## Test plan

- [x] 全1039件のテスト合格（新規4件含む）
- [ ] 繰越モードでカード登録（例: 「1月から繰越」を2月に実行）
- [ ] 物品出納簿を生成し、「1月から繰越」行の日付が2月1日と表示されることを確認

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)