### PR TITLE
feat: デバッグモードで職員証認証ダイアログに仮想タッチボタンを追加（#688）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
@@ -71,18 +71,33 @@
         </StackPanel>
 
         <!-- キャンセルボタン -->
-        <Button x:Name="CancelButton"
-                Grid.Row="4"
-                Content="キャンセル"
-                MinWidth="120"
-                Height="40"
-                Padding="16,0"
-                HorizontalAlignment="Center"
-                FontSize="{DynamicResource BaseFontSize}"
-                IsCancel="True"
-                Click="CancelButton_Click"
-                AutomationProperties.Name="キャンセル"
-                AutomationProperties.HelpText="認証をキャンセルします"
-                ToolTip="認証をキャンセル (Escape)"/>
+        <StackPanel Grid.Row="4" HorizontalAlignment="Center" Orientation="Horizontal">
+            <Button x:Name="CancelButton"
+                    Content="キャンセル"
+                    MinWidth="120"
+                    Height="40"
+                    Padding="16,0"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    IsCancel="True"
+                    Click="CancelButton_Click"
+                    AutomationProperties.Name="キャンセル"
+                    AutomationProperties.HelpText="認証をキャンセルします"
+                    ToolTip="認証をキャンセル (Escape)"/>
+
+            <!-- Issue #688: デバッグモード用仮想タッチボタン -->
+            <Button x:Name="DebugVirtualTouchButton"
+                    Content="🃏 職員証（仮想タッチ）"
+                    MinWidth="180"
+                    Height="40"
+                    Padding="16,0"
+                    Margin="10,0,0,0"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    Background="#FFF3E0"
+                    Foreground="#E65100"
+                    Click="DebugVirtualTouchButton_Click"
+                    Visibility="Collapsed"
+                    AutomationProperties.Name="職員証仮想タッチ（デバッグ用）"
+                    ToolTip="デバッグ用: 職員証の仮想タッチをシミュレート"/>
+        </StackPanel>
     </Grid>
 </Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml.cs
@@ -79,6 +79,14 @@ namespace ICCardManager.Views.Dialogs
 
             // タイムアウトタイマー開始
             _timeoutTimer.Start();
+
+#if DEBUG
+            // Issue #688: デバッグモードでは仮想タッチボタンを表示
+            if (_cardReader is HybridCardReader)
+            {
+                DebugVirtualTouchButton.Visibility = Visibility.Visible;
+            }
+#endif
         }
 
         private void OnClosed(object? sender, EventArgs e)
@@ -178,6 +186,19 @@ namespace ICCardManager.Views.Dialogs
                 StatusText.Foreground = new System.Windows.Media.SolidColorBrush(
                     System.Windows.Media.Color.FromRgb(0x2E, 0x7D, 0x32));
             }
+        }
+
+        /// <summary>
+        /// Issue #688: デバッグ用仮想タッチボタンのクリックハンドラ
+        /// </summary>
+        private void DebugVirtualTouchButton_Click(object sender, RoutedEventArgs e)
+        {
+#if DEBUG
+            if (_cardReader is HybridCardReader hybridReader)
+            {
+                hybridReader.SimulateCardRead("FFFF000000000001");
+            }
+#endif
         }
 
         private void CancelButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- 職員証認証ダイアログ（`StaffAuthDialog`）にDEBUGビルド限定の仮想タッチボタンを追加
- `HybridCardReader`使用時のみボタンが表示される（`Visibility.Collapsed` → `Visible`）
- ボタンクリックで `SimulateCardRead("FFFF000000000001")` が発火し、既存の `OnCardRead` ハンドラで認証処理が実行される

## Background
モーダルダイアログ表示中はメインウィンドウの仮想タッチボタンがクリックできないため、デバッグ時の操作性に問題があった。

## Changes
- `StaffAuthDialog.xaml`: キャンセルボタン横に仮想タッチボタンを追加（初期状態は `Collapsed`）
- `StaffAuthDialog.xaml.cs`: `#if DEBUG` で仮想タッチボタンの表示制御とクリックハンドラを実装

## Test plan
- [x] デバッグモードでアプリを起動し、職員証が必要な操作（履歴編集等）を実行
- [x] 認証ダイアログに「🃏 職員証（仮想タッチ）」ボタンが表示されることを確認
- [x] ボタンをクリックすると認証が成功し、ダイアログが閉じることを確認
- [x] キャンセルボタンが引き続き正常に動作することを確認
- [x] Releaseビルドでは仮想タッチボタンが表示されないことを確認

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)