### PR TITLE
docs: DB設計書にledger_merge_historyテーブルの定義を追加（#572）

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -8,6 +8,7 @@ erDiagram
     staff ||--o{ ic_card : "最終貸出者"
     ic_card ||--o{ ledger : "対象カード"
     ledger ||--o{ ledger_detail : "利用詳細"
+    ledger ||--o{ ledger_merge_history : "統合先"
     staff ||--o{ operation_log : "操作者"
 
     staff {
@@ -75,6 +76,15 @@ erDiagram
         TEXT action "操作種別"
         TEXT before_data "変更前データ"
         TEXT after_data "変更後データ"
+    }
+
+    ledger_merge_history {
+        INTEGER id PK "履歴ID"
+        TEXT merged_at "統合日時"
+        INTEGER target_ledger_id FK "統合先レコードID"
+        TEXT description "統合内容の説明"
+        TEXT undo_data "Undoデータ"
+        INTEGER is_undone "取消済フラグ"
     }
 
     settings {
@@ -216,7 +226,27 @@ ICカードの個別利用記録を保存するテーブル。
 **インデックス:**
 - `idx_log_timestamp` ON operation_log(timestamp)
 
-### 2.6 settings（設定）
+### 2.6 ledger_merge_history（統合履歴）
+
+履歴統合操作の記録を保存するテーブル（Issue #548）。統合のundo（取り消し）機能を実現するため、統合時の操作内容とundo用データをJSON形式で保持する。
+
+| カラム名 | 型 | NULL | デフォルト | 説明 |
+|----------|-----|------|------------|------|
+| id | INTEGER | NO | 自動採番 | 履歴ID（主キー） |
+| merged_at | TEXT | NO | CURRENT_TIMESTAMP | 統合日時（ISO 8601形式） |
+| target_ledger_id | INTEGER | NO | - | 統合先のledger ID |
+| description | TEXT | NO | - | 統合内容の説明（表示用） |
+| undo_data | TEXT | NO | - | Undo用データ（JSON形式） |
+| is_undone | INTEGER | NO | 0 | 取消済フラグ（0:有効, 1:取消済） |
+
+**インデックス:**
+- `idx_merge_history_target` ON ledger_merge_history(target_ledger_id)
+
+**undo_dataの構造:**
+
+`undo_data` には統合前の状態を復元するために必要な情報がJSON形式で格納される。統合のundo操作時にこのデータを読み込み、統合元のledgerレコードを再作成し、detailのledger_idを元に戻す。
+
+### 2.7 settings（設定）
 
 アプリケーション設定を保存するテーブル。
 
@@ -249,6 +279,7 @@ ICカードの個別利用記録を保存するテーブル。
 | ledger_detail | idx_detail_bus | is_bus | バス利用の検索 |
 | ic_card | idx_card_lent_deleted | is_lent, is_deleted | 貸出状態×削除フラグの複合検索 |
 | ledger | idx_ledger_card_id | card_idm, id DESC | カード別の最新履歴取得 |
+| ledger_merge_history | idx_merge_history_target | target_ledger_id | 統合先レコードの検索 |
 | operation_log | idx_log_timestamp | timestamp | 時系列での検索 |
 
 ---
@@ -263,6 +294,7 @@ ICカードの個別利用記録を保存するテーブル。
 | ic_card | 論理削除 | 過去の履歴参照時にカード情報を表示するため |
 | ledger | 物理削除 | 6年経過後に自動削除（監査対応期間経過後） |
 | ledger_detail | 物理削除 | 親レコード（ledger）に連動してCASCADE削除 |
+| ledger_merge_history | 削除しない | undo操作のため永続保存（is_undoneで取消済を管理） |
 | operation_log | 削除しない | 監査証跡として永続保存 |
 | settings | 物理削除 | マスタデータとして管理 |
 


### PR DESCRIPTION
## Summary
- ER図に `ledger_merge_history` エンティティと `ledger` とのリレーションシップを追加
- テーブル定義（セクション2.6）にカラム定義・インデックス・undo機能の説明を追加
- インデックス一覧に `idx_merge_history_target` を追加
- 論理削除の方針に `ledger_merge_history`（削除しない、is_undoneで管理）を追加

## Test plan
- [ ] Mermaid ER図が正しく描画され、ledger → ledger_merge_history のリレーションが表示されること
- [ ] テーブル定義の内容が `Migration_007_AddMergeHistory.cs` のCREATE文と一致していること
- [ ] セクション番号（2.6/2.7）が正しく連番になっていること

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)