### PR TITLE
feat: 履歴詳細画面に行の追加・編集・削除機能を追加（#635）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -227,6 +227,7 @@ namespace ICCardManager
             services.AddTransient<OperationLogSearchViewModel>();
             services.AddTransient<LedgerEditViewModel>();
             services.AddTransient<LedgerDetailViewModel>();
+            services.AddTransient<LedgerDetailEditViewModel>();
             services.AddTransient<SystemManageViewModel>();
 
             // Views
@@ -242,6 +243,7 @@ namespace ICCardManager
             services.AddTransient<Views.Dialogs.OperationLogDialog>();
             services.AddTransient<Views.Dialogs.LedgerDetailDialog>();
             services.AddTransient<Views.Dialogs.LedgerEditDialog>();
+            services.AddTransient<Views.Dialogs.LedgerDetailEditDialog>();
             services.AddTransient<Views.Dialogs.SystemManageDialog>();
         }
 

--- a/ICCardManager/src/ICCardManager/Common/Enums.cs
+++ b/ICCardManager/src/ICCardManager/Common/Enums.cs
@@ -57,4 +57,22 @@ namespace ICCardManager.Common
         /// <summary>その他・不明</summary>
         Unknown
     }
+
+    /// <summary>
+    /// 利用種別（履歴詳細の手動入力用）
+    /// </summary>
+    public enum UsageType
+    {
+        /// <summary>鉄道利用</summary>
+        Rail,
+
+        /// <summary>バス利用</summary>
+        Bus,
+
+        /// <summary>チャージ</summary>
+        Charge,
+
+        /// <summary>ポイント還元</summary>
+        PointRedemption
+    }
 }

--- a/ICCardManager/src/ICCardManager/ViewModels/LedgerDetailEditViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/LedgerDetailEditViewModel.cs
@@ -1,0 +1,459 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ICCardManager.Common;
+using ICCardManager.Models;
+
+namespace ICCardManager.ViewModels
+{
+    /// <summary>
+    /// 利用履歴詳細の追加/編集ダイアログ用ViewModel（Issue #635）
+    /// </summary>
+    public partial class LedgerDetailEditViewModel : ObservableObject
+    {
+        /// <summary>
+        /// 追加モードかどうか（false=編集モード）
+        /// </summary>
+        [ObservableProperty]
+        private bool _isInsertMode;
+
+        /// <summary>
+        /// ダイアログタイトル
+        /// </summary>
+        [ObservableProperty]
+        private string _dialogTitle = "利用詳細の追加";
+
+        /// <summary>
+        /// 選択された利用種別
+        /// </summary>
+        [ObservableProperty]
+        private UsageType _selectedUsageType = UsageType.Rail;
+
+        /// <summary>
+        /// 利用種別の選択肢
+        /// </summary>
+        public List<UsageTypeOption> UsageTypeOptions { get; } = new()
+        {
+            new UsageTypeOption(UsageType.Rail, "鉄道利用"),
+            new UsageTypeOption(UsageType.Bus, "バス利用"),
+            new UsageTypeOption(UsageType.Charge, "チャージ"),
+            new UsageTypeOption(UsageType.PointRedemption, "ポイント還元"),
+        };
+
+        /// <summary>
+        /// 利用日
+        /// </summary>
+        [ObservableProperty]
+        private DateTime? _useDate;
+
+        /// <summary>
+        /// 利用時刻（時:分）
+        /// </summary>
+        [ObservableProperty]
+        private string _useTimeText = string.Empty;
+
+        /// <summary>
+        /// 乗車駅
+        /// </summary>
+        [ObservableProperty]
+        private string _entryStation = string.Empty;
+
+        /// <summary>
+        /// 降車駅
+        /// </summary>
+        [ObservableProperty]
+        private string _exitStation = string.Empty;
+
+        /// <summary>
+        /// バス停名
+        /// </summary>
+        [ObservableProperty]
+        private string _busStops = string.Empty;
+
+        /// <summary>
+        /// 金額（文字列でバリデーション用）
+        /// </summary>
+        [ObservableProperty]
+        private string _amountText = string.Empty;
+
+        /// <summary>
+        /// 残高（文字列で表示）
+        /// </summary>
+        [ObservableProperty]
+        private string _balanceText = string.Empty;
+
+        /// <summary>
+        /// 残高自動計算フラグ
+        /// </summary>
+        [ObservableProperty]
+        private bool _autoCalculateBalance = true;
+
+        /// <summary>
+        /// 挿入位置（追加モード時）
+        /// </summary>
+        [ObservableProperty]
+        private int _insertIndex;
+
+        /// <summary>
+        /// 挿入位置の説明テキスト
+        /// </summary>
+        [ObservableProperty]
+        private string _insertPositionDescription = string.Empty;
+
+        /// <summary>
+        /// 確定フラグ（trueでダイアログ自動閉じ）
+        /// </summary>
+        [ObservableProperty]
+        private bool _isCompleted;
+
+        /// <summary>
+        /// バリデーションエラーがあるかどうか
+        /// </summary>
+        [ObservableProperty]
+        private bool _hasValidationError;
+
+        /// <summary>
+        /// バリデーションメッセージ
+        /// </summary>
+        [ObservableProperty]
+        private string _validationMessage = string.Empty;
+
+        /// <summary>
+        /// 鉄道利用フィールドを表示するか
+        /// </summary>
+        [ObservableProperty]
+        private bool _showRailFields = true;
+
+        /// <summary>
+        /// バス利用フィールドを表示するか
+        /// </summary>
+        [ObservableProperty]
+        private bool _showBusFields;
+
+        /// <summary>
+        /// 確定結果のLedgerDetail
+        /// </summary>
+        public LedgerDetail? Result { get; private set; }
+
+        /// <summary>
+        /// 現在の全アイテムリスト（挿入位置計算用）
+        /// </summary>
+        private IList<LedgerDetailItemViewModel> _items = new List<LedgerDetailItemViewModel>();
+
+        /// <summary>
+        /// 編集対象のインデックス（編集モード時）
+        /// </summary>
+        private int _editTargetIndex = -1;
+
+        /// <summary>
+        /// 初期化中フラグ（プロパティ変更通知の連鎖を防止）
+        /// </summary>
+        private bool _isInitializing;
+
+        /// <summary>
+        /// 追加モードで初期化
+        /// </summary>
+        public void InitializeForInsert(IList<LedgerDetailItemViewModel> items, int suggestedIndex)
+        {
+            _items = items;
+            _isInitializing = true;
+            IsInsertMode = true;
+            DialogTitle = "利用詳細の追加";
+            UseDate = DateTime.Today;
+            InsertIndex = Math.Max(0, Math.Min(suggestedIndex, items.Count));
+            _isInitializing = false;
+            UpdateInsertPositionDescription();
+        }
+
+        /// <summary>
+        /// 編集モードで初期化
+        /// </summary>
+        public void InitializeForEdit(LedgerDetailItemViewModel editTarget, IList<LedgerDetailItemViewModel> items)
+        {
+            _items = items;
+            _editTargetIndex = editTarget.Index;
+            IsInsertMode = false;
+            DialogTitle = "利用詳細の編集";
+
+            var detail = editTarget.Detail;
+
+            // 利用種別を判定
+            if (detail.IsCharge)
+                SelectedUsageType = UsageType.Charge;
+            else if (detail.IsPointRedemption)
+                SelectedUsageType = UsageType.PointRedemption;
+            else if (detail.IsBus)
+                SelectedUsageType = UsageType.Bus;
+            else
+                SelectedUsageType = UsageType.Rail;
+
+            UseDate = detail.UseDate?.Date;
+            UseTimeText = detail.UseDate?.ToString("HH:mm") ?? string.Empty;
+            EntryStation = detail.EntryStation ?? string.Empty;
+            ExitStation = detail.ExitStation ?? string.Empty;
+            BusStops = detail.BusStops ?? string.Empty;
+            AmountText = detail.Amount?.ToString() ?? string.Empty;
+            BalanceText = detail.Balance?.ToString() ?? string.Empty;
+            AutoCalculateBalance = false; // 編集時は既存値を表示
+        }
+
+        partial void OnSelectedUsageTypeChanged(UsageType value)
+        {
+            ShowRailFields = value == UsageType.Rail;
+            ShowBusFields = value == UsageType.Bus;
+            RecalculateBalance();
+        }
+
+        partial void OnUseDateChanged(DateTime? value)
+        {
+            if (_isInitializing) return;
+            if (IsInsertMode && value.HasValue)
+            {
+                InsertIndex = SuggestInsertIndex(value.Value);
+                UpdateInsertPositionDescription();
+            }
+        }
+
+        partial void OnAmountTextChanged(string value)
+        {
+            RecalculateBalance();
+        }
+
+        partial void OnAutoCalculateBalanceChanged(bool value)
+        {
+            if (value)
+            {
+                RecalculateBalance();
+            }
+        }
+
+        /// <summary>
+        /// 日付から挿入位置を自動計算（use_date昇順で合致する位置）
+        /// </summary>
+        public int SuggestInsertIndex(DateTime useDate)
+        {
+            // 時刻テキストがあればそれを結合、なければ渡された日時をそのまま使用
+            var fullDate = TryParseTime(UseTimeText, out var time) ? useDate.Date.Add(time) : useDate;
+
+            for (int i = 0; i < _items.Count; i++)
+            {
+                if (_items[i].Detail.UseDate.HasValue && _items[i].Detail.UseDate > fullDate)
+                {
+                    return i;
+                }
+            }
+            return _items.Count;
+        }
+
+        /// <summary>
+        /// 残高を自動計算
+        /// </summary>
+        public void RecalculateBalance()
+        {
+            if (!AutoCalculateBalance) return;
+            if (!int.TryParse(AmountText, out var amount) || amount < 0)
+            {
+                BalanceText = string.Empty;
+                return;
+            }
+
+            int prevBalance = GetPreviousBalance();
+
+            bool isIncome = SelectedUsageType == UsageType.Charge || SelectedUsageType == UsageType.PointRedemption;
+            int newBalance = isIncome ? prevBalance + amount : prevBalance - amount;
+            BalanceText = newBalance.ToString();
+        }
+
+        /// <summary>
+        /// 前行の残高を取得
+        /// </summary>
+        private int GetPreviousBalance()
+        {
+            int targetIndex = IsInsertMode ? InsertIndex : _editTargetIndex;
+
+            // 挿入位置の前の行を探す
+            int prevIndex = targetIndex - 1;
+            if (prevIndex >= 0 && prevIndex < _items.Count)
+            {
+                return _items[prevIndex].Detail.Balance ?? 0;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// 挿入位置を上に移動
+        /// </summary>
+        [RelayCommand]
+        private void MoveInsertPositionUp()
+        {
+            if (InsertIndex > 0)
+            {
+                InsertIndex--;
+                UpdateInsertPositionDescription();
+                RecalculateBalance();
+            }
+        }
+
+        /// <summary>
+        /// 挿入位置を下に移動
+        /// </summary>
+        [RelayCommand]
+        private void MoveInsertPositionDown()
+        {
+            if (InsertIndex < _items.Count)
+            {
+                InsertIndex++;
+                UpdateInsertPositionDescription();
+                RecalculateBalance();
+            }
+        }
+
+        /// <summary>
+        /// 挿入位置の説明テキストを更新
+        /// </summary>
+        private void UpdateInsertPositionDescription()
+        {
+            if (_items.Count == 0)
+            {
+                InsertPositionDescription = "先頭に挿入";
+                return;
+            }
+
+            if (InsertIndex == 0)
+            {
+                InsertPositionDescription = "先頭に挿入";
+            }
+            else if (InsertIndex >= _items.Count)
+            {
+                InsertPositionDescription = $"「{_items[_items.Count - 1].RouteDisplay}」の後に挿入（末尾）";
+            }
+            else
+            {
+                InsertPositionDescription = $"「{_items[InsertIndex - 1].RouteDisplay}」の後に挿入";
+            }
+        }
+
+        /// <summary>
+        /// 確定コマンド
+        /// </summary>
+        [RelayCommand]
+        private void Confirm()
+        {
+            if (!Validate()) return;
+
+            Result = BuildLedgerDetail();
+            IsCompleted = true;
+        }
+
+        /// <summary>
+        /// バリデーション
+        /// </summary>
+        public bool Validate()
+        {
+            HasValidationError = false;
+            ValidationMessage = string.Empty;
+
+            if (!UseDate.HasValue)
+            {
+                HasValidationError = true;
+                ValidationMessage = "利用日を入力してください。";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(AmountText))
+            {
+                HasValidationError = true;
+                ValidationMessage = "金額を入力してください。";
+                return false;
+            }
+
+            if (!int.TryParse(AmountText, out var amount) || amount < 0)
+            {
+                HasValidationError = true;
+                ValidationMessage = "金額は0以上の数値を入力してください。";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(BalanceText) && !int.TryParse(BalanceText, out _))
+            {
+                HasValidationError = true;
+                ValidationMessage = "残高は数値を入力してください。";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(UseTimeText) && !TryParseTime(UseTimeText, out _))
+            {
+                HasValidationError = true;
+                ValidationMessage = "時刻は HH:mm 形式で入力してください。";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// フォーム値からLedgerDetailを生成
+        /// </summary>
+        public LedgerDetail BuildLedgerDetail()
+        {
+            int.TryParse(AmountText, out var amount);
+            int? balance = int.TryParse(BalanceText, out var b) ? b : null;
+
+            var useDate = CombineDateTime(UseDate!.Value);
+
+            return new LedgerDetail
+            {
+                UseDate = useDate,
+                EntryStation = SelectedUsageType == UsageType.Rail ? EntryStation : string.Empty,
+                ExitStation = SelectedUsageType == UsageType.Rail ? ExitStation : string.Empty,
+                BusStops = SelectedUsageType == UsageType.Bus ? BusStops : string.Empty,
+                Amount = amount,
+                Balance = balance,
+                IsCharge = SelectedUsageType == UsageType.Charge,
+                IsPointRedemption = SelectedUsageType == UsageType.PointRedemption,
+                IsBus = SelectedUsageType == UsageType.Bus,
+                SequenceNumber = 0 // 手動入力はSequenceNumber=0
+            };
+        }
+
+        /// <summary>
+        /// 日付と時刻テキストを結合
+        /// </summary>
+        private DateTime CombineDateTime(DateTime date)
+        {
+            if (TryParseTime(UseTimeText, out var time))
+            {
+                return date.Date.Add(time);
+            }
+            return date.Date;
+        }
+
+        /// <summary>
+        /// 時刻文字列をパース
+        /// </summary>
+        private static bool TryParseTime(string text, out TimeSpan result)
+        {
+            result = TimeSpan.Zero;
+            if (string.IsNullOrWhiteSpace(text)) return false;
+            return TimeSpan.TryParse(text, out result);
+        }
+    }
+
+    /// <summary>
+    /// 利用種別のComboBox選択肢
+    /// </summary>
+    public class UsageTypeOption
+    {
+        public UsageType Value { get; }
+        public string DisplayName { get; }
+
+        public UsageTypeOption(UsageType value, string displayName)
+        {
+            Value = value;
+            DisplayName = displayName;
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
@@ -141,8 +141,31 @@
                     <Button Content="🔄 自動検出に戻す"
                             Command="{Binding ResetToAutoDetectCommand}"
                             Padding="12,6"
+                            Margin="0,0,8,0"
                             ToolTip="すべての分割線を削除し、自動検出モードに戻します"
                             AutomationProperties.Name="自動検出に戻す"/>
+
+                    <!-- Issue #635: 行操作ボタン -->
+                    <Border Width="1" Background="#BDBDBD" Margin="4,2"/>
+                    <Button Content="➕ 行の追加"
+                            Command="{Binding InsertRowCommand}"
+                            Padding="12,6"
+                            Margin="8,0,8,0"
+                            ToolTip="利用詳細行を手動で追加します"
+                            AutomationProperties.Name="行の追加"/>
+                    <Button Content="✏️ 編集"
+                            Command="{Binding EditRowCommand}"
+                            IsEnabled="{Binding HasSelectedItem}"
+                            Padding="12,6"
+                            Margin="0,0,8,0"
+                            ToolTip="選択した行を編集します"
+                            AutomationProperties.Name="編集"/>
+                    <Button Content="🗑️ 削除"
+                            Command="{Binding DeleteRowCommand}"
+                            IsEnabled="{Binding HasSelectedItem}"
+                            Padding="12,6"
+                            ToolTip="選択した行を削除します"
+                            AutomationProperties.Name="削除"/>
                 </StackPanel>
 
                 <TextBlock Grid.Column="1"
@@ -185,11 +208,21 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <!-- データ行 -->
-                                    <Border Padding="8,8" x:Name="DataRowBorder">
+                                    <!-- データ行（Issue #635: 選択・ダブルクリック対応） -->
+                                    <Border Padding="8,8" x:Name="DataRowBorder"
+                                            Tag="{Binding}"
+                                            Cursor="Hand"
+                                            MouseLeftButtonDown="DataRow_MouseLeftButtonDown"
+                                            MouseRightButtonDown="DataRow_MouseLeftButtonDown">
+                                        <Border.InputBindings>
+                                            <MouseBinding MouseAction="LeftDoubleClick"
+                                                          Command="{Binding DataContext.EditRowCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"/>
+                                        </Border.InputBindings>
                                         <Border.Style>
                                             <Style TargetType="Border">
                                                 <Setter Property="Background" Value="Transparent"/>
+                                                <Setter Property="BorderThickness" Value="2"/>
+                                                <Setter Property="BorderBrush" Value="Transparent"/>
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding GroupColorIndex}" Value="1">
                                                         <Setter Property="Background" Value="#E3F2FD"/>
@@ -205,6 +238,11 @@
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding GroupColorIndex}" Value="5">
                                                         <Setter Property="Background" Value="#FFEBEE"/>
+                                                    </DataTrigger>
+                                                    <!-- 選択状態 -->
+                                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                        <Setter Property="BorderBrush" Value="#1976D2"/>
+                                                        <Setter Property="Background" Value="#E3F2FD"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
@@ -391,6 +429,8 @@
                     <Run Text=" 行と行の間をクリックして分割線を挿入/削除できます。"/>
                     <LineBreak/>
                     <Run Text="太い線で区切られていない連続した行は、1つの乗り継ぎとして摘要にまとめられます。"/>
+                    <LineBreak/>
+                    <Run Text="行を選択して「編集」「削除」が可能です。「行の追加」で手動入力もできます。ダブルクリックで編集できます。"/>
                 </TextBlock>
                 <!-- 複数グループ時の追加説明（Issue #634） -->
                 <TextBlock TextWrapping="Wrap"

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using ICCardManager.Dtos;
 using ICCardManager.Models;
 using ICCardManager.ViewModels;
@@ -52,6 +53,19 @@ namespace ICCardManager.Views.Dialogs
                 }
             };
 
+            // Issue #635: ダイアログファクトリを設定
+            _viewModel.CreateEditDialogFunc = () =>
+            {
+                var dialog = App.Current.ServiceProvider.GetRequiredService<LedgerDetailEditDialog>();
+                dialog.Owner = this;
+                return dialog;
+            };
+
+            // Issue #635: 削除確認コールバックを設定
+            _viewModel.OnRequestDeleteConfirmation = (message) =>
+                MessageBox.Show(message, "確認", MessageBoxButton.YesNo, MessageBoxImage.Warning)
+                == MessageBoxResult.Yes;
+
             await _viewModel.InitializeAsync(ledgerId, operatorIdm);
         }
 
@@ -79,6 +93,17 @@ namespace ICCardManager.Views.Dialogs
             if (sender is System.Windows.Controls.Button button && button.Tag is int index)
             {
                 _viewModel?.ToggleDividerAt(index);
+            }
+        }
+
+        /// <summary>
+        /// データ行クリック時の処理（Issue #635: 行選択）
+        /// </summary>
+        private void DataRow_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is Border border && border.Tag is LedgerDetailItemViewModel item)
+            {
+                _viewModel?.SelectItemCommand.Execute(item);
             }
         }
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailEditDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailEditDialog.xaml
@@ -1,0 +1,249 @@
+<Window x:Class="ICCardManager.Views.Dialogs.LedgerDetailEditDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:LedgerDetailEditViewModel}"
+        Title="{Binding DialogTitle}"
+        SizeToContent="Height"
+        Width="500"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        AutomationProperties.Name="利用詳細の追加・編集ダイアログ">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </Window.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/> <!-- 利用種別 -->
+            <RowDefinition Height="Auto"/> <!-- 利用日時 -->
+            <RowDefinition Height="Auto"/> <!-- 鉄道フィールド -->
+            <RowDefinition Height="Auto"/> <!-- バスフィールド -->
+            <RowDefinition Height="Auto"/> <!-- 金額・残高 -->
+            <RowDefinition Height="Auto"/> <!-- 挿入位置 -->
+            <RowDefinition Height="Auto"/> <!-- エラー -->
+            <RowDefinition Height="Auto"/> <!-- ボタン -->
+        </Grid.RowDefinitions>
+
+        <!-- 利用種別 -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="利用種別"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4"/>
+            <ComboBox ItemsSource="{Binding UsageTypeOptions}"
+                      SelectedValue="{Binding SelectedUsageType}"
+                      SelectedValuePath="Value"
+                      DisplayMemberPath="DisplayName"
+                      FontSize="{DynamicResource BaseFontSize}"
+                      Padding="8,6"
+                      AutomationProperties.Name="利用種別"/>
+        </StackPanel>
+
+        <!-- 利用日時 -->
+        <StackPanel Grid.Row="1" Margin="0,0,0,12">
+            <TextBlock Text="利用日時"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4"/>
+            <StackPanel Orientation="Horizontal">
+                <DatePicker SelectedDate="{Binding UseDate, UpdateSourceTrigger=PropertyChanged}"
+                            FontSize="{DynamicResource BaseFontSize}"
+                            Width="180"
+                            AutomationProperties.Name="利用日"/>
+                <TextBox Text="{Binding UseTimeText, UpdateSourceTrigger=PropertyChanged}"
+                         FontSize="{DynamicResource BaseFontSize}"
+                         Width="80"
+                         Margin="10,0,0,0"
+                         Padding="8,6"
+                         AutomationProperties.Name="利用時刻"
+                         ToolTip="HH:mm 形式（例: 09:30）"/>
+                <TextBlock Text="（HH:mm）"
+                           FontSize="{DynamicResource SmallFontSize}"
+                           Foreground="Gray"
+                           VerticalAlignment="Center"
+                           Margin="6,0,0,0"/>
+            </StackPanel>
+        </StackPanel>
+
+        <!-- 鉄道利用フィールド -->
+        <StackPanel Grid.Row="2" Margin="0,0,0,12"
+                    Visibility="{Binding ShowRailFields, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="乗車駅"
+                               FontSize="{DynamicResource SmallFontSize}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding EntryStation, UpdateSourceTrigger=PropertyChanged}"
+                             FontSize="{DynamicResource BaseFontSize}"
+                             Padding="8,6"
+                             AutomationProperties.Name="乗車駅"/>
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="降車駅"
+                               FontSize="{DynamicResource SmallFontSize}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding ExitStation, UpdateSourceTrigger=PropertyChanged}"
+                             FontSize="{DynamicResource BaseFontSize}"
+                             Padding="8,6"
+                             AutomationProperties.Name="降車駅"/>
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+
+        <!-- バス利用フィールド -->
+        <StackPanel Grid.Row="3" Margin="0,0,0,12"
+                    Visibility="{Binding ShowBusFields, Converter={StaticResource BoolToVisibilityConverter}}">
+            <TextBlock Text="バス停名"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,4"/>
+            <TextBox Text="{Binding BusStops, UpdateSourceTrigger=PropertyChanged}"
+                     FontSize="{DynamicResource BaseFontSize}"
+                     Padding="8,6"
+                     AutomationProperties.Name="バス停名"
+                     ToolTip="バス停名を入力してください（空欄の場合は★で表示）"/>
+        </StackPanel>
+
+        <!-- 金額・残高 -->
+        <StackPanel Grid.Row="4" Margin="0,0,0,12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="金額"
+                               FontSize="{DynamicResource SmallFontSize}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox Text="{Binding AmountText, UpdateSourceTrigger=PropertyChanged}"
+                                 FontSize="{DynamicResource BaseFontSize}"
+                                 Width="120"
+                                 Padding="8,6"
+                                 AutomationProperties.Name="金額"/>
+                        <TextBlock Text="円"
+                                   FontSize="{DynamicResource BaseFontSize}"
+                                   VerticalAlignment="Center"
+                                   Margin="6,0,0,0"/>
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="残額"
+                               FontSize="{DynamicResource SmallFontSize}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,4"/>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox Text="{Binding BalanceText, UpdateSourceTrigger=PropertyChanged}"
+                                 FontSize="{DynamicResource BaseFontSize}"
+                                 Width="120"
+                                 Padding="8,6"
+                                 IsReadOnly="{Binding AutoCalculateBalance}"
+                                 AutomationProperties.Name="残額"/>
+                        <TextBlock Text="円"
+                                   FontSize="{DynamicResource BaseFontSize}"
+                                   VerticalAlignment="Center"
+                                   Margin="6,0,0,0"/>
+                    </StackPanel>
+                    <CheckBox Content="自動計算"
+                              IsChecked="{Binding AutoCalculateBalance}"
+                              FontSize="{DynamicResource SmallFontSize}"
+                              Margin="0,4,0,0"
+                              AutomationProperties.Name="残高自動計算"/>
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+
+        <!-- 挿入位置（追加モード時のみ） -->
+        <Border Grid.Row="5" Margin="0,0,0,12"
+                Background="#F5F5F5" CornerRadius="4" Padding="12"
+                Visibility="{Binding IsInsertMode, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel>
+                <TextBlock Text="挿入位置"
+                           FontSize="{DynamicResource SmallFontSize}"
+                           FontWeight="SemiBold"
+                           Margin="0,0,0,6"/>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0"
+                            Content="&#x25B2;"
+                            Command="{Binding MoveInsertPositionUpCommand}"
+                            Padding="10,4"
+                            FontSize="{DynamicResource BaseFontSize}"
+                            AutomationProperties.Name="挿入位置を上に移動"
+                            ToolTip="挿入位置を1つ上に移動"/>
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding InsertPositionDescription}"
+                               FontSize="{DynamicResource SmallFontSize}"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               Margin="8,0"/>
+                    <Button Grid.Column="2"
+                            Content="&#x25BC;"
+                            Command="{Binding MoveInsertPositionDownCommand}"
+                            Padding="10,4"
+                            FontSize="{DynamicResource BaseFontSize}"
+                            AutomationProperties.Name="挿入位置を下に移動"
+                            ToolTip="挿入位置を1つ下に移動"/>
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <!-- バリデーションエラー -->
+        <Border Grid.Row="6" Margin="0,0,0,12"
+                Background="#FFEBEE" CornerRadius="4" Padding="10"
+                Visibility="{Binding HasValidationError, Converter={StaticResource BoolToVisibilityConverter}}">
+            <TextBlock Text="{Binding ValidationMessage}"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       Foreground="#D32F2F"
+                       TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- ボタン -->
+        <Grid Grid.Row="7" Margin="0,8,0,0">
+            <Button Content="キャンセル"
+                    Click="CancelButton_Click"
+                    HorizontalAlignment="Left"
+                    Padding="20,8"
+                    IsCancel="True"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    AutomationProperties.Name="キャンセル"/>
+            <Button Command="{Binding ConfirmCommand}"
+                    HorizontalAlignment="Right"
+                    Padding="20,8"
+                    Background="#4CAF50"
+                    Foreground="White"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    AutomationProperties.Name="確定">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Setter Property="Content" Value="追加"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsInsertMode}" Value="False">
+                                <Setter Property="Content" Value="更新"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+        </Grid>
+    </Grid>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailEditDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailEditDialog.xaml.cs
@@ -1,0 +1,49 @@
+using System.Windows;
+using ICCardManager.Models;
+using ICCardManager.ViewModels;
+
+namespace ICCardManager.Views.Dialogs
+{
+    /// <summary>
+    /// 利用履歴詳細の追加/編集ダイアログ（Issue #635）
+    /// </summary>
+    public partial class LedgerDetailEditDialog : Window
+    {
+        private readonly LedgerDetailEditViewModel _viewModel;
+
+        public LedgerDetailEditDialog(LedgerDetailEditViewModel viewModel)
+        {
+            InitializeComponent();
+            _viewModel = viewModel;
+            DataContext = _viewModel;
+
+            _viewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(_viewModel.IsCompleted) && _viewModel.IsCompleted)
+                {
+                    DialogResult = true;
+                    Close();
+                }
+            };
+        }
+
+        /// <summary>
+        /// 確定結果のLedgerDetail
+        /// </summary>
+        public LedgerDetail? Result => _viewModel.Result;
+
+        /// <summary>
+        /// 挿入位置
+        /// </summary>
+        public int InsertIndex => _viewModel.InsertIndex;
+
+        /// <summary>
+        /// キャンセルボタン
+        /// </summary>
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailEditViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailEditViewModelTests.cs
@@ -1,0 +1,532 @@
+using FluentAssertions;
+using ICCardManager.Common;
+using ICCardManager.Models;
+using ICCardManager.ViewModels;
+using Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// LedgerDetailEditViewModelの単体テスト
+/// Issue #635: 履歴詳細の追加/編集ダイアログ
+/// </summary>
+public class LedgerDetailEditViewModelTests
+{
+    private readonly LedgerDetailEditViewModel _viewModel;
+
+    public LedgerDetailEditViewModelTests()
+    {
+        _viewModel = new LedgerDetailEditViewModel();
+    }
+
+    /// <summary>
+    /// テスト用のアイテムリストを作成
+    /// </summary>
+    private static ObservableCollection<LedgerDetailItemViewModel> CreateTestItems()
+    {
+        var items = new ObservableCollection<LedgerDetailItemViewModel>();
+        var details = new[]
+        {
+            new LedgerDetail
+            {
+                UseDate = new DateTime(2026, 2, 10, 9, 0, 0),
+                EntryStation = "博多", ExitStation = "天神",
+                Amount = 260, Balance = 740,
+                SequenceNumber = 1
+            },
+            new LedgerDetail
+            {
+                UseDate = new DateTime(2026, 2, 10, 12, 0, 0),
+                EntryStation = "天神", ExitStation = "赤坂",
+                Amount = 200, Balance = 540,
+                SequenceNumber = 2
+            },
+            new LedgerDetail
+            {
+                UseDate = new DateTime(2026, 2, 10, 18, 0, 0),
+                EntryStation = "赤坂", ExitStation = "博多",
+                Amount = 260, Balance = 280,
+                SequenceNumber = 3
+            }
+        };
+
+        for (int i = 0; i < details.Length; i++)
+        {
+            items.Add(new LedgerDetailItemViewModel(details[i], i));
+        }
+        return items;
+    }
+
+    #region InitializeForInsert テスト
+
+    [Fact]
+    public void InitializeForInsert_SetsInsertMode()
+    {
+        // Arrange
+        var items = CreateTestItems();
+
+        // Act
+        _viewModel.InitializeForInsert(items, 1);
+
+        // Assert
+        _viewModel.IsInsertMode.Should().BeTrue();
+        _viewModel.DialogTitle.Should().Be("利用詳細の追加");
+        _viewModel.InsertIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void InitializeForInsert_ClampsIndexToRange()
+    {
+        // Arrange
+        var items = CreateTestItems();
+
+        // Act
+        _viewModel.InitializeForInsert(items, 100);
+
+        // Assert: 最大はitems.Countにクランプされる
+        _viewModel.InsertIndex.Should().Be(items.Count);
+    }
+
+    #endregion
+
+    #region InitializeForEdit テスト
+
+    [Fact]
+    public void InitializeForEdit_PopulatesFields()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        var editTarget = items[0]; // 博多→天神
+
+        // Act
+        _viewModel.InitializeForEdit(editTarget, items);
+
+        // Assert
+        _viewModel.IsInsertMode.Should().BeFalse();
+        _viewModel.DialogTitle.Should().Be("利用詳細の編集");
+        _viewModel.SelectedUsageType.Should().Be(UsageType.Rail);
+        _viewModel.EntryStation.Should().Be("博多");
+        _viewModel.ExitStation.Should().Be("天神");
+        _viewModel.AmountText.Should().Be("260");
+        _viewModel.BalanceText.Should().Be("740");
+    }
+
+    [Fact]
+    public void InitializeForEdit_ChargeType_SetsCorrectUsageType()
+    {
+        // Arrange
+        var chargeDetail = new LedgerDetail
+        {
+            UseDate = new DateTime(2026, 2, 10, 10, 0, 0),
+            IsCharge = true,
+            Amount = 3000,
+            Balance = 3540,
+            SequenceNumber = 1
+        };
+        var items = new ObservableCollection<LedgerDetailItemViewModel>
+        {
+            new LedgerDetailItemViewModel(chargeDetail, 0)
+        };
+
+        // Act
+        _viewModel.InitializeForEdit(items[0], items);
+
+        // Assert
+        _viewModel.SelectedUsageType.Should().Be(UsageType.Charge);
+    }
+
+    [Fact]
+    public void InitializeForEdit_BusType_SetsCorrectUsageType()
+    {
+        // Arrange
+        var busDetail = new LedgerDetail
+        {
+            UseDate = new DateTime(2026, 2, 10, 10, 0, 0),
+            IsBus = true, BusStops = "天神バス停",
+            Amount = 100, Balance = 440,
+            SequenceNumber = 1
+        };
+        var items = new ObservableCollection<LedgerDetailItemViewModel>
+        {
+            new LedgerDetailItemViewModel(busDetail, 0)
+        };
+
+        // Act
+        _viewModel.InitializeForEdit(items[0], items);
+
+        // Assert
+        _viewModel.SelectedUsageType.Should().Be(UsageType.Bus);
+        _viewModel.BusStops.Should().Be("天神バス停");
+    }
+
+    #endregion
+
+    #region UsageType切替 テスト
+
+    [Fact]
+    public void UsageTypeRail_ShowsStationFields()
+    {
+        // Act
+        _viewModel.SelectedUsageType = UsageType.Rail;
+
+        // Assert
+        _viewModel.ShowRailFields.Should().BeTrue();
+        _viewModel.ShowBusFields.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UsageTypeBus_ShowsBusFields()
+    {
+        // Act
+        _viewModel.SelectedUsageType = UsageType.Bus;
+
+        // Assert
+        _viewModel.ShowRailFields.Should().BeFalse();
+        _viewModel.ShowBusFields.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UsageTypeCharge_HidesAllRouteFields()
+    {
+        // Act
+        _viewModel.SelectedUsageType = UsageType.Charge;
+
+        // Assert
+        _viewModel.ShowRailFields.Should().BeFalse();
+        _viewModel.ShowBusFields.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region 残高自動計算 テスト
+
+    [Fact]
+    public void AutoCalculateBalance_Usage_SubtractsFromPrevious()
+    {
+        // Arrange: 前行の残高が740
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 1); // index=1, 前行は博多→天神(Balance=740)
+        _viewModel.SelectedUsageType = UsageType.Rail;
+
+        // Act
+        _viewModel.AmountText = "200";
+
+        // Assert: 740 - 200 = 540
+        _viewModel.BalanceText.Should().Be("540");
+    }
+
+    [Fact]
+    public void AutoCalculateBalance_Charge_AddsToPrevious()
+    {
+        // Arrange: 前行の残高が540
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 2); // index=2, 前行は天神→赤坂(Balance=540)
+        _viewModel.SelectedUsageType = UsageType.Charge;
+
+        // Act
+        _viewModel.AmountText = "3000";
+
+        // Assert: 540 + 3000 = 3540
+        _viewModel.BalanceText.Should().Be("3540");
+    }
+
+    [Fact]
+    public void AutoCalculateBalance_PointRedemption_AddsToPrevious()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 1);
+        _viewModel.SelectedUsageType = UsageType.PointRedemption;
+
+        // Act
+        _viewModel.AmountText = "50";
+
+        // Assert: 740 + 50 = 790
+        _viewModel.BalanceText.Should().Be("790");
+    }
+
+    [Fact]
+    public void AutoCalculateBalance_FirstRow_PreviousBalanceIsZero()
+    {
+        // Arrange: 先頭に挿入
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+        _viewModel.SelectedUsageType = UsageType.Charge;
+
+        // Act
+        _viewModel.AmountText = "1000";
+
+        // Assert: 0 + 1000 = 1000
+        _viewModel.BalanceText.Should().Be("1000");
+    }
+
+    [Fact]
+    public void AutoCalculateBalance_Off_DoesNotChange()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 1);
+        _viewModel.AutoCalculateBalance = false;
+        _viewModel.BalanceText = "999";
+
+        // Act
+        _viewModel.AmountText = "200";
+
+        // Assert: 自動計算オフなので変わらない
+        _viewModel.BalanceText.Should().Be("999");
+    }
+
+    #endregion
+
+    #region SuggestInsertIndex テスト
+
+    [Fact]
+    public void SuggestInsertIndex_ByDate_CorrectPosition()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+
+        // Act: 10:00の利用 → 9:00と12:00の間に挿入
+        var index = _viewModel.SuggestInsertIndex(new DateTime(2026, 2, 10, 10, 0, 0));
+
+        // Assert
+        index.Should().Be(1, "9:00の次、12:00の前");
+    }
+
+    [Fact]
+    public void SuggestInsertIndex_AfterAllItems_ReturnsCount()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+
+        // Act: 20:00 → 全アイテムより後
+        var index = _viewModel.SuggestInsertIndex(new DateTime(2026, 2, 10, 20, 0, 0));
+
+        // Assert
+        index.Should().Be(3, "末尾に挿入");
+    }
+
+    [Fact]
+    public void SuggestInsertIndex_BeforeAllItems_ReturnsZero()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+
+        // Act: 8:00 → 全アイテムより前
+        var index = _viewModel.SuggestInsertIndex(new DateTime(2026, 2, 10, 8, 0, 0));
+
+        // Assert
+        index.Should().Be(0, "先頭に挿入");
+    }
+
+    #endregion
+
+    #region MoveInsertPosition テスト
+
+    [Fact]
+    public void MoveInsertPosition_UpDown_BoundaryCheck()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+
+        // Act: 0より上には行けない
+        _viewModel.MoveInsertPositionUpCommand.Execute(null);
+        _viewModel.InsertIndex.Should().Be(0, "下限");
+
+        // Act: 下に移動
+        _viewModel.MoveInsertPositionDownCommand.Execute(null);
+        _viewModel.InsertIndex.Should().Be(1);
+
+        // Act: items.Countまで移動
+        _viewModel.MoveInsertPositionDownCommand.Execute(null);
+        _viewModel.MoveInsertPositionDownCommand.Execute(null);
+        _viewModel.InsertIndex.Should().Be(3, "items.Count");
+
+        // Act: items.Countより上には行けない
+        _viewModel.MoveInsertPositionDownCommand.Execute(null);
+        _viewModel.InsertIndex.Should().Be(3, "上限");
+    }
+
+    #endregion
+
+    #region Validate テスト
+
+    [Fact]
+    public void Confirm_MissingDate_ValidationError()
+    {
+        // Arrange: 日付なし
+        _viewModel.UseDate = null;
+        _viewModel.AmountText = "260";
+
+        // Act
+        var result = _viewModel.Validate();
+
+        // Assert
+        result.Should().BeFalse();
+        _viewModel.HasValidationError.Should().BeTrue();
+        _viewModel.ValidationMessage.Should().Contain("利用日");
+    }
+
+    [Fact]
+    public void Confirm_MissingAmount_ValidationError()
+    {
+        // Arrange
+        _viewModel.UseDate = DateTime.Today;
+        _viewModel.AmountText = "";
+
+        // Act
+        var result = _viewModel.Validate();
+
+        // Assert
+        result.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("金額");
+    }
+
+    [Fact]
+    public void Confirm_NegativeAmount_ValidationError()
+    {
+        // Arrange
+        _viewModel.UseDate = DateTime.Today;
+        _viewModel.AmountText = "-100";
+
+        // Act
+        var result = _viewModel.Validate();
+
+        // Assert
+        result.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("0以上");
+    }
+
+    [Fact]
+    public void Confirm_InvalidTime_ValidationError()
+    {
+        // Arrange
+        _viewModel.UseDate = DateTime.Today;
+        _viewModel.AmountText = "260";
+        _viewModel.UseTimeText = "abc";
+
+        // Act
+        var result = _viewModel.Validate();
+
+        // Assert
+        result.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("HH:mm");
+    }
+
+    [Fact]
+    public void Confirm_ValidData_SetsIsCompleted()
+    {
+        // Arrange
+        var items = CreateTestItems();
+        _viewModel.InitializeForInsert(items, 0);
+        _viewModel.UseDate = new DateTime(2026, 2, 10);
+        _viewModel.UseTimeText = "10:30";
+        _viewModel.AmountText = "260";
+        _viewModel.EntryStation = "博多";
+        _viewModel.ExitStation = "天神";
+
+        // Act
+        _viewModel.ConfirmCommand.Execute(null);
+
+        // Assert
+        _viewModel.IsCompleted.Should().BeTrue();
+        _viewModel.Result.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region BuildLedgerDetail テスト
+
+    [Fact]
+    public void BuildLedgerDetail_Rail_CorrectFlags()
+    {
+        // Arrange
+        _viewModel.UseDate = new DateTime(2026, 2, 10);
+        _viewModel.UseTimeText = "10:30";
+        _viewModel.SelectedUsageType = UsageType.Rail;
+        _viewModel.EntryStation = "博多";
+        _viewModel.ExitStation = "天神";
+        _viewModel.AmountText = "260";
+        _viewModel.BalanceText = "740";
+
+        // Act
+        var detail = _viewModel.BuildLedgerDetail();
+
+        // Assert
+        detail.IsCharge.Should().BeFalse();
+        detail.IsBus.Should().BeFalse();
+        detail.IsPointRedemption.Should().BeFalse();
+        detail.EntryStation.Should().Be("博多");
+        detail.ExitStation.Should().Be("天神");
+        detail.Amount.Should().Be(260);
+        detail.Balance.Should().Be(740);
+        detail.UseDate.Should().Be(new DateTime(2026, 2, 10, 10, 30, 0));
+    }
+
+    [Fact]
+    public void BuildLedgerDetail_Bus_CorrectFlags()
+    {
+        // Arrange
+        _viewModel.UseDate = new DateTime(2026, 2, 10);
+        _viewModel.SelectedUsageType = UsageType.Bus;
+        _viewModel.BusStops = "天神バス停";
+        _viewModel.AmountText = "100";
+        _viewModel.BalanceText = "640";
+
+        // Act
+        var detail = _viewModel.BuildLedgerDetail();
+
+        // Assert
+        detail.IsBus.Should().BeTrue();
+        detail.IsCharge.Should().BeFalse();
+        detail.BusStops.Should().Be("天神バス停");
+        detail.EntryStation.Should().BeEmpty();
+        detail.ExitStation.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildLedgerDetail_Charge_CorrectFlags()
+    {
+        // Arrange
+        _viewModel.UseDate = new DateTime(2026, 2, 10);
+        _viewModel.SelectedUsageType = UsageType.Charge;
+        _viewModel.AmountText = "3000";
+        _viewModel.BalanceText = "3540";
+
+        // Act
+        var detail = _viewModel.BuildLedgerDetail();
+
+        // Assert
+        detail.IsCharge.Should().BeTrue();
+        detail.IsBus.Should().BeFalse();
+        detail.IsPointRedemption.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildLedgerDetail_PointRedemption_CorrectFlags()
+    {
+        // Arrange
+        _viewModel.UseDate = new DateTime(2026, 2, 10);
+        _viewModel.SelectedUsageType = UsageType.PointRedemption;
+        _viewModel.AmountText = "50";
+        _viewModel.BalanceText = "790";
+
+        // Act
+        var detail = _viewModel.BuildLedgerDetail();
+
+        // Assert
+        detail.IsPointRedemption.Should().BeTrue();
+        detail.IsCharge.Should().BeFalse();
+        detail.IsBus.Should().BeFalse();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- 利用履歴詳細画面（LedgerDetailDialog）上で直接、行の追加・編集・削除を行える機能を実装
- ICカードリーダーの20件制限を超える利用がある場合に、古い履歴を手動で追加可能に
- 変更は一括保存パターン（既存の「保存」ボタンで一括反映）

## 変更内容

### 新規ファイル（4件）
- **LedgerDetailEditViewModel.cs** — 追加/編集ダイアログ用ViewModel
  - 利用種別（鉄道/バス/チャージ/ポイント還元）の選択と表示切替
  - 残高の自動計算（前行残高から加減算、手動上書きも可能）
  - 日付に基づく挿入位置の自動提案と▲▼手動調整
  - 入力バリデーション（日付・金額・時刻形式）
- **LedgerDetailEditDialog.xaml / .xaml.cs** — 追加/編集ダイアログUI
- **LedgerDetailEditViewModelTests.cs** — 単体テスト26件

### 修正ファイル（6件）
- **Enums.cs** — `UsageType` enum追加
- **LedgerDetailViewModel.cs** — 行選択・Insert/Edit/Delete コマンド・SaveAsync財務再計算
- **LedgerDetailDialog.xaml** — ツールバーに行操作ボタン追加、選択スタイル、操作説明更新
- **LedgerDetailDialog.xaml.cs** — クリックハンドラ、ダイアログファクトリ、削除確認コールバック
- **App.xaml.cs** — DI登録追加
- **LedgerDetailViewModelTests.cs** — 行選択・削除テスト5件追加

## Test plan
- [x] ビルド成功（0 エラー）
- [x] 全1,155件のテストがパス（新規31件含む）
- [ ] 「行の追加」で鉄道利用行を追加し、正しい位置に挿入されることを確認
- [ ] 種別をバス/チャージ/ポイント還元に切り替え、フィールド表示が変わることを確認
- [ ] 金額入力→残高が自動計算されることを確認
- [ ] 挿入位置の▲▼で位置が変わり、説明テキストが更新されることを確認
- [ ] 行を選択して「編集」→値が変更されることを確認
- [ ] 行を選択して「削除」→確認後に削除されることを確認
- [ ] ダブルクリックで編集ダイアログが開くことを確認
- [ ] 変更後に「保存」→親Ledgerの摘要/受入/払出/残高が再計算されることを確認
- [ ] 変更後に保存せず閉じようとすると確認ダイアログが出ることを確認

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)