### PR TITLE
docs: CLAUDE.mdから存在しないViews/Controls/を削除（#576）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,8 @@ ICCardManager/
 │       │   │   ├── SettingsDialog.xaml
 │       │   │   ├── ReportDialog.xaml
 │       │   │   └── ...
-│       │   ├── Converters/             # WPF値コンバーター
-│       │   │   └── VisibilityConverters.cs
-│       │   └── Controls/
+│       │   └── Converters/             # WPF値コンバーター
+│       │       └── VisibilityConverters.cs
 │       ├── ViewModels/                 # ViewModel
 │       │   ├── ViewModelBase.cs
 │       │   ├── MainViewModel.cs


### PR DESCRIPTION
## Summary
- CLAUDE.mdのディレクトリ構成から実在しない `Views/Controls/` エントリを削除
- `Converters/` が `Views/` 配下の最後の子になるため、ツリー記号（`├` → `└`、接続線）を修正

## Test plan
- [ ] CLAUDE.mdのディレクトリツリーが正しいASCII構造であること
- [ ] 実際のディレクトリ構成と一致すること

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)