### PR TITLE
docs: 管理者マニュアルのシステム設定セクションを実際のappsettings.jsonに合わせて修正

### DIFF
--- a/ICCardManager/docs/manual/管理者マニュアル.md
+++ b/ICCardManager/docs/manual/管理者マニュアル.md
@@ -1,6 +1,6 @@
 # 交通系ICカード管理システム 管理者マニュアル
 
-**バージョン**: 1.2
+**バージョン**: 1.3
 **最終更新日**: 2026年2月
 
 ---
@@ -551,9 +551,32 @@ CSVファイルからデータを取り込むことができます。「デー�
 
 ## 7. システム設定
 
-### 7.1 設定ファイル
+### 7.1 設定の保存場所
 
-設定は `appsettings.json` ファイルで管理されます。
+本システムでは、設定が2か所に分かれて保存されています。
+
+| 設定の種類 | 保存場所 | 変更方法 |
+|------------|----------|----------|
+| アプリケーション設定 | データベース（`iccard.db`） | 設定画面（F5）から変更 |
+| ログ設定 | `appsettings.json` | テキストエディタで直接編集 |
+
+### 7.2 アプリケーション設定
+
+アプリケーション設定は、設定画面（F5）から変更できます。設定はデータベースに自動保存されます。
+
+| 項目 | 説明 | 設定値 |
+|------|------|--------|
+| 残額警告 | 残額警告閾値 | 0～20,000円。デフォルト: 10,000円 |
+| 文字サイズ | 画面の文字サイズ | 小 / 中 / 大 / 特大。デフォルト: 中 |
+| 音声モード | 操作時の音声 | 効果音（ピッ/ピピッ）/ 音声（男性）/ 音声（女性）/ 無し。デフォルト: 効果音 |
+| ポップアップ位置 | 通知の表示位置 | 右上 / 左上 / 右下 / 左下。デフォルト: 右上 |
+| バックアップ保存先 | バックアップフォルダパス | フォルダパス（空欄時はアプリフォルダ） |
+
+> **補足**: ウィンドウの位置・サイズやDB最適化日時もデータベースに保存されますが、アプリケーションが自動的に管理するため、手動で変更する必要はありません。
+
+### 7.3 ログ設定（appsettings.json）
+
+ログ出力に関する設定は `appsettings.json` ファイルで管理されます。
 
 **保存場所:**
 - インストーラー使用時: `C:\Program Files\ICCardManager\appsettings.json`
@@ -563,33 +586,67 @@ CSVファイルからデータを取り込むことができます。「デー�
 
 ```json
 {
-  "WarningBalance": 10000,
-  "BackupPath": "",
-  "FontSize": "Medium",
-  "SoundMode": "Beep",
-  "ToastPosition": "TopRight",
-  "MainWindowSettings": {
-    "Left": null,
-    "Top": null,
-    "Width": null,
-    "Height": null,
-    "IsMaximized": false
-  },
-  "LastVacuumDate": null
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "ICCardManager": "Information",
+      "Microsoft": "Warning"
+    },
+    "File": {
+      "Enabled": true,
+      "Path": "Logs",
+      "RetentionDays": 30,
+      "MaxFileSizeMB": 10
+    },
+    "Debug": {
+      "Enabled": false
+    }
+  }
 }
 ```
 
-### 7.2 設定項目一覧
+#### LogLevel（ログレベル）
 
-| 項目 | 説明 | 設定値 |
-|------|------|--------|
-| WarningBalance | 残額警告閾値 | 0～20000（円） |
-| BackupPath | バックアップ保存先 | フォルダパス（空欄時はアプリフォルダ） |
-| FontSize | 文字サイズ | Small / Medium / Large / ExtraLarge |
-| SoundMode | 音声モード | Beep（効果音）/ VoiceMale（男性音声）/ VoiceFemale（女性音声）/ None（無音） |
-| ToastPosition | ポップアップ位置 | TopRight / TopLeft / BottomRight / BottomLeft |
-| MainWindowSettings | ウィンドウ位置・サイズ | アプリが自動保存（編集不要） |
-| LastVacuumDate | DB最適化日時 | アプリが自動設定（編集不要） |
+アプリケーションが出力するログの詳細度を制御します。
+
+| 項目 | 説明 | デフォルト値 |
+|------|------|-------------|
+| Default | 全体のデフォルトログレベル | Information |
+| ICCardManager | アプリケーション固有のログレベル | Information |
+| Microsoft | Microsoftライブラリのログレベル | Warning |
+
+**ログレベルの種類（詳細度の高い順）：**
+
+| レベル | 説明 |
+|--------|------|
+| Trace | 最も詳細なログ |
+| Debug | デバッグ情報 |
+| Information | 一般的な動作情報（デフォルト） |
+| Warning | 警告 |
+| Error | エラー |
+| Critical | 致命的なエラー |
+| None | ログを出力しない |
+
+> **ヒント**: トラブルシューティング時には `Default` を `Debug` に変更すると、より詳細なログが出力されます。調査終了後は `Information` に戻してください。
+
+#### File（ファイル出力設定）
+
+ログファイルの出力に関する設定です。ログファイルは `%PROGRAMDATA%\ICCardManager\Logs\` に出力されます。
+
+| 項目 | 説明 | デフォルト値 |
+|------|------|-------------|
+| Enabled | ファイルへのログ出力の有効/無効 | true |
+| Path | ログファイルの出力先フォルダ名 | Logs |
+| RetentionDays | ログファイルの保持日数（超過した古いログは自動削除） | 30 |
+| MaxFileSizeMB | 1ファイルあたりの最大サイズ（MB） | 10 |
+
+#### Debug（デバッグ出力設定）
+
+| 項目 | 説明 | デフォルト値 |
+|------|------|-------------|
+| Enabled | デバッグ出力の有効/無効 | false |
+
+> **注意**: Debug設定は開発者向けです。通常の運用では `false` のままにしてください。
 
 ---
 


### PR DESCRIPTION
## Summary
- セクション7「システム設定」を全面的に書き直し、実際のシステム構成と一致させた
- 設定の保存場所を明確化：アプリケーション設定はデータベース（`iccard.db`）、ログ設定は`appsettings.json`
- `appsettings.json`のサンプルを実際の内容（Logging/LogLevel/File/Debug）に置き換え
- 各ログ設定項目（LogLevel、File、Debug）の詳細な説明を追加

### 変更前の問題点
マニュアルの`appsettings.json`サンプルに`WarningBalance`、`FontSize`、`SoundMode`等のアプリケーション設定が記載されていたが、実際にはこれらはSQLiteデータベースの`settings`テーブルに保存されており、`appsettings.json`にはログ設定のみが含まれている。

Closes #670

## Test plan
- [ ] セクション7.1: 設定が2種類（アプリケーション設定/ログ設定）に分けて説明されていること
- [ ] セクション7.2: アプリケーション設定が日本語の項目名で記載され、設定画面（F5）から変更する旨が記載されていること
- [ ] セクション7.3: `appsettings.json`のJSONサンプルが実際のファイル内容（Logging/File/Debug）と一致していること
- [ ] 実際の`appsettings.json`とマニュアルの記載が一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)