### PR TITLE
fix: 新規購入カードの登録日が月初めになるバグを修正（#657）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -999,13 +999,13 @@ namespace ICCardManager.ViewModels
         /// 履歴インポートの開始日を取得（Issue #596）
         /// </summary>
         /// <remarks>
-        /// 新規購入: 当月1日
+        /// 新規購入: 当日（Issue #657: 月初めではなく購入日を使用）
         /// 繰越: 繰越月の翌月1日（SummaryGenerator.GetMidYearCarryoverDateを使用）
         /// </remarks>
-        private static DateTime GetImportFromDate(Views.Dialogs.CardRegistrationModeResult modeResult)
+        internal static DateTime GetImportFromDate(Views.Dialogs.CardRegistrationModeResult modeResult)
         {
             if (modeResult.IsNewPurchase)
-                return new DateTime(DateTime.Now.Year, DateTime.Now.Month, 1);
+                return DateTime.Today;
             else
                 return SummaryGenerator.GetMidYearCarryoverDate(
                     modeResult.CarryoverMonth!.Value, DateTime.Now);

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -662,4 +662,49 @@ public class CardManageViewModelTests
     }
 
     #endregion
+
+    #region Issue #657: GetImportFromDateテスト
+
+    /// <summary>
+    /// 新規購入時、GetImportFromDateが当日を返すこと（月初めではない）
+    /// </summary>
+    [Fact]
+    public void GetImportFromDate_NewPurchase_ShouldReturnToday()
+    {
+        // Arrange
+        var modeResult = new ICCardManager.Views.Dialogs.CardRegistrationModeResult
+        {
+            IsNewPurchase = true
+        };
+
+        // Act
+        var result = CardManageViewModel.GetImportFromDate(modeResult);
+
+        // Assert
+        result.Should().Be(DateTime.Today);
+    }
+
+    /// <summary>
+    /// 繰越時、GetImportFromDateがSummaryGenerator.GetMidYearCarryoverDateと同じ値を返すこと
+    /// </summary>
+    [Fact]
+    public void GetImportFromDate_Carryover_ShouldReturnMidYearCarryoverDate()
+    {
+        // Arrange
+        var carryoverMonth = 10; // 10月繰越
+        var modeResult = new ICCardManager.Views.Dialogs.CardRegistrationModeResult
+        {
+            IsNewPurchase = false,
+            CarryoverMonth = carryoverMonth
+        };
+        var expected = SummaryGenerator.GetMidYearCarryoverDate(carryoverMonth, DateTime.Now);
+
+        // Act
+        var result = CardManageViewModel.GetImportFromDate(modeResult);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- `GetImportFromDate()` が新規購入時に `new DateTime(..., 1)`（当月1日）を返していたのを `DateTime.Today` に変更
- メソッドのアクセス修飾子を `private` → `internal` に変更し、直接テストを追加
- 繰越パスの回帰テストも併せて追加

## Root Cause
Issue #596 で追加された `GetImportFromDate()` は、繰越カードのために月初めを返す設計だったが、新規購入ケースにも同じロジックが適用されていた。新規購入カードには購入日より前の履歴が存在しないため、当日（`DateTime.Today`）が正しい起点。

## Test plan
- [x] `GetImportFromDate_NewPurchase_ShouldReturnToday` — 新規購入時に当日が返ること
- [x] `GetImportFromDate_Carryover_ShouldReturnMidYearCarryoverDate` — 繰越時の既存動作が維持されること
- [x] 全1161テスト通過
- [x] 手動テスト: 月途中にカード登録 → 初期レコードの日付が当日であることを確認

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)