### PR TITLE
feat: メインウィンドウにヘルプボタンを追加（#641）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1803,6 +1803,32 @@ public partial class MainViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// ヘルプ（ドキュメントフォルダ）を開く（Issue #641）
+    /// </summary>
+    [RelayCommand]
+    public void OpenHelp()
+    {
+        var exeDir = AppDomain.CurrentDomain.BaseDirectory;
+        var docsPath = System.IO.Path.Combine(exeDir, "Docs");
+        if (System.IO.Directory.Exists(docsPath))
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = docsPath,
+                UseShellExecute = true
+            });
+        }
+        else
+        {
+            MessageBox.Show(
+                "ドキュメントフォルダが見つかりません。\nアプリケーションを再インストールしてください。",
+                "ヘルプ",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+        }
+    }
+
+    /// <summary>
     /// ダッシュボードから履歴を表示
     /// </summary>
     [RelayCommand]

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -33,6 +33,7 @@
         <KeyBinding Key="F4" Command="{Binding OpenDataExportImportCommand}"/>
         <KeyBinding Key="F5" Command="{Binding OpenSettingsCommand}"/>
         <KeyBinding Key="F6" Command="{Binding OpenSystemManageCommand}"/>
+        <KeyBinding Key="F7" Command="{Binding OpenHelpCommand}"/>
     </Window.InputBindings>
 
     <Grid>
@@ -99,10 +100,17 @@
                             AutomationProperties.Name="システム管理ダイアログを開く"
                             AutomationProperties.HelpText="データベースのバックアップ・リストア・操作ログを管理します。ショートカット: F6"
                             ToolTip="システム管理を開く (F6)"/>
+                    <Button Content="ヘルプ (F7)" Margin="5,3"
+                            Style="{StaticResource AccessibleButtonStyle}"
+                            Command="{Binding OpenHelpCommand}"
+                            TabIndex="7"
+                            AutomationProperties.Name="ヘルプを開く"
+                            AutomationProperties.HelpText="ユーザーマニュアル等のドキュメントフォルダを開きます。ショートカット: F7"
+                            ToolTip="ヘルプを開く (F7)"/>
                     <Button Content="終了" Margin="15,3,5,3"
                             Style="{StaticResource AccessibleButtonStyle}"
                             Command="{Binding ExitCommand}"
-                            TabIndex="7"
+                            TabIndex="8"
                             AutomationProperties.Name="アプリケーションを終了"
                             AutomationProperties.HelpText="アプリケーションを終了します。"
                             ToolTip="アプリケーションを終了"/>


### PR DESCRIPTION
## Summary
- メインウィンドウのツールバーに「ヘルプ (F7)」ボタンを追加
- クリックまたはF7キーで、アプリケーションの `Docs` フォルダをエクスプローラーで開く
- Docsフォルダが見つからない場合はエラーメッセージを表示

## 実装詳細
- `MainViewModel.OpenHelp()`: `AppDomain.CurrentDomain.BaseDirectory` + `Docs` のパスを `Process.Start` で開く（既存の `DataExportImportViewModel.OpenExportFolder` と同じパターン）
- `MainWindow.xaml`: 「システム管理 (F6)」と「終了」の間にボタン配置、F7キーバインド追加

## Test plan
- [x] ビルド成功（0 errors）
- [x] 既存テスト全1136件パス（回帰なし）
- [ ] 手動テスト: F7キーでDocsフォルダがエクスプローラーで開かれる
- [ ] 手動テスト: ヘルプボタンクリックで同じ動作
- [x] 手動テスト: Docsフォルダが存在しない場合にエラーメッセージが表示される
- [ ] 手動テスト: TabIndex順序が正しい（F1〜F7 → 終了）

※ `Process.Start` による外部プロセス起動のため単体テスト作成は困難。手動テストで動作確認をお願いします。

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)