### PR TITLE
fix: 設定変更後にカード一覧の残額警告表示を即時更新（#604）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1722,9 +1722,10 @@ public partial class MainViewModel : ViewModelBase
         dialog.Owner = System.Windows.Application.Current.MainWindow;
         dialog.ShowDialog();
 
-        // 設定変更後に音声モードを再適用
+        // 設定変更後に音声モードを再適用し、カード一覧を更新（残額警告閾値の変更を反映）
         var settings = await _settingsRepository.GetAppSettingsAsync();
         _soundPlayer.SoundMode = settings.SoundMode;
+        await RefreshDashboardAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- 設定ダイアログで残額警告閾値を変更した後、カード一覧の警告表示が即座に更新されるよう修正
- OpenSettingsAsync()にRefreshDashboardAsync()の呼び出しを追加

## Test plan
- [x] ビルド成功
- [x] 全1063件の既存テスト成功
- [x] 手動: 残額警告閾値を変更し設定を閉じた直後にカード一覧の警告色が変わること

Closes #604