### PR TITLE
fix: 履歴詳細画面の分割操作が摘要に反映されない（#633）

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailViewModelTests.cs
@@ -1,0 +1,190 @@
+using FluentAssertions;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using ICCardManager.ViewModels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// LedgerDetailViewModelの単体テスト
+/// Issue #633: 分割操作でGroupIdが正しく設定されることを検証
+/// </summary>
+public class LedgerDetailViewModelTests
+{
+    private readonly LedgerDetailViewModel _viewModel;
+
+    public LedgerDetailViewModelTests()
+    {
+        var ledgerRepoMock = new Mock<ILedgerRepository>();
+        var summaryGenerator = new SummaryGenerator();
+        var operationLogRepoMock = new Mock<IOperationLogRepository>();
+        var staffRepoMock = new Mock<IStaffRepository>();
+        var operationLogger = new OperationLogger(
+            operationLogRepoMock.Object,
+            staffRepoMock.Object);
+        var logger = NullLogger<LedgerDetailViewModel>.Instance;
+
+        _viewModel = new LedgerDetailViewModel(
+            ledgerRepoMock.Object,
+            summaryGenerator,
+            operationLogger,
+            logger);
+    }
+
+    /// <summary>
+    /// テスト用にItemsを直接追加するヘルパー
+    /// </summary>
+    private void AddItems(int count)
+    {
+        _viewModel.Items.Clear();
+        for (int i = 0; i < count; i++)
+        {
+            var detail = new LedgerDetail
+            {
+                EntryStation = $"駅{i * 2 + 1}",
+                ExitStation = $"駅{i * 2 + 2}",
+                UseDate = new DateTime(2026, 2, 10, 10 + i, 0, 0),
+                Balance = 1000 - (i * 260),
+                Amount = 260,
+                SequenceNumber = i + 1
+            };
+            _viewModel.Items.Add(new LedgerDetailItemViewModel(detail, i));
+        }
+    }
+
+    #region ToggleDividerAt テスト
+
+    [Fact]
+    public void ToggleDividerAt_TwoItems_BothGetGroupId()
+    {
+        // Arrange
+        AddItems(2);
+
+        // Act: 1番目のアイテムの下に分割線を挿入
+        _viewModel.ToggleDividerAt(0);
+
+        // Assert: 分割線があるため、両方にGroupIdが設定される
+        _viewModel.Items[0].GroupId.Should().NotBeNull("分割線がある場合、単独アイテムにもGroupIdが付与される");
+        _viewModel.Items[1].GroupId.Should().NotBeNull("分割線がある場合、単独アイテムにもGroupIdが付与される");
+        _viewModel.Items[0].GroupId.Should().NotBe(_viewModel.Items[1].GroupId,
+            "分割されたアイテムは異なるGroupIdを持つ");
+    }
+
+    [Fact]
+    public void ToggleDividerAt_ThreeItems_SplitAfterFirst_CorrectGroupIds()
+    {
+        // Arrange
+        AddItems(3);
+
+        // Act: 1番目のアイテムの下に分割線を挿入
+        _viewModel.ToggleDividerAt(0);
+
+        // Assert
+        // Item 0: GroupId=1（単独グループ）
+        _viewModel.Items[0].GroupId.Should().Be(1, "1番目のアイテムは独立したグループ");
+        // Item 1, 2: GroupId=2（同じグループ）
+        _viewModel.Items[1].GroupId.Should().Be(2, "2番目と3番目は同じグループ");
+        _viewModel.Items[2].GroupId.Should().Be(2, "2番目と3番目は同じグループ");
+    }
+
+    [Fact]
+    public void ToggleDividerAt_Toggle_RemovesDivider_ClearsGroupIds()
+    {
+        // Arrange
+        AddItems(2);
+        _viewModel.ToggleDividerAt(0); // 分割線を挿入
+
+        // Act: もう一度トグルして分割線を削除
+        _viewModel.ToggleDividerAt(0);
+
+        // Assert: 分割線がなくなったのでGroupIdはnull（自動検出モード）
+        _viewModel.Items[0].GroupId.Should().BeNull("分割線なしではGroupIdはnull");
+        _viewModel.Items[1].GroupId.Should().BeNull("分割線なしではGroupIdはnull");
+    }
+
+    #endregion
+
+    #region SplitAll テスト
+
+    [Fact]
+    public void SplitAll_ThreeItems_AllGetUniqueGroupIds()
+    {
+        // Arrange
+        AddItems(3);
+
+        // Act
+        _viewModel.SplitAllCommand.Execute(null);
+
+        // Assert: 全アイテムにGroupIdが付与される
+        _viewModel.Items[0].GroupId.Should().Be(1);
+        _viewModel.Items[1].GroupId.Should().Be(2);
+        _viewModel.Items[2].GroupId.Should().Be(3);
+    }
+
+    [Fact]
+    public void SplitAll_TwoItems_BothGetDistinctGroupIds()
+    {
+        // Arrange
+        AddItems(2);
+
+        // Act
+        _viewModel.SplitAllCommand.Execute(null);
+
+        // Assert
+        _viewModel.Items[0].GroupId.Should().NotBeNull();
+        _viewModel.Items[1].GroupId.Should().NotBeNull();
+        _viewModel.Items[0].GroupId.Should().NotBe(_viewModel.Items[1].GroupId);
+    }
+
+    #endregion
+
+    #region MergeAll テスト
+
+    [Fact]
+    public void MergeAll_AfterSplit_ClearsAllGroupIds()
+    {
+        // Arrange
+        AddItems(3);
+        _viewModel.SplitAllCommand.Execute(null);
+
+        // すべてにGroupIdが設定されていることを確認
+        _viewModel.Items.All(i => i.GroupId.HasValue).Should().BeTrue();
+
+        // Act: すべてを統合
+        _viewModel.MergeAllCommand.Execute(null);
+
+        // Assert: 分割線がないのでGroupIdはすべてnull（自動検出モード）
+        _viewModel.Items[0].GroupId.Should().BeNull("統合後はGroupIdがクリアされる");
+        _viewModel.Items[1].GroupId.Should().BeNull("統合後はGroupIdがクリアされる");
+        _viewModel.Items[2].GroupId.Should().BeNull("統合後はGroupIdがクリアされる");
+    }
+
+    #endregion
+
+    #region HasChanges テスト
+
+    [Fact]
+    public void ToggleDividerAt_SetsHasChanges()
+    {
+        // Arrange
+        AddItems(2);
+        _viewModel.HasChanges.Should().BeFalse();
+
+        // Act
+        _viewModel.ToggleDividerAt(0);
+
+        // Assert
+        _viewModel.HasChanges.Should().BeTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- 履歴詳細画面で分割線を挿入しても、保存後に摘要欄が更新されないバグを修正
- `RecalculateGroupsFromDividers`で単独アイテムのGroupIdが`null`になり、`SummaryGenerator`が自動検出モードにフォールバックしていた
- 分割線がある場合は単独アイテムにもGroupIdを付与し、GroupIdベースの摘要生成パスが使われるよう修正

## Root Cause
`RecalculateGroupsFromDividers()`は`groupSize >= 2`の場合のみGroupIdを設定し、単独アイテム（`groupSize == 1`）には`null`を設定していた。これにより：
1. `SplitAll`で全アイテムを分割 → 全て`GroupId = null`
2. `SummaryGenerator.GenerateRailwaySummary()`が`hasGroupId = false`と判定
3. `GenerateRailwaySummaryAutomatic()`（自動検出）にフォールバック
4. 自動検出が往復・乗継を再統合 → 分割前と同じ摘要文字列を生成
5. `newSummary != _ledger.Summary`が`false` → 更新されない

## Changes
| File | Change |
|------|--------|
| `LedgerDetailViewModel.cs` | `RecalculateGroupsFromDividers()`: 分割線がある場合は全アイテムにGroupIdを付与 |
| `SummaryGeneratorTests.cs` | GroupIdによる分割が摘要に反映されるテスト3件追加 |
| `LedgerDetailViewModelTests.cs` | 新規: 分割・統合操作のGroupId設定テスト7件追加 |

## Test plan
- [x] `dotnet test` で全1098テスト（既存+新規10件）がパスすること
- [x] 履歴詳細画面で分割線を挿入して保存 → 摘要欄が分割された内容に更新されること
- [x] 往復（A→B, B→A）を分割 → 摘要が「A～B 往復」から「A～B、B～A」に変わること
- [ ] 乗継（A→B, B→C）を分割 → 摘要が「A～C」から「A～B、B～C」に変わること
- [x] 「すべて統合」で元に戻す → 摘要が自動検出（往復・乗継統合）に戻ること

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)