### PR TITLE
feat: 新規購入カードに購入日を指定可能にする（#658）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -927,7 +927,8 @@ namespace ICCardManager.ViewModels
                     }
                     else if (modeResult.IsNewPurchase)
                     {
-                        recordDate = now;
+                        // Issue #658: 購入日が指定されている場合はその日付を使用
+                        recordDate = modeResult.PurchaseDate?.Date ?? now;
                     }
                     else
                     {
@@ -1005,7 +1006,7 @@ namespace ICCardManager.ViewModels
         internal static DateTime GetImportFromDate(Views.Dialogs.CardRegistrationModeResult modeResult)
         {
             if (modeResult.IsNewPurchase)
-                return DateTime.Today;
+                return modeResult.PurchaseDate?.Date ?? DateTime.Today;
             else
                 return SummaryGenerator.GetMidYearCarryoverDate(
                     modeResult.CarryoverMonth!.Value, DateTime.Now);

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml
@@ -54,6 +54,21 @@
                            FontSize="{DynamicResource SmallFontSize}"
                            Foreground="#666"
                            Margin="20,5,0,0"/>
+
+                <!-- 購入日選択（Issue #658） -->
+                <StackPanel x:Name="NewPurchaseOptionsPanel" Margin="20,10,0,0" IsEnabled="True">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="購入日:"
+                                   FontSize="{DynamicResource BaseFontSize}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"/>
+                        <DatePicker x:Name="PurchaseDatePicker"
+                                    Width="130"
+                                    Padding="5"
+                                    FontSize="{DynamicResource BaseFontSize}"
+                                    AutomationProperties.Name="購入日の選択"/>
+                    </StackPanel>
+                </StackPanel>
             </StackPanel>
         </Border>
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Windows;
 
@@ -22,6 +23,11 @@ namespace ICCardManager.Views.Dialogs
         /// 開始ページ番号。デフォルトは1
         /// </summary>
         public int StartingPageNumber { get; set; } = 1;
+
+        /// <summary>
+        /// 購入日（Issue #658）。新規購入モード時に指定可能。nullの場合は当日
+        /// </summary>
+        public DateTime? PurchaseDate { get; set; }
     }
 
     /// <summary>
@@ -61,6 +67,13 @@ namespace ICCardManager.Views.Dialogs
         {
             InitializeComponent();
             InitializeMonthComboBox();
+            InitializePurchaseDatePicker();
+        }
+
+        private void InitializePurchaseDatePicker()
+        {
+            PurchaseDatePicker.SelectedDate = DateTime.Today;
+            PurchaseDatePicker.DisplayDateEnd = DateTime.Today;
         }
 
         private void InitializeMonthComboBox()
@@ -80,6 +93,10 @@ namespace ICCardManager.Views.Dialogs
             {
                 CarryoverOptionsPanel.IsEnabled = false;
             }
+            if (NewPurchaseOptionsPanel != null)
+            {
+                NewPurchaseOptionsPanel.IsEnabled = true;
+            }
         }
 
         private void CarryoverRadio_Checked(object sender, RoutedEventArgs e)
@@ -87,6 +104,10 @@ namespace ICCardManager.Views.Dialogs
             if (CarryoverOptionsPanel != null)
             {
                 CarryoverOptionsPanel.IsEnabled = true;
+            }
+            if (NewPurchaseOptionsPanel != null)
+            {
+                NewPurchaseOptionsPanel.IsEnabled = false;
             }
         }
 
@@ -99,6 +120,7 @@ namespace ICCardManager.Views.Dialogs
                 result.IsNewPurchase = true;
                 result.CarryoverMonth = null;
                 result.StartingPageNumber = 1;
+                result.PurchaseDate = PurchaseDatePicker.SelectedDate ?? DateTime.Today;
             }
             else
             {

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -707,4 +707,49 @@ public class CardManageViewModelTests
     }
 
     #endregion
+
+    #region Issue #658: 新規購入カードに購入日を指定可能にする
+
+    /// <summary>
+    /// 購入日を明示的に指定した場合、GetImportFromDateがその日付を返すこと
+    /// </summary>
+    [Fact]
+    public void GetImportFromDate_NewPurchaseWithExplicitDate_ShouldReturnSpecifiedDate()
+    {
+        // Arrange
+        var purchaseDate = new DateTime(2026, 2, 5);
+        var modeResult = new ICCardManager.Views.Dialogs.CardRegistrationModeResult
+        {
+            IsNewPurchase = true,
+            PurchaseDate = purchaseDate
+        };
+
+        // Act
+        var result = CardManageViewModel.GetImportFromDate(modeResult);
+
+        // Assert
+        result.Should().Be(purchaseDate.Date);
+    }
+
+    /// <summary>
+    /// 購入日がnull（未指定）の場合、GetImportFromDateが当日を返すこと（後方互換性）
+    /// </summary>
+    [Fact]
+    public void GetImportFromDate_NewPurchaseWithNullDate_ShouldReturnToday()
+    {
+        // Arrange
+        var modeResult = new ICCardManager.Views.Dialogs.CardRegistrationModeResult
+        {
+            IsNewPurchase = true,
+            PurchaseDate = null
+        };
+
+        // Act
+        var result = CardManageViewModel.GetImportFromDate(modeResult);
+
+        // Assert
+        result.Should().Be(DateTime.Today);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- カード登録モードダイアログの「新規購入」オプションにDatePickerを追加し、購入日を指定可能にした
- デフォルトは当日、未来の日付は選択不可（`DisplayDateEnd = DateTime.Today`）
- 「繰越」選択時はDatePickerが無効化される

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `CardRegistrationModeResult` | `DateTime? PurchaseDate` プロパティ追加 |
| `CardRegistrationModeDialog.xaml` | 購入日DatePickerパネル追加 |
| `CardRegistrationModeDialog.xaml.cs` | DatePicker初期化・ラジオボタン連動・OK時の値設定 |
| `CardManageViewModel.cs` | `GetImportFromDate`・`CreateInitialLedgerAsync` で `PurchaseDate` を参照 |
| `CardManageViewModelTests.cs` | テスト2件追加（購入日指定時・null時） |

## Test plan
- [x] `dotnet build` ビルド成功
- [x] `dotnet test` 全1163テスト通過（新規2件含む）
- [x] 手動テスト: ダイアログで過去の日付を選択 → 初期レコードの日付がその日付であることを確認
- [ ] 手動テスト: デフォルト（当日）のまま登録 → 従来通りの動作を確認
- [ ] 手動テスト: 「繰越」選択時にDatePickerが無効化されることを確認

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)