### PR TITLE
fix: カード返却時に今月の履歴完全性をチェック（#596）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -899,6 +899,14 @@ public partial class MainViewModel : ViewModelBase
                 }
             }
 
+            // Issue #596: 今月の履歴が不完全な可能性がある場合に通知
+            if (result.MayHaveIncompleteHistory)
+            {
+                _toastNotificationService.ShowWarning(
+                    "履歴の確認",
+                    "今月の利用履歴がすべて取得できていない可能性があります。\nCSVインポートで不足分を補完してください。");
+            }
+
             // 30秒ルール用に職員情報を保存（ResetStateの前に保存）
             _lastProcessedStaffIdm = _currentStaffIdm;
             _lastProcessedStaffName = _currentStaffName;


### PR DESCRIPTION
## Summary

- カード返却時に、読み取った20件の履歴がすべて今月分の場合、過去の利用履歴が取得しきれていない可能性をトースト通知で警告
- CSVインポートで不足分を補完するようユーザーに案内
- 月初めにアプリを導入した場合など、過去履歴が20件を超えるケースに対応

## 変更内容

| ファイル | 変更 |
|---------|------|
| `LendingService.cs` | `LendingResult.MayHaveIncompleteHistory`プロパティ追加、`CheckHistoryCompleteness`メソッド追加、`ReturnAsync`に完全性チェック組み込み |
| `MainViewModel.cs` | 返却成功後にトースト通知で警告表示 |
| `LendingServiceTests.cs` | 7件の単体テスト追加（静的メソッド5件、ReturnAsync統合テスト2件） |

## ロジック

1. 返却処理時、今月の既存ledgerレコードを確認
2. 今月のレコードが**まだ存在しない**場合（初回返却）のみチェック実行
3. 読み取った履歴が**20件**かつ**すべて今月分** → 不完全の可能性あり
4. 20件未満、または前月以前の履歴を含む → 完全と判定

## Test plan

- [x] `CheckHistoryCompleteness` - 20件すべて今月 → true
- [x] `CheckHistoryCompleteness` - 前月の履歴あり → false
- [x] `CheckHistoryCompleteness` - 20件未満 → false
- [x] `CheckHistoryCompleteness` - 空リスト → false
- [x] `CheckHistoryCompleteness` - null日付の混在 → 正常動作
- [x] `ReturnAsync` - 初回返却で20件全今月 → MayHaveIncompleteHistory=true
- [x] `ReturnAsync` - 既存レコードあり → MayHaveIncompleteHistory=false

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)