### PR TITLE
feat: カード登録時に当月履歴を自動読み取り（#596）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using ICCardManager.Common;
+using ICCardManager.Models;
 using ICCardManager.ViewModels;
 
 namespace ICCardManager.Views.Dialogs
@@ -17,6 +18,7 @@ namespace ICCardManager.Views.Dialogs
         private readonly CardManageViewModel _viewModel;
         private string _presetIdm;
         private int? _presetBalance;
+        private List<LedgerDetail> _presetHistory;
 
         public CardManageDialog(CardManageViewModel viewModel)
         {
@@ -41,6 +43,12 @@ namespace ICCardManager.Views.Dialogs
                     if (_presetBalance.HasValue)
                     {
                         _viewModel.SetPreReadBalance(_presetBalance);
+                    }
+
+                    // Issue #596対応: 事前に読み取った履歴をViewModelに設定
+                    if (_presetHistory != null)
+                    {
+                        _viewModel.SetPreReadHistory(_presetHistory);
                     }
 
                     // Issue #284対応: タッチ時点で削除済み/登録済みチェックを行う
@@ -81,6 +89,23 @@ namespace ICCardManager.Views.Dialogs
         {
             _presetIdm = idm;
             _presetBalance = balance;
+        }
+
+        /// <summary>
+        /// IDm・残高・履歴を指定して新規登録モードで初期化（Issue #596対応）
+        /// </summary>
+        /// <remarks>
+        /// カード検出時に残高と履歴を事前に読み取っておくことで、
+        /// カード登録後に当月分の履歴を自動インポートできる。
+        /// </remarks>
+        /// <param name="idm">カードのIDm</param>
+        /// <param name="balance">事前に読み取ったカード残高</param>
+        /// <param name="history">事前に読み取ったカード利用履歴</param>
+        public void InitializeWithIdmBalanceAndHistory(string idm, int? balance, List<LedgerDetail> history)
+        {
+            _presetIdm = idm;
+            _presetBalance = balance;
+            _presetHistory = history;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- カード登録直後に、カード内のFeliCa履歴から当月分を自動的にledgerレコードとして登録する機能を実装
- 既存の`CreateUsageLedgersAsync`を再利用し、重複チェック・チャージ分離・残高不足パターン検出等をそのまま活用
- 20件すべてが対象期間内の場合、CSV補完が必要な可能性をユーザーに警告

## 変更内容

### LendingService.cs
- `HistoryImportResult`クラスを追加（成功/件数/不完全警告を格納）
- `ImportHistoryForRegistrationAsync`メソッドを追加（`CreateUsageLedgersAsync`を内部呼び出し）

### CardManageViewModel.cs
- `LendingService`をDIで注入
- `_preReadHistory`フィールドと`SetPreReadHistory()`メソッドを追加
- `SaveAsync()`で登録後に履歴インポートフローを統合
- `CreateInitialLedgerAsync()`にオプション引数`overrideDate`/`overrideBalance`を追加
- `CalculatePreHistoryBalance()`ヘルパー追加（最古の履歴から初期残高を逆算）
- `GetImportFromDate()`ヘルパー追加（登録モードに応じたインポート開始日を算出）

### MainViewModel.cs
- 未登録カード検出時に`ReadHistoryAsync`も呼び出し、履歴を事前読み取り

### CardManageDialog.xaml.cs
- `InitializeWithIdmBalanceAndHistory()`メソッドを追加
- `CardManageDialog_Loaded`で履歴をViewModelに引き渡し

### テスト（8件追加）
- `ImportHistoryForRegistrationAsync`: 空リスト/期間外のみ/混在履歴/staffName=null/20件全当月
- `CalculatePreHistoryBalance`: 利用エントリ/チャージエントリ/空リスト

## Test plan
- [x] `dotnet build` でビルド成功（0エラー）
- [x] `dotnet test` で全1088テスト合格
- [ ] 手動テスト: カードをリーダーに置いたまま登録 → 当月分の履歴がledgerに自動登録されること
- [ ] 手動テスト: 帳票作成で該当月のデータが正しく反映されること
- [ ] 手動テスト: 20件すべて当月の場合に警告メッセージが表示されること

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)