### PR TITLE
fix: 設定の残額警告閾値変更後にシステム警告メッセージを更新する（#661）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1739,6 +1739,8 @@ public partial class MainViewModel : ViewModelBase
         var settings = await _settingsRepository.GetAppSettingsAsync();
         _soundPlayer.SoundMode = settings.SoundMode;
         await RefreshDashboardAsync();
+        // Issue #661: 残額警告の閾値変更後に警告メッセージを更新
+        await CheckWarningsAsync();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- OpenSettingsAsync()でRefreshDashboardAsync()の後にCheckWarningsAsync()を追加
- 残額警告の閾値を変更した際、WarningMessages（システム警告テキスト）が即座に更新される

## 原因
OpenSettingsAsync()ではRefreshDashboardAsync()でカード一覧UIは更新されるが、CheckWarningsAsync()が呼ばれないためWarningMessagesコレクションが古い閾値のまま残っていた。

## Test plan
- [x] ビルド成功（0エラー）
- [x] 既存テスト全1,165件がパス
- [x] 残額3,000円のカードで閾値を1,000円に設定→警告が消えることを確認
- [ ] 閾値を5,000円に変更→残額3,000円のカードの警告が即座に表示されることを確認
- [ ] 設定をキャンセルで閉じた場合→警告に変化がないことを確認

Closes #661