### PR TITLE
docs: DB設計書にic_cardテーブルの未記載カラムを追加（#570）

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -26,9 +26,12 @@ erDiagram
         TEXT note "備考"
         INTEGER is_deleted "削除フラグ"
         TEXT deleted_at "削除日時"
+        INTEGER is_refunded "払戻済フラグ"
+        TEXT refunded_at "払戻日時"
         INTEGER is_lent "貸出状態"
         TEXT last_lent_at "最終貸出日時"
         TEXT last_lent_staff FK "最終貸出者IDm"
+        INTEGER starting_page_number "開始ページ番号"
     }
 
     ledger {
@@ -59,6 +62,7 @@ erDiagram
         INTEGER is_charge "チャージフラグ"
         INTEGER is_point_redemption "ポイント還元フラグ"
         INTEGER is_bus "バス利用フラグ"
+        INTEGER group_id "グループID"
     }
 
     operation_log {
@@ -111,12 +115,16 @@ erDiagram
 | note | TEXT | YES | NULL | 備考 |
 | is_deleted | INTEGER | NO | 0 | 削除フラグ（0:有効, 1:削除済） |
 | deleted_at | TEXT | YES | NULL | 削除日時（ISO 8601形式） |
+| is_refunded | INTEGER | NO | 0 | 払戻済フラグ（0:通常, 1:払戻済）（Issue #530） |
+| refunded_at | TEXT | YES | NULL | 払戻日時（ISO 8601形式）（Issue #530） |
 | is_lent | INTEGER | NO | 0 | 貸出状態（0:返却済, 1:貸出中） |
 | last_lent_at | TEXT | YES | NULL | 最終貸出日時（ISO 8601形式） |
 | last_lent_staff | TEXT | YES | NULL | 最終貸出者IDm（FK→staff） |
+| starting_page_number | INTEGER | NO | 1 | 帳票の開始ページ番号（Issue #510） |
 
 **インデックス:**
 - `idx_card_deleted` ON ic_card(is_deleted)
+- `idx_card_lent_deleted` ON ic_card(is_lent, is_deleted)
 
 **外部キー:**
 - last_lent_staff → staff(staff_idm)
@@ -168,6 +176,7 @@ ICカードの個別利用記録を保存するテーブル。
 | is_charge | INTEGER | NO | 0 | チャージフラグ（0:利用, 1:チャージ） |
 | is_point_redemption | INTEGER | NO | 0 | ポイント還元フラグ（0:通常, 1:ポイント還元） |
 | is_bus | INTEGER | NO | 0 | バス利用フラグ（0:鉄道, 1:バス） |
+| group_id | INTEGER | YES | NULL | グループID（乗り継ぎ統合用、NULLは自動判定） |
 
 **インデックス:**
 - `idx_detail_ledger` ON ledger_detail(ledger_id)
@@ -226,6 +235,8 @@ ICカードの個別利用記録を保存するテーブル。
 | ledger | idx_ledger_lender | lender_idm | 貸出者での検索 |
 | ledger_detail | idx_detail_ledger | ledger_id | 親レコードの紐付け |
 | ledger_detail | idx_detail_bus | is_bus | バス利用の検索 |
+| ic_card | idx_card_lent_deleted | is_lent, is_deleted | 貸出状態×削除フラグの複合検索 |
+| ledger | idx_ledger_card_id | card_idm, id DESC | カード別の最新履歴取得 |
 | operation_log | idx_log_timestamp | timestamp | 時系列での検索 |
 
 ---


### PR DESCRIPTION
## Summary
- `02_DB設計書.md` の ic_card テーブル定義に `is_refunded`/`refunded_at`（Issue #530）、`starting_page_number`（Issue #510）の3カラムを追加
- 併せて同様に未記載だった `ledger_detail.group_id` カラムと追加インデックス2件（`idx_card_lent_deleted`, `idx_ledger_card_id`）も追加
- ER図・テーブル定義・インデックス一覧の3箇所を一括更新し、`schema.sql` との整合性を回復

## Test plan
- [ ] Mermaid ER図が正しく描画されることを確認（GitHubのプレビューで確認可能）
- [ ] テーブル定義の内容が `Data/schema.sql` と一致していることを目視確認

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)