### PR TITLE
feat: システム警告をクリック可能にし対象カード履歴へ遷移（#672）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -234,6 +234,7 @@ namespace ICCardManager
             services.AddTransient<LedgerEditViewModel>();
             services.AddTransient<LedgerDetailViewModel>();
             services.AddTransient<SystemManageViewModel>();
+            services.AddTransient<IncompleteBusStopViewModel>();
     #if DEBUG
             // Issue #640: 仮想タッチ設定ダイアログ
             services.AddTransient<VirtualCardViewModel>();
@@ -253,6 +254,7 @@ namespace ICCardManager
             services.AddTransient<Views.Dialogs.LedgerDetailDialog>();
             services.AddTransient<Views.Dialogs.LedgerEditDialog>();
             services.AddTransient<Views.Dialogs.SystemManageDialog>();
+            services.AddTransient<Views.Dialogs.IncompleteBusStopDialog>();
     #if DEBUG
             services.AddTransient<Views.Dialogs.VirtualCardDialog>();
     #endif

--- a/ICCardManager/src/ICCardManager/Dtos/IncompleteBusStopItem.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/IncompleteBusStopItem.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace ICCardManager.Dtos
+{
+    /// <summary>
+    /// バス停名未入力履歴の一覧表示用DTO（Issue #672）
+    /// </summary>
+    public class IncompleteBusStopItem
+    {
+        /// <summary>
+        /// 利用履歴ID
+        /// </summary>
+        public int LedgerId { get; set; }
+
+        /// <summary>
+        /// カードIDm
+        /// </summary>
+        public string CardIdm { get; set; } = string.Empty;
+
+        /// <summary>
+        /// カード名（種別 + 番号）
+        /// </summary>
+        public string CardDisplayName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 利用日
+        /// </summary>
+        public DateTime Date { get; set; }
+
+        /// <summary>
+        /// 表示用: 利用日
+        /// </summary>
+        public string DateDisplay => Date.ToString("yyyy/MM/dd");
+
+        /// <summary>
+        /// 摘要
+        /// </summary>
+        public string Summary { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 払出金額
+        /// </summary>
+        public int Expense { get; set; }
+
+        /// <summary>
+        /// 表示用: 金額
+        /// </summary>
+        public string ExpenseDisplay => Expense > 0 ? $"{Expense:N0}円" : "";
+
+        /// <summary>
+        /// 利用者名
+        /// </summary>
+        public string StaffName { get; set; } = string.Empty;
+    }
+}

--- a/ICCardManager/src/ICCardManager/Dtos/WarningItem.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/WarningItem.cs
@@ -1,0 +1,41 @@
+namespace ICCardManager.Dtos
+{
+    /// <summary>
+    /// 警告の種別
+    /// </summary>
+    public enum WarningType
+    {
+        /// <summary>残額不足警告（カード単位）</summary>
+        LowBalance,
+
+        /// <summary>バス停名未入力警告（集約）</summary>
+        IncompleteBusStop,
+
+        /// <summary>カードリーダーエラー</summary>
+        CardReaderError,
+
+        /// <summary>カードリーダー接続状態</summary>
+        CardReaderConnection
+    }
+
+    /// <summary>
+    /// システム警告エリアの1行に対応する警告情報DTO（Issue #672）
+    /// </summary>
+    public class WarningItem
+    {
+        /// <summary>
+        /// 表示テキスト
+        /// </summary>
+        public string DisplayText { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 警告種別
+        /// </summary>
+        public WarningType Type { get; set; }
+
+        /// <summary>
+        /// 対象カードIDm（LowBalance時のみ使用）
+        /// </summary>
+        public string CardIdm { get; set; }
+    }
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/IncompleteBusStopViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/IncompleteBusStopViewModel.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
+
+namespace ICCardManager.ViewModels
+{
+    /// <summary>
+    /// バス停名未入力一覧ダイアログのViewModel（Issue #672）
+    /// </summary>
+    public partial class IncompleteBusStopViewModel : ViewModelBase
+    {
+        private readonly ILedgerRepository _ledgerRepository;
+        private readonly ICardRepository _cardRepository;
+
+        private List<IncompleteBusStopItem> _allItems = new();
+
+        [ObservableProperty]
+        private ObservableCollection<IncompleteBusStopItem> _items = new();
+
+        [ObservableProperty]
+        private IncompleteBusStopItem _selectedItem;
+
+        /// <summary>
+        /// カード名フィルタの選択肢
+        /// </summary>
+        [ObservableProperty]
+        private ObservableCollection<string> _cardFilterOptions = new();
+
+        /// <summary>
+        /// 選択中のカード名フィルタ
+        /// </summary>
+        [ObservableProperty]
+        private string _selectedCardFilter = "すべて";
+
+        /// <summary>
+        /// 確認完了フラグ（ダイアログ結果用）
+        /// </summary>
+        [ObservableProperty]
+        private bool _isConfirmed;
+
+        /// <summary>
+        /// 選択されたカードのIDm
+        /// </summary>
+        public string SelectedCardIdm => SelectedItem?.CardIdm;
+
+        public IncompleteBusStopViewModel(
+            ILedgerRepository ledgerRepository,
+            ICardRepository cardRepository)
+        {
+            _ledgerRepository = ledgerRepository;
+            _cardRepository = cardRepository;
+        }
+
+        /// <summary>
+        /// 初期化（バス停未入力履歴を読み込み）
+        /// </summary>
+        public async Task InitializeAsync()
+        {
+            using (BeginBusy("読み込み中..."))
+            {
+                var ledgers = await _ledgerRepository.GetByDateRangeAsync(
+                    null, DateTime.Now.AddYears(-1), DateTime.Now);
+                var incompleteLedgers = ledgers.Where(l => l.Summary.Contains("★")).ToList();
+
+                var cards = await _cardRepository.GetAllAsync();
+                var cardMap = cards.ToDictionary(c => c.CardIdm, c => $"{c.CardType} {c.CardNumber}");
+
+                _allItems = incompleteLedgers.Select(l => new IncompleteBusStopItem
+                {
+                    LedgerId = l.Id,
+                    CardIdm = l.CardIdm,
+                    CardDisplayName = cardMap.TryGetValue(l.CardIdm, out var name) ? name : l.CardIdm,
+                    Date = l.Date,
+                    Summary = l.Summary,
+                    Expense = l.Expense,
+                    StaffName = l.StaffName ?? ""
+                }).OrderByDescending(i => i.Date).ToList();
+
+                CardFilterOptions.Clear();
+                CardFilterOptions.Add("すべて");
+                foreach (var cardName in _allItems.Select(i => i.CardDisplayName).Distinct().OrderBy(n => n))
+                {
+                    CardFilterOptions.Add(cardName);
+                }
+
+                ApplyFilter();
+            }
+        }
+
+        partial void OnSelectedCardFilterChanged(string value) => ApplyFilter();
+
+        /// <summary>
+        /// フィルタ適用
+        /// </summary>
+        internal void ApplyFilter()
+        {
+            var filtered = _allItems.AsEnumerable();
+
+            if (!string.IsNullOrEmpty(SelectedCardFilter) && SelectedCardFilter != "すべて")
+            {
+                filtered = filtered.Where(i => i.CardDisplayName == SelectedCardFilter);
+            }
+
+            Items = new ObservableCollection<IncompleteBusStopItem>(filtered);
+        }
+
+        /// <summary>
+        /// 選択確定
+        /// </summary>
+        [RelayCommand]
+        public void Confirm()
+        {
+            if (SelectedItem != null)
+            {
+                IsConfirmed = true;
+            }
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
@@ -1,0 +1,159 @@
+<Window x:Class="ICCardManager.Views.Dialogs.IncompleteBusStopDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:IncompleteBusStopViewModel}"
+        Title="バス停名未入力の履歴"
+        Height="500"
+        Width="800"
+        MinHeight="350"
+        MinWidth="600"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResize"
+        AutomationProperties.Name="バス停名未入力履歴一覧ダイアログ"
+        AutomationProperties.HelpText="バス停名が未入力の利用履歴を確認できます。項目を選択して履歴を表示ボタンを押すと、そのカードの履歴が表示されます。">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+    </Window.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- ヘッダー -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock Text="バス停名未入力の履歴一覧"
+                       FontSize="{DynamicResource LargeFontSize}"
+                       FontWeight="Bold"/>
+            <TextBlock Text="バス停名が未入力（★マーク）の利用履歴です。項目を選択して「履歴を表示」を押すと、そのカードの履歴画面に遷移します。"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       Foreground="Gray"
+                       TextWrapping="Wrap"
+                       Margin="0,5,0,0"/>
+        </StackPanel>
+
+        <!-- フィルタ行 -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="カード:"
+                       VerticalAlignment="Center"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       Margin="0,0,8,0"/>
+            <ComboBox ItemsSource="{Binding CardFilterOptions}"
+                      SelectedItem="{Binding SelectedCardFilter}"
+                      Width="200"
+                      FontSize="{DynamicResource BaseFontSize}"
+                      AutomationProperties.Name="カード名フィルタ"
+                      ToolTip="表示するカードを絞り込みます"/>
+        </StackPanel>
+
+        <!-- DataGrid -->
+        <DataGrid Grid.Row="2"
+                  ItemsSource="{Binding Items}"
+                  SelectedItem="{Binding SelectedItem}"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True"
+                  SelectionMode="Single"
+                  CanUserSortColumns="True"
+                  CanUserReorderColumns="False"
+                  CanUserResizeColumns="True"
+                  HeadersVisibility="Column"
+                  RowHeaderWidth="0"
+                  GridLinesVisibility="Horizontal"
+                  BorderBrush="#E0E0E0"
+                  BorderThickness="1"
+                  FontSize="{DynamicResource BaseFontSize}"
+                  MouseDoubleClick="DataGrid_MouseDoubleClick"
+                  AutomationProperties.Name="バス停名未入力履歴一覧">
+
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="利用日"
+                                    Binding="{Binding DateDisplay}"
+                                    Width="100"
+                                    SortMemberPath="Date"/>
+                <DataGridTextColumn Header="カード名"
+                                    Binding="{Binding CardDisplayName}"
+                                    Width="150"/>
+                <DataGridTextColumn Header="摘要"
+                                    Binding="{Binding Summary}"
+                                    Width="*"/>
+                <DataGridTextColumn Header="金額"
+                                    Binding="{Binding ExpenseDisplay}"
+                                    Width="80">
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="HorizontalAlignment" Value="Right"/>
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+                <DataGridTextColumn Header="利用者"
+                                    Binding="{Binding StaffName}"
+                                    Width="100"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- フッター -->
+        <Grid Grid.Row="3" Margin="0,15,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- ステータス -->
+            <TextBlock Grid.Column="0"
+                       VerticalAlignment="Center"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       Foreground="Gray">
+                <Run Text="{Binding Items.Count, Mode=OneWay, StringFormat={}{0}件}"/>
+            </TextBlock>
+
+            <!-- ボタン -->
+            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                <Button Content="履歴を表示"
+                        Command="{Binding ConfirmCommand}"
+                        Padding="20,8"
+                        AutomationProperties.Name="選択したカードの履歴を表示"
+                        ToolTip="選択した項目のカード履歴を表示します">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedItem}" Value="{x:Null}">
+                                    <Setter Property="IsEnabled" Value="False"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                <Button Content="閉じる"
+                        Click="CloseButton_Click"
+                        Padding="20,8"
+                        Margin="10,0,0,0"
+                        IsCancel="True"
+                        AutomationProperties.Name="閉じる"
+                        ToolTip="ダイアログを閉じる (Escape)"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- 処理中オーバーレイ -->
+        <Border Grid.RowSpan="4"
+                Background="#80000000"
+                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
+                <TextBlock Text="{Binding BusyMessage}"
+                           Foreground="White"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           Margin="0,10,0,0"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using ICCardManager.ViewModels;
+
+namespace ICCardManager.Views.Dialogs
+{
+    /// <summary>
+    /// バス停名未入力一覧ダイアログ（Issue #672）
+    /// </summary>
+    public partial class IncompleteBusStopDialog : Window
+    {
+        private readonly IncompleteBusStopViewModel _viewModel;
+
+        public IncompleteBusStopDialog(IncompleteBusStopViewModel viewModel)
+        {
+            InitializeComponent();
+
+            _viewModel = viewModel;
+            DataContext = _viewModel;
+
+            // 確認完了時に自動的に閉じる
+            _viewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(IncompleteBusStopViewModel.IsConfirmed) && _viewModel.IsConfirmed)
+                {
+                    DialogResult = true;
+                    Close();
+                }
+            };
+
+            Loaded += async (s, e) =>
+            {
+                try
+                {
+                    await _viewModel.InitializeAsync();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"データの読み込み中にエラーが発生しました。\n\n{ex.Message}",
+                        "エラー",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                }
+            };
+        }
+
+        /// <summary>
+        /// 選択されたカードのIDm
+        /// </summary>
+        public string SelectedCardIdm => _viewModel.SelectedCardIdm;
+
+        /// <summary>
+        /// DataGridの行ダブルクリックで確定
+        /// </summary>
+        private void DataGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (_viewModel.SelectedItem != null)
+            {
+                _viewModel.ConfirmCommand.Execute(null);
+            }
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -735,12 +735,30 @@
                     <ScrollViewer Grid.Row="4"
                                   VerticalScrollBarVisibility="Auto"
                                   HorizontalScrollBarVisibility="Disabled">
+                        <!-- Issue #672: 警告をクリック可能に -->
                         <ItemsControl ItemsSource="{Binding WarningMessages}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="#FFF3E0" CornerRadius="4"
-                                            Margin="0,2" Padding="10,8">
-                                        <TextBlock Text="{Binding}"
+                                    <Border CornerRadius="4"
+                                            Margin="0,2" Padding="10,8"
+                                            Cursor="Hand"
+                                            AutomationProperties.Name="{Binding DisplayText}">
+                                        <Border.InputBindings>
+                                            <MouseBinding MouseAction="LeftClick"
+                                                          Command="{Binding DataContext.HandleWarningClickCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                          CommandParameter="{Binding}"/>
+                                        </Border.InputBindings>
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="Background" Value="#FFF3E0"/>
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Background" Value="#FFE0B2"/>
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <TextBlock Text="{Binding DisplayText}"
                                                    TextWrapping="Wrap"
                                                    FontSize="{DynamicResource SmallFontSize}"/>
                                     </Border>

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/IncompleteBusStopViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/IncompleteBusStopViewModelTests.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
+using ICCardManager.Models;
+using ICCardManager.ViewModels;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// IncompleteBusStopViewModelの単体テスト（Issue #672）
+/// </summary>
+public class IncompleteBusStopViewModelTests
+{
+    private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
+    private readonly Mock<ICardRepository> _cardRepositoryMock;
+    private readonly IncompleteBusStopViewModel _viewModel;
+
+    public IncompleteBusStopViewModelTests()
+    {
+        _ledgerRepositoryMock = new Mock<ILedgerRepository>();
+        _cardRepositoryMock = new Mock<ICardRepository>();
+
+        _viewModel = new IncompleteBusStopViewModel(
+            _ledgerRepositoryMock.Object,
+            _cardRepositoryMock.Object);
+    }
+
+    #region InitializeAsync テスト
+
+    /// <summary>
+    /// "★"を含む履歴のみがItemsに表示されること
+    /// </summary>
+    [Fact]
+    public async Task InitializeAsync_ShouldShowOnlyIncompleteBusStopLedgers()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 200, StaffName = "田中" },
+            new Ledger { Id = 2, CardIdm = "CARD001", Date = new DateTime(2026, 1, 11), Summary = "鉄道（A駅～B駅）", Expense = 300, StaffName = "田中" },
+            new Ledger { Id = 3, CardIdm = "CARD002", Date = new DateTime(2026, 1, 12), Summary = "バス（★）、鉄道（C駅～D駅）", Expense = 500, StaffName = "鈴木" },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+            new IcCard { CardIdm = "CARD002", CardType = "nimoca", CardNumber = "002" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(2);
+        _viewModel.Items.Should().OnlyContain(i => i.Summary.Contains("★"));
+    }
+
+    /// <summary>
+    /// カード名が正しく解決されること
+    /// </summary>
+    [Fact]
+    public async Task InitializeAsync_ShouldResolveCardDisplayNames()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 200, StaffName = "田中" },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(1);
+        _viewModel.Items[0].CardDisplayName.Should().Be("はやかけん 001");
+        _viewModel.Items[0].CardIdm.Should().Be("CARD001");
+        _viewModel.Items[0].LedgerId.Should().Be(1);
+    }
+
+    /// <summary>
+    /// 未登録カードの場合CardIdmがそのまま表示されること
+    /// </summary>
+    [Fact]
+    public async Task InitializeAsync_ShouldFallbackToCardIdm_WhenCardNotFound()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "UNKNOWN_CARD", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 100, StaffName = "佐藤" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new List<IcCard>());
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(1);
+        _viewModel.Items[0].CardDisplayName.Should().Be("UNKNOWN_CARD");
+    }
+
+    /// <summary>
+    /// 日付降順でソートされること
+    /// </summary>
+    [Fact]
+    public async Task InitializeAsync_ShouldSortByDateDescending()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 5), Summary = "バス（★）", Expense = 100 },
+            new Ledger { Id = 2, CardIdm = "CARD001", Date = new DateTime(2026, 1, 15), Summary = "バス（★）", Expense = 200 },
+            new Ledger { Id = 3, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 150 },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(3);
+        _viewModel.Items[0].Date.Should().Be(new DateTime(2026, 1, 15));
+        _viewModel.Items[1].Date.Should().Be(new DateTime(2026, 1, 10));
+        _viewModel.Items[2].Date.Should().Be(new DateTime(2026, 1, 5));
+    }
+
+    /// <summary>
+    /// カードフィルタの選択肢が正しく構築されること
+    /// </summary>
+    [Fact]
+    public async Task InitializeAsync_ShouldBuildCardFilterOptions()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 200 },
+            new Ledger { Id = 2, CardIdm = "CARD002", Date = new DateTime(2026, 1, 11), Summary = "バス（★）", Expense = 300 },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+            new IcCard { CardIdm = "CARD002", CardType = "nimoca", CardNumber = "002" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.CardFilterOptions.Should().HaveCount(3); // "すべて" + 2カード
+        _viewModel.CardFilterOptions[0].Should().Be("すべて");
+        _viewModel.CardFilterOptions.Should().Contain("はやかけん 001");
+        _viewModel.CardFilterOptions.Should().Contain("nimoca 002");
+    }
+
+    #endregion
+
+    #region カードフィルタテスト
+
+    /// <summary>
+    /// カード名フィルタで絞り込みが機能すること
+    /// </summary>
+    [Fact]
+    public async Task SelectedCardFilter_ShouldFilterItemsByCardName()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 200 },
+            new Ledger { Id = 2, CardIdm = "CARD002", Date = new DateTime(2026, 1, 11), Summary = "バス（★）", Expense = 300 },
+            new Ledger { Id = 3, CardIdm = "CARD001", Date = new DateTime(2026, 1, 12), Summary = "バス（★）", Expense = 150 },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+            new IcCard { CardIdm = "CARD002", CardType = "nimoca", CardNumber = "002" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        await _viewModel.InitializeAsync();
+
+        // Act
+        _viewModel.SelectedCardFilter = "はやかけん 001";
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(2);
+        _viewModel.Items.Should().OnlyContain(i => i.CardDisplayName == "はやかけん 001");
+    }
+
+    /// <summary>
+    /// 「すべて」を選択するとフィルタがリセットされること
+    /// </summary>
+    [Fact]
+    public async Task SelectedCardFilter_AllOption_ShouldShowAllItems()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, CardIdm = "CARD001", Date = new DateTime(2026, 1, 10), Summary = "バス（★）", Expense = 200 },
+            new Ledger { Id = 2, CardIdm = "CARD002", Date = new DateTime(2026, 1, 11), Summary = "バス（★）", Expense = 300 },
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "CARD001", CardType = "はやかけん", CardNumber = "001" },
+            new IcCard { CardIdm = "CARD002", CardType = "nimoca", CardNumber = "002" },
+        };
+
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(ledgers);
+        _cardRepositoryMock
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(cards);
+
+        await _viewModel.InitializeAsync();
+        _viewModel.SelectedCardFilter = "はやかけん 001";
+        _viewModel.Items.Should().HaveCount(1);
+
+        // Act
+        _viewModel.SelectedCardFilter = "すべて";
+
+        // Assert
+        _viewModel.Items.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region Confirmコマンドテスト
+
+    /// <summary>
+    /// 選択がある場合にIsConfirmedがtrueになること
+    /// </summary>
+    [Fact]
+    public void Confirm_WithSelectedItem_ShouldSetIsConfirmedTrue()
+    {
+        // Arrange
+        _viewModel.SelectedItem = new IncompleteBusStopItem
+        {
+            LedgerId = 1,
+            CardIdm = "CARD001",
+            CardDisplayName = "はやかけん 001"
+        };
+
+        // Act
+        _viewModel.ConfirmCommand.Execute(null);
+
+        // Assert
+        _viewModel.IsConfirmed.Should().BeTrue();
+        _viewModel.SelectedCardIdm.Should().Be("CARD001");
+    }
+
+    /// <summary>
+    /// 選択がない場合にIsConfirmedがfalseのままであること
+    /// </summary>
+    [Fact]
+    public void Confirm_WithoutSelectedItem_ShouldNotSetIsConfirmed()
+    {
+        // Arrange
+        _viewModel.SelectedItem = null;
+
+        // Act
+        _viewModel.ConfirmCommand.Execute(null);
+
+        // Assert
+        _viewModel.IsConfirmed.Should().BeFalse();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- システム警告エリアの警告メッセージをクリック可能にし、対象カードの履歴画面へ遷移できるようにした
- `WarningMessages` の型を `ObservableCollection<string>` から `ObservableCollection<WarningItem>` に変更し、警告種別・カードIDmのメタデータを保持
- 残額警告クリック → 対象カードの履歴画面に直接遷移
- バス停未入力警告クリック → 一覧ダイアログ（カード名フィルタ、ソート対応）を表示、選択後に履歴画面へ遷移

## 変更内容
- **新規**: `Dtos/WarningItem.cs` — 警告種別enum + 警告DTOクラス
- **新規**: `Dtos/IncompleteBusStopItem.cs` — バス停未入力一覧ダイアログの行データDTO
- **新規**: `ViewModels/IncompleteBusStopViewModel.cs` — 一覧ダイアログのViewModel（フィルタ、確定機能）
- **新規**: `Views/Dialogs/IncompleteBusStopDialog.xaml/.cs` — バス停未入力一覧ダイアログ
- **変更**: `ViewModels/MainViewModel.cs` — WarningMessages型変更、HandleWarningClickコマンド追加、カードリーダー警告も統一
- **変更**: `Views/MainWindow.xaml` — 警告エリアにクリック操作とホバー効果を追加
- **変更**: `App.xaml.cs` — DI登録追加

## Test plan
- [x] 単体テスト9件追加（全1174件パス）
- [x] 残額警告をクリック → そのカードの履歴画面に遷移すること
- [x] バス停未入力警告をクリック → 一覧ダイアログが表示されること
- [x] ダイアログでカード名フィルタが機能すること
- [x] ダイアログで列ヘッダクリックによるソートが機能すること
- [x] ダイアログで項目を選択し「履歴を表示」→ そのカードの履歴画面に遷移すること
- [x] ダイアログでダブルクリック → 同様に遷移すること
- [x] 警告ホバー時に視覚的フィードバック（背景色変更）があること

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)