### PR TITLE
fix: カード一覧のデフォルトソートを「カード名順」に変更（#662）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -181,7 +181,7 @@ public partial class MainViewModel : ViewModelBase
     /// ダッシュボードのソート順
     /// </summary>
     [ObservableProperty]
-    private DashboardSortOrder _dashboardSortOrder = DashboardSortOrder.BalanceAscending;
+    private DashboardSortOrder _dashboardSortOrder = DashboardSortOrder.CardName;
 
     /// <summary>
     /// 選択中のダッシュボードアイテム


### PR DESCRIPTION
## Summary
- カード残高ダッシュボード（カード一覧）のデフォルトソート順を「残額昇順」から「カード名順」に変更

## 変更内容
- **`ViewModels/MainViewModel.cs`**: `_dashboardSortOrder` の初期値を `BalanceAscending` → `CardName` に変更（1行）

## Test plan
- [ ] アプリ起動後、カード一覧がカード種別・番号順（例: はやかけん 001, はやかけん 002, nimoca 001...）で表示されること
- [ ] ソート切り替えボタンで他のソート順に変更できること（従来どおり）

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)