### PR TITLE
fix: 繰越登録時の履歴不完全メッセージに実際の最古月を表示（#664）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -87,6 +87,11 @@ namespace ICCardManager.Services
         /// trueの場合、CSVインポートで不足分を補完する必要がある旨をユーザーに通知する。
         /// </remarks>
         public bool MayHaveIncompleteHistory { get; set; }
+
+        /// <summary>
+        /// カード内の履歴の最古日付（Issue #664: 不完全履歴の場合のみ有効）
+        /// </summary>
+        public DateTime? EarliestHistoryDate { get; set; }
     }
 
     /// <summary>
@@ -920,6 +925,14 @@ namespace ICCardManager.Services
 
                     // 完全性チェック: 元の履歴（フィルタ前）を使用
                     result.MayHaveIncompleteHistory = CheckHistoryCompleteness(historyDetails, importFromDate);
+
+                    // Issue #664: 不完全な場合、履歴の最古日付をメッセージ用に記録
+                    if (result.MayHaveIncompleteHistory)
+                    {
+                        result.EarliestHistoryDate = historyDetails
+                            .Where(d => d.UseDate.HasValue)
+                            .Min(d => d.UseDate.Value);
+                    }
                 }
                 catch
                 {

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -466,8 +466,12 @@ namespace ICCardManager.ViewModels
 
                             if (importResult.MayHaveIncompleteHistory)
                             {
+                                // Issue #664: カード内の履歴の実際の最古月を表示
+                                var monthText = importResult.EarliestHistoryDate.HasValue
+                                    ? $"{importResult.EarliestHistoryDate.Value.Month}月以降分"
+                                    : "今月分";
                                 _dialogService.ShowInformation(
-                                    "カード内の履歴がすべて今月分のため、月初めからの履歴が不足している可能性があります。\n" +
+                                    $"交通系ICカード内の履歴が{monthText}のため、それより前の履歴が不足している可能性があります。\n" +
                                     "不足分はCSVインポートで補完してください。",
                                     "履歴インポートの注意");
                             }


### PR DESCRIPTION
## Summary
- 繰越登録で先々月を選択した場合、「カード内の履歴がすべて今月分」ではなく「交通系ICカード内の履歴が○月以降分」と実態に合ったメッセージを表示するよう修正
- `HistoryImportResult` に `EarliestHistoryDate` プロパティを追加し、サービス層で最古日付を計算
- CLAUDE.md規約に従い「ICカード」→「交通系ICカード」に修正

## 変更内容
- **`Services/LendingService.cs`**: `HistoryImportResult.EarliestHistoryDate` 追加、`ImportHistoryForRegistrationAsync` で不完全時に最古日付を設定
- **`ViewModels/CardManageViewModel.cs`**: メッセージを動的生成に変更（`○月以降分`）
- **`Tests/Services/LendingServiceTests.cs`**: 単体テスト2件追加

## Test plan
- [x] 単体テスト2件追加（全1176件パス）
- [ ] カード新規登録 → 先々月から繰越 → 「交通系ICカード内の履歴が○月以降分のため…」と表示されること
- [ ] カード新規登録 → 繰越なし（今月登録）→ メッセージの月表示が正しいこと

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)