### PR TITLE
fix: カード管理画面の新規登録時に履歴を事前読み取りする（#665）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -818,6 +818,18 @@ namespace ICCardManager.ViewModels
                     _preReadBalance = null;
                 }
 
+                // Issue #665: カード読み取り時点で履歴も事前取得
+                // カードがリーダーにある間に履歴を読み取り、保存時に使用する
+                // これにより、ユーザーがカードを離しても正しく履歴をインポートできる
+                try
+                {
+                    _preReadHistory = (await _cardReader.ReadHistoryAsync(e.Idm))?.ToList();
+                }
+                catch
+                {
+                    _preReadHistory = null;
+                }
+
                 // 注意: App.IsCardRegistrationActive はここで解除しない
                 // ダイアログが開いている間は常にフラグを維持し、
                 // CancelEdit() または Cleanup() でのみ解除する


### PR DESCRIPTION
## Summary
- カード管理画面（F3）→「新規登録」→カードタッチのフローで、`OnCardRead`ハンドラが残高のみ事前読み取りし履歴を読み取っていなかったため、カードをすぐに離すと履歴インポートが失敗する問題を修正
- `OnCardRead`内に`ReadHistoryAsync`呼び出しを追加し、メイン画面経由のフロー（`MainViewModel.HandleUnregisteredCardAsync`）と同じ動作に統一
- 事前読み取り履歴の有無に応じた`SaveAsync`の動作を検証する単体テスト2件を追加

## 変更ファイル
- `CardManageViewModel.cs`: `OnCardRead`メソッドに`ReadHistoryAsync`呼び出しを追加
- `CardManageViewModelTests.cs`: テスト2件追加
  - 事前読み取り履歴がある場合、カードリーダーへの再読み取りが行われないこと
  - 事前読み取り履歴がない場合、フォールバックとしてカードリーダーから直接読み取ること

## Test plan
- [x] 既存テスト全1,165件がパスすること
- [x] 新規テスト2件がパスすること
- [ ] カード管理画面（F3）→「新規登録」→カードを**すばやくタッチして離す**→カード情報入力→「保存」→「紙の出納簿からの繰越」を選択→履歴がインポートされることを確認

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)