### PR TITLE
fix: デフォルトのウィンドウサイズを拡大しボタンが一行に収まるよう修正（#663）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml
+++ b/ICCardManager/src/ICCardManager/App.xaml
@@ -25,8 +25,8 @@
 
             <!-- Issue #542: サイドバー幅（フォントサイズに応じて動的に変更） -->
             <sys:Double x:Key="SidebarWidth">350</sys:Double>
-            <!-- Issue #542: ウィンドウ最小幅（固定値） -->
-            <sys:Double x:Key="WindowMinWidth">1200</sys:Double>
+            <!-- Issue #542: ウィンドウ最小幅（固定値） Issue #663: ヘルプボタン追加に伴い拡大 -->
+            <sys:Double x:Key="WindowMinWidth">1300</sys:Double>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -393,8 +393,8 @@ namespace ICCardManager
             // 基準: Medium (14) で 350px、差分 × 5 で調整
             // Small(12)→340, Medium(14)→350, Large(16)→360, ExtraLarge(20)→380
             var sidebarWidth = Math.Round(350 + (baseFontSize - 14) * 5);
-            // ウィンドウ最小幅はフォントサイズに関係なく固定（1200px）
-            const double windowMinWidth = 1200;
+            // Issue #663: ウィンドウ最小幅はフォントサイズに関係なく固定（1300px）
+            const double windowMinWidth = 1300;
 
             // アプリケーションリソースを更新
             var resources = Application.Current.Resources;

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -11,7 +11,7 @@
         d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
         Title="交通系ICカード管理システム"
         Height="700"
-        Width="1250"
+        Width="1350"
         MinWidth="{DynamicResource WindowMinWidth}"
         MinHeight="600"
         WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
## Summary
- ヘルプボタン(F7)追加に伴い、デフォルトウィンドウ幅で「終了」ボタンが二行目に折り返されていた問題を修正
- デフォルト幅: 1250 → 1350px
- 最小幅: 1200 → 1300px

## 変更内容
- **`Views/MainWindow.xaml`**: デフォルト `Width` を 1250 → 1350 に変更
- **`App.xaml`**: `WindowMinWidth` リソースを 1200 → 1300 に変更
- **`App.xaml.cs`**: `windowMinWidth` 定数を 1200 → 1300 に変更

## Test plan
- [ ] デフォルトのフォントサイズ（中）でアプリを起動し、ヘッダーのボタンが「終了」まで一行に収まっていること
- [ ] フォントサイズを「小」に設定し、ボタンが一行に収まっていること
- [ ] ウィンドウを最小幅まで縮小した場合、ボタンが適切に折り返されること（WrapPanel動作の確認）

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)