### PR TITLE
docs: CLAUDE.mdから存在しない初期プロンプト.mdへの参照を削除（#577）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,6 @@ THEN
 
 ## 参照ドキュメント
 
-- `初期プロンプト.md` - 詳細な要件定義
 - `docs/design/` - 設計書一式
 - `docs/manual/` - マニュアル（ユーザー・管理者・開発者）
 - `Resources/Templates/物品出納簿テンプレート.xlsx` - 月次帳票テンプレート


### PR DESCRIPTION
## Summary
- CLAUDE.mdの参照ドキュメントセクションから、リポジトリ内に存在しない `初期プロンプト.md` への参照を削除

## Test plan
- [ ] CLAUDE.mdの参照ドキュメントセクションに不要な記載がないこと
- [ ] 残りの参照先（`docs/design/`、`docs/manual/`、`Resources/Templates/`）が実在すること

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)