### PR TITLE
fix: 履歴画面の払出金額の文字色を赤から黒に変更

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -196,7 +196,6 @@
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                            <Setter Property="Foreground" Value="OrangeRed"/>
                             <Setter Property="FontWeight" Value="Bold"/>
                         </Style>
                     </DataGridTextColumn.ElementStyle>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -416,7 +416,6 @@
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                                            <Setter Property="Foreground" Value="OrangeRed"/>
                                             <Setter Property="FontWeight" Value="Bold"/>
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>


### PR DESCRIPTION
## Summary
- 履歴画面（HistoryDialog）の払出金額列から `Foreground="OrangeRed"` を削除し、デフォルトの黒文字に変更
- メイン画面（MainWindow）の履歴表示の払出金額列も同様に黒文字に変更

Closes #671

## Test plan
- [ ] 履歴ダイアログ（カードをダブルクリックまたは選択して表示）で、払出金額が黒文字で表示されること
- [ ] メイン画面の左側履歴エリアで、払出金額が黒文字で表示されること
- [ ] 受入金額は引き続き緑色の太字で表示されていること
- [ ] 払出金額の太字スタイルは維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)