### PR TITLE
docs: クラス設計書にLedgerMergeService等5つのサービスを追加（#574）

### DIFF
--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -96,6 +96,10 @@ graph TB
         SVC_TEMPLATE[TemplateResolver]
         SVC_TOAST[ToastNotificationService]
         SVC_DEBUG[DebugDataService]
+        SVC_MERGE[LedgerMergeService]
+        SVC_CARDLOCK[CardLockManager]
+        SVC_STAFFAUTH[IStaffAuthService]
+        SVC_DIALOG[IDialogService]
     end
 
     subgraph "Data Access Layer"
@@ -186,6 +190,10 @@ graph TB
 | TemplateResolver | Excelテンプレートのパス解決（静的クラス） |
 | ToastNotificationService | トースト通知の表示 |
 | DebugDataService | テストデータの管理（DEBUGビルド専用） |
+| LedgerMergeService | 複数Ledgerレコードの統合・取り消し（Issue #548） |
+| CardLockManager | カードアクセスの排他制御（シングルトン） |
+| IStaffAuthService / StaffAuthService | 職員証による操作者認証 |
+| IDialogService / DialogService | ダイアログ表示の抽象化（テスタビリティ向上） |
 
 ### 3.4 Repositories
 
@@ -220,6 +228,10 @@ graph LR
         RS[ReportService]
         SG[SummaryGenerator]
         CD[CardTypeDetector]
+        LMS[LedgerMergeService]
+        CLM[CardLockManager]
+        SAS[StaffAuthService]
+        DS[DialogService]
     end
 
     subgraph "Repositories"
@@ -252,6 +264,11 @@ graph LR
 
     RS --> CR
     RS --> LR
+
+    LMS --> LR
+    LMS --> SG
+    SAS --> SR
+    SAS --> ICR
 
     SR --> DBC
     CR --> DBC
@@ -633,6 +650,105 @@ classDiagram
     }
 ```
 
+### 5.14 LedgerMergeService
+
+```mermaid
+classDiagram
+    class LedgerMergeService {
+        -ILedgerRepository _ledgerRepository
+        -SummaryGenerator _summaryGenerator
+        -OperationLogger _operationLogger
+        -ILogger _logger
+        +MergeAsync(ledgerIds, operatorIdm) Task~LedgerMergeResult~
+        +UnmergeAsync(mergeHistoryId, operatorIdm) Task~LedgerMergeResult~
+        +GetUndoableMergeHistoriesAsync() Task~List~MergeHistoryEntry~~
+    }
+
+    class LedgerMergeResult {
+        +bool Success
+        +string ErrorMessage
+        +Ledger MergedLedger
+    }
+
+    class MergeHistoryEntry {
+        +int Id
+        +DateTime MergedAt
+        +int TargetLedgerId
+        +string Description
+    }
+
+    LedgerMergeService --> LedgerMergeResult
+    LedgerMergeService --> MergeHistoryEntry
+```
+
+### 5.15 CardLockManager
+
+```mermaid
+classDiagram
+    class CardLockManager {
+        <<IDisposable>>
+        -ConcurrentDictionary _locks
+        -ILogger _logger
+        +GetLock(cardIdm) SemaphoreSlim
+        +ReleaseLockReference(cardIdm) void
+        +CleanupExpiredLocks() void
+        +ClearAllLocks() void
+        +HasLock(cardIdm) bool
+        +Dispose() void
+    }
+```
+
+### 5.16 StaffAuthService
+
+```mermaid
+classDiagram
+    class IStaffAuthService {
+        <<interface>>
+        +RequestAuthenticationAsync(operationDescription) Task~StaffAuthResult~
+    }
+
+    class StaffAuthService {
+        -IStaffRepository _staffRepository
+        -ICardReader _cardReader
+        -ISoundPlayer _soundPlayer
+        +RequestAuthenticationAsync(operationDescription) Task~StaffAuthResult~
+    }
+
+    class StaffAuthResult {
+        +string Idm
+        +string StaffName
+    }
+
+    StaffAuthService ..|> IStaffAuthService
+    StaffAuthService --> StaffAuthResult
+```
+
+### 5.17 DialogService
+
+```mermaid
+classDiagram
+    class IDialogService {
+        <<interface>>
+        +ShowConfirmation(message, title) bool
+        +ShowWarningConfirmation(message, title) bool
+        +ShowInformation(message, title) void
+        +ShowWarning(message, title) void
+        +ShowError(message, title) void
+        +ShowCardRegistrationModeDialog() CardRegistrationModeResult
+    }
+
+    class DialogService {
+        +ShowConfirmation(message, title) bool
+        +ShowWarningConfirmation(message, title) bool
+        +ShowInformation(message, title) void
+        +ShowWarning(message, title) void
+        +ShowError(message, title) void
+        +ShowCardRegistrationModeDialog() CardRegistrationModeResult
+    }
+
+    DialogService ..|> IDialogService
+```
+
 ---
 
 ## 6. DIコンテナ設定
@@ -657,6 +773,10 @@ services.AddSingleton<CsvExportService>();
 services.AddSingleton<CsvImportService>();
 services.AddSingleton<PrintService>();
 services.AddSingleton<IToastNotificationService, ToastNotificationService>();
+services.AddSingleton<LedgerMergeService>();
+services.AddSingleton<CardLockManager>();
+services.AddSingleton<IStaffAuthService, StaffAuthService>();
+services.AddSingleton<IDialogService, DialogService>();
 #if DEBUG
 services.AddSingleton<DebugDataService>();
 #endif


### PR DESCRIPTION
## Summary
- クラス設計書に未記載だった5つのサービスを追加
  - **LedgerMergeService** — 複数Ledgerレコードの統合・undo（Issue #548）
  - **CardLockManager** — カードアクセスの排他制御（SemaphoreSlim）
  - **IStaffAuthService / StaffAuthService** — 職員証による操作者認証
  - **IDialogService / DialogService** — MessageBox抽象化によるテスタビリティ向上
- レイヤー構成図（セクション2）に4サービスを追加
- サービス一覧テーブル（セクション3.3）に4行追加
- 依存関係図（セクション4）にノードと依存線を追加
- クラス詳細（セクション5.14〜5.17）にMermaidクラス図を追加
- DI登録（セクション6.1）に4サービスの登録コードを追加

## Test plan
- [ ] Mermaidレイヤー構成図・依存関係図・クラス図が正しく描画されること
- [ ] サービス一覧テーブルの記載が実装と一致していること
- [ ] DI登録コードが実際の `App.xaml.cs` と整合していること

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)