### PR TITLE
docs: DB設計書にledger_detailの乗り継ぎ統合機能の説明を追記（#571）

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -176,7 +176,7 @@ ICカードの個別利用記録を保存するテーブル。
 | is_charge | INTEGER | NO | 0 | チャージフラグ（0:利用, 1:チャージ） |
 | is_point_redemption | INTEGER | NO | 0 | ポイント還元フラグ（0:通常, 1:ポイント還元） |
 | is_bus | INTEGER | NO | 0 | バス利用フラグ（0:鉄道, 1:バス） |
-| group_id | INTEGER | YES | NULL | グループID（乗り継ぎ統合用、NULLは自動判定） |
+| group_id | INTEGER | YES | NULL | グループID（乗り継ぎ統合用、NULLは自動判定）（Issue #484） |
 
 **インデックス:**
 - `idx_detail_ledger` ON ledger_detail(ledger_id)
@@ -184,6 +184,18 @@ ICカードの個別利用記録を保存するテーブル。
 
 **外部キー:**
 - ledger_id → ledger(id) ON DELETE CASCADE
+
+**乗り継ぎ統合機能（Issue #484）:**
+
+`group_id` は複数の利用詳細を1つの乗り継ぎとして摘要に統合するためのカラム。
+
+- 同じ `group_id` を持つ詳細レコードは、1つの乗り継ぎ区間として `SummaryGenerator` が摘要を生成する（例: 「鉄道（A駅～C駅）」）
+- `group_id` が NULL の場合は従来通り自動判定（往復パターン・乗継パターンの検出）を行う
+- ユーザーが履歴詳細画面から手動で統合・分割を操作すると `group_id` が設定される
+
+**シーケンス番号（Issue #548）:**
+
+モデルクラス `LedgerDetail` には `SequenceNumber` プロパティが存在するが、これはDBの物理カラムではなくSQLiteの `rowid` から取得される仮想値。チャージが間に入っても正しい時系列順序を保持するために使用される。
 
 ### 2.5 operation_log（操作ログ）
 


### PR DESCRIPTION
## Summary
- `group_id` カラムの説明に Issue #484 の参照を追加
- 乗り継ぎ統合機能の動作仕様（`group_id` による統合、NULL時の自動判定、手動操作）を追記
- `SequenceNumber`（Issue #548）がDBの物理カラムではなくSQLiteの `rowid` から取得される仮想値である旨を補足

## Test plan
- [ ] DB設計書の ledger_detail セクションに乗り継ぎ統合機能の説明が記載されていること
- [ ] `group_id` の説明に Issue #484 への参照が含まれていること
- [ ] SequenceNumber の補足説明が記載されていること

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)