### PR TITLE
fix: 貸出時にカード残高が0になる問題を修正（#656）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -258,7 +258,18 @@ namespace ICCardManager.Services
                 try
                 {
                     // 貸出レコードを作成
+                    // Issue #656: カードから残高を読み取れなかった場合、直近の履歴から残高を取得
                     var currentBalance = balance ?? 0;
+                    if (!balance.HasValue)
+                    {
+                        var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+                        if (latestLedger != null)
+                        {
+                            currentBalance = latestLedger.Balance;
+                            _logger.LogInformation(
+                                "LendAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", currentBalance);
+                        }
+                    }
                     var ledger = new Ledger
                     {
                         CardIdm = cardIdm,

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -794,7 +794,9 @@ public partial class MainViewModel : ViewModelBase
         SetInternalState(AppState.Processing);
 
         // カードから残高を読み取る（Issue #526: 貸出時も残高を記録）
+        // Issue #656: エラーイベントを一時的に抑制（カード離脱時の警告メッセージを防止）
         int? balance = null;
+        _cardReader.Error -= OnCardReaderError;
         try
         {
             balance = await _cardReader.ReadBalanceAsync(card.CardIdm);
@@ -802,6 +804,10 @@ public partial class MainViewModel : ViewModelBase
         catch
         {
             // 残高読み取りエラーは無視（貸出処理は続行）
+        }
+        finally
+        {
+            _cardReader.Error += OnCardReaderError;
         }
 
         var result = await _lendingService.LendAsync(_currentStaffIdm!, card.CardIdm, balance);


### PR DESCRIPTION
## Summary
- 貸出時にカードから残高を読み取れなかった場合、DBの直近履歴残高をフォールバックとして使用するよう修正
- `ProcessLendAsync` で `ReadBalanceAsync` 呼び出し中の `Error` イベントを一時抑制し、不要な警告メッセージを防止

## Root Cause
カード検出から `ReadBalanceAsync` 呼び出しまでに複数の非同期DB問い合わせ（`GetByIdmAsync` 等）が挟まるため、ユーザーがカードを素早くリーダーから離すと残高読み取りに失敗。`ReadBalanceAsync` が `null` を返し、`balance ?? 0` により残高が0として記録されていた。

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `LendingService.cs` | `LendAsync` で `balance` が `null` の場合、`GetLatestLedgerAsync` で直近の履歴残高を取得 |
| `MainViewModel.cs` | `ProcessLendAsync` で `ReadBalanceAsync` 中の `Error` イベントを一時的に抑制（カード離脱時の不要な警告を防止） |
| `LendingServiceTests.cs` | 4件のテストを追加（残高指定あり/なし/0/DB履歴なし） |

## Test plan
- [x] `LendAsync_WithBalance_UsesProvidedBalance` — 残高が渡された場合にその値が使用される
- [x] `LendAsync_WithNullBalance_FallsBackToLatestLedgerBalance` — 残高null時にDB履歴残高にフォールバック
- [x] `LendAsync_WithNullBalanceAndNoLedgerHistory_DefaultsToZero` — 残高null＋DB履歴なし→0
- [x] `LendAsync_WithZeroBalance_DoesNotFallBackToDb` — 残高0（実際の0円）はフォールバックしない
- [x] 実機で貸出操作を行い、正しい残高が記録されることを確認
- [ ] カードを素早く離しても残高が0にならないことを確認

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)