### PR TITLE
fix: インポート実行後に完了ダイアログを表示（#598）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -185,7 +185,7 @@ namespace ICCardManager.Services
         /// </summary>
         /// <param name="filePath">CSVファイルパス</param>
         /// <param name="skipExisting">既存データをスキップするか（falseの場合は更新）</param>
-        public async Task<CsvImportResult> ImportCardsAsync(string filePath, bool skipExisting = true)
+        public virtual async Task<CsvImportResult> ImportCardsAsync(string filePath, bool skipExisting = true)
         {
             var errors = new List<CsvImportError>();
             return await ExecuteImportWithErrorHandlingAsync(
@@ -394,7 +394,7 @@ namespace ICCardManager.Services
         /// </summary>
         /// <param name="filePath">CSVファイルパス</param>
         /// <param name="skipExisting">既存データをスキップするか（falseの場合は更新）</param>
-        public async Task<CsvImportResult> ImportStaffAsync(string filePath, bool skipExisting = true)
+        public virtual async Task<CsvImportResult> ImportStaffAsync(string filePath, bool skipExisting = true)
         {
             var errors = new List<CsvImportError>();
             return await ExecuteImportWithErrorHandlingAsync(
@@ -891,7 +891,7 @@ namespace ICCardManager.Services
         /// 注意: 管理番号は参照用で、実際のデータ識別はカードIDmで行います
         /// Issue #511: CSVのIDm列が空の場合、targetCardIdmが指定されていればそのIDmを使用
         /// </remarks>
-        public async Task<CsvImportResult> ImportLedgersAsync(string filePath, bool skipExisting = true, string? targetCardIdm = null)
+        public virtual async Task<CsvImportResult> ImportLedgersAsync(string filePath, bool skipExisting = true, string? targetCardIdm = null)
         {
             var errors = new List<CsvImportError>();
             var importedCount = 0;

--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -521,10 +521,18 @@ public partial class DataExportImportViewModel : ViewModelBase
                     }
                     StatusMessage = message;
                     ClearPreview();
+
+                    _dialogService.ShowInformation(
+                        $"インポートが完了しました。\n\n登録件数: {result.ImportedCount}件"
+                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : ""),
+                        "インポート完了");
                 }
                 else if (!string.IsNullOrEmpty(result.ErrorMessage))
                 {
                     StatusMessage = $"インポートエラー: {result.ErrorMessage}";
+                    _dialogService.ShowError(
+                        $"インポートに失敗しました。\n\n{result.ErrorMessage}",
+                        "インポートエラー");
                 }
                 else
                 {
@@ -545,11 +553,20 @@ public partial class DataExportImportViewModel : ViewModelBase
                     {
                         ImportErrors.Add($"... 他 {result.Errors.Count - 10}件のエラー");
                     }
+
+                    _dialogService.ShowWarning(
+                        $"インポートが完了しましたが、一部エラーがあります。\n\n登録件数: {result.ImportedCount}件\nエラー: {result.ErrorCount}件"
+                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "")
+                        + "\n\n詳細はエラー一覧を確認してください。",
+                        "インポート完了（一部エラー）");
                 }
             }
             catch (Exception ex)
             {
                 StatusMessage = $"インポートエラー: {ex.Message}";
+                _dialogService.ShowError(
+                    $"インポート中にエラーが発生しました。\n\n{ex.Message}",
+                    "インポートエラー");
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[ExecuteImport Error] {ex.GetType().Name}: {ex.Message}");
 #endif
@@ -625,10 +642,18 @@ public partial class DataExportImportViewModel : ViewModelBase
                         message += $"（{result.SkippedCount}件はスキップ）";
                     }
                     StatusMessage = message;
+
+                    _dialogService.ShowInformation(
+                        $"インポートが完了しました。\n\n登録件数: {result.ImportedCount}件"
+                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : ""),
+                        "インポート完了");
                 }
                 else if (!string.IsNullOrEmpty(result.ErrorMessage))
                 {
                     StatusMessage = $"インポートエラー: {result.ErrorMessage}";
+                    _dialogService.ShowError(
+                        $"インポートに失敗しました。\n\n{result.ErrorMessage}",
+                        "インポートエラー");
                 }
                 else
                 {
@@ -649,11 +674,20 @@ public partial class DataExportImportViewModel : ViewModelBase
                     {
                         ImportErrors.Add($"... 他 {result.Errors.Count - 10}件のエラー");
                     }
+
+                    _dialogService.ShowWarning(
+                        $"インポートが完了しましたが、一部エラーがあります。\n\n登録件数: {result.ImportedCount}件\nエラー: {result.ErrorCount}件"
+                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "")
+                        + "\n\n詳細はエラー一覧を確認してください。",
+                        "インポート完了（一部エラー）");
                 }
             }
             catch (Exception ex)
             {
                 StatusMessage = $"インポートエラー: {ex.Message}";
+                _dialogService.ShowError(
+                    $"インポート中にエラーが発生しました。\n\n{ex.Message}",
+                    "インポートエラー");
 #if DEBUG
                 System.Diagnostics.Debug.WriteLine($"[Import Error] {ex.GetType().Name}: {ex.Message}");
                 System.Diagnostics.Debug.WriteLine($"[Import Error] StackTrace: {ex.StackTrace}");

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
@@ -1,0 +1,309 @@
+using System.Collections.Generic;
+using System.Data.SQLite;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
+using ICCardManager.Services;
+using ICCardManager.ViewModels;
+using Moq;
+using Xunit;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// DataExportImportViewModelの単体テスト
+/// </summary>
+/// <remarks>
+/// インポート実行後にダイアログで結果が通知されることを検証する（Issue #598）
+/// </remarks>
+public class DataExportImportViewModelTests : IDisposable
+{
+    private readonly Mock<ICardRepository> _cardRepositoryMock;
+    private readonly Mock<IStaffRepository> _staffRepositoryMock;
+    private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
+    private readonly Mock<IValidationService> _validationServiceMock;
+    private readonly Mock<DbContext> _dbContextMock;
+    private readonly Mock<ICacheService> _cacheServiceMock;
+    private readonly Mock<IDialogService> _dialogServiceMock;
+    private readonly Mock<CsvImportService> _importServiceMock;
+    private readonly Mock<CsvExportService> _exportServiceMock;
+    private readonly SQLiteConnection _connection;
+    private readonly DataExportImportViewModel _viewModel;
+
+    public DataExportImportViewModelTests()
+    {
+        _cardRepositoryMock = new Mock<ICardRepository>();
+        _staffRepositoryMock = new Mock<IStaffRepository>();
+        _ledgerRepositoryMock = new Mock<ILedgerRepository>();
+        _validationServiceMock = new Mock<IValidationService>();
+        _dbContextMock = new Mock<DbContext>();
+        _cacheServiceMock = new Mock<ICacheService>();
+        _dialogServiceMock = new Mock<IDialogService>();
+
+        // SQLiteインメモリ接続（DbContextモックのトランザクション用）
+        _connection = new SQLiteConnection("Data Source=:memory:");
+        _connection.Open();
+        var transaction = _connection.BeginTransaction();
+        _dbContextMock.Setup(x => x.BeginTransaction()).Returns(transaction);
+
+        // CsvExportService（コンストラクタで必要だが、テスト対象ではない）
+        _exportServiceMock = new Mock<CsvExportService>(
+            _cardRepositoryMock.Object,
+            _staffRepositoryMock.Object,
+            _ledgerRepositoryMock.Object);
+
+        // CsvImportService（virtualメソッドをモックする）
+        _importServiceMock = new Mock<CsvImportService>(
+            _cardRepositoryMock.Object,
+            _staffRepositoryMock.Object,
+            _ledgerRepositoryMock.Object,
+            _validationServiceMock.Object,
+            _dbContextMock.Object,
+            _cacheServiceMock.Object);
+
+        _viewModel = new DataExportImportViewModel(
+            _exportServiceMock.Object,
+            _importServiceMock.Object,
+            _dialogServiceMock.Object,
+            _cardRepositoryMock.Object);
+    }
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+    }
+
+    /// <summary>
+    /// プレビュー未実行時、ExecuteImportAsyncはステータスメッセージを表示してダイアログは表示しないこと
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_WithoutPreview_ShouldSetStatusMessageAndNotShowDialog()
+    {
+        // Arrange - プレビュー未実行（ImportPreview = null）
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _viewModel.StatusMessage.Should().Contain("プレビューを実行してください");
+        _dialogServiceMock.Verify(
+            d => d.ShowInformation(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _dialogServiceMock.Verify(
+            d => d.ShowError(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// インポート成功時、完了ダイアログが表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnSuccess_ShouldShowInformationDialog()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 3,
+                SkippedCount = 0
+            });
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowInformation(
+                It.Is<string>(msg => msg.Contains("3件")),
+                It.Is<string>(title => title.Contains("インポート完了"))),
+            Times.Once);
+        _viewModel.StatusMessage.Should().Contain("3件を登録しました");
+    }
+
+    /// <summary>
+    /// インポート成功時（スキップあり）、スキップ件数がダイアログに表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnSuccessWithSkip_ShouldShowSkipCountInDialog()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 2,
+                SkippedCount = 1
+            });
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowInformation(
+                It.Is<string>(msg => msg.Contains("2件") && msg.Contains("スキップ") && msg.Contains("1件")),
+                It.IsAny<string>()),
+            Times.Once);
+        _viewModel.StatusMessage.Should().Contain("1件はスキップ");
+    }
+
+    /// <summary>
+    /// インポートエラー時、エラーダイアログが表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnError_ShouldShowErrorDialog()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "ファイル形式が不正です"
+            });
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowError(
+                It.Is<string>(msg => msg.Contains("ファイル形式が不正です")),
+                It.Is<string>(title => title.Contains("エラー"))),
+            Times.Once);
+        _viewModel.StatusMessage.Should().Contain("エラー");
+    }
+
+    /// <summary>
+    /// インポート一部エラー時、警告ダイアログが表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnPartialSuccess_ShouldShowWarningDialog()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = null,
+                ImportedCount = 2,
+                ErrorCount = 1,
+                SkippedCount = 0,
+                Errors = new List<CsvImportError>
+                {
+                    new CsvImportError { LineNumber = 3, Message = "IDmが不正です" }
+                }
+            });
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowWarning(
+                It.Is<string>(msg => msg.Contains("2件") && msg.Contains("1件")),
+                It.Is<string>(title => title.Contains("一部エラー"))),
+            Times.Once);
+        _viewModel.ImportErrors.Should().ContainSingle(e => e.Contains("IDmが不正です"));
+    }
+
+    /// <summary>
+    /// インポート中に例外が発生した場合、エラーダイアログが表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnException_ShouldShowErrorDialog()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ThrowsAsync(new InvalidOperationException("DB接続エラー"));
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowError(
+                It.Is<string>(msg => msg.Contains("DB接続エラー")),
+                It.Is<string>(title => title.Contains("エラー"))),
+            Times.Once);
+        _viewModel.StatusMessage.Should().Contain("DB接続エラー");
+    }
+
+    /// <summary>
+    /// インポート成功後、プレビューがクリアされること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_OnSuccess_ShouldClearPreview()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 1
+            });
+
+        _viewModel.HasPreview.Should().BeTrue("プレビューがセットアップされていること");
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _viewModel.HasPreview.Should().BeFalse("成功後にプレビューがクリアされること");
+        _viewModel.PreviewItems.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// 職員データインポート成功時もダイアログが表示されること
+    /// </summary>
+    [Fact]
+    public async Task ExecuteImportAsync_StaffImport_OnSuccess_ShouldShowInformationDialog()
+    {
+        // Arrange
+        SetupValidPreview(DataType.Staff);
+        _importServiceMock
+            .Setup(s => s.ImportStaffAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 5
+            });
+
+        // Act
+        await _viewModel.ExecuteImportAsync();
+
+        // Assert
+        _dialogServiceMock.Verify(
+            d => d.ShowInformation(
+                It.Is<string>(msg => msg.Contains("5件")),
+                It.Is<string>(title => title.Contains("インポート完了"))),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// テスト用にプレビュー状態をセットアップするヘルパー
+    /// </summary>
+    private void SetupValidPreview(DataType dataType = DataType.Cards)
+    {
+        _viewModel.SelectedImportType = dataType;
+        _viewModel.ImportPreviewFile = "test.csv";
+        _viewModel.ImportPreview = new CsvImportPreviewResult { IsValid = true };
+        _viewModel.HasPreview = true;
+    }
+}


### PR DESCRIPTION
## Summary
- インポート実行後にエクスポートと同様の結果通知ダイアログを追加
- 成功/エラー/一部エラーの3パターンでそれぞれ適切なダイアログ（Information/Error/Warning）を表示
- CsvImportServiceのImport*Asyncメソッドにvirtualを追加（テスト容易性向上）

## 変更ファイル
| ファイル | 変更内容 |
|---------|----------|
| `DataExportImportViewModel.cs` | `ExecuteImportAsync`と`ImportAsync`に`ShowInformation`/`ShowError`/`ShowWarning`呼び出しを追加 |
| `CsvImportService.cs` | `ImportCardsAsync`/`ImportStaffAsync`/`ImportLedgersAsync`に`virtual`を追加 |
| `DataExportImportViewModelTests.cs` | 新規: ダイアログ表示を検証する8テストケース |

## Test plan
- [x] 単体テスト8件すべて成功（全1047件リグレッションなし）
- [ ] カード一覧CSVをプレビュー→「インポート実行」→ 完了ダイアログが表示されること
- [ ] 不正なCSVを「直接インポート」→ エラーダイアログが表示されること
- [ ] 一部不正データを含むCSVをインポート→ 警告ダイアログ（一部エラー）が表示されること

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)