### PR TITLE
docs: マニュアルのページ方向をA4横に変更（#692）

### DIFF
--- a/ICCardManager/docs/manual/create-reference-doc.ps1
+++ b/ICCardManager/docs/manual/create-reference-doc.ps1
@@ -4,7 +4,7 @@
 # このスクリプトは以下の設定を持つリファレンスドキュメントを生成します:
 #   - 余白: やや狭い (上下左右 1.27cm / 0.5インチ)
 #   - ページ番号: フッター中央に表示
-#   - 用紙サイズ: A4
+#   - 用紙サイズ: A4横 (ランドスケープ)
 #   - テーブルスタイル: 黒・単線・0.5ptの罫線（Issue #600: 印刷時に罫線が消えないようにする）
 #
 # 使用方法:
@@ -48,6 +48,9 @@ try {
     # 用紙サイズ: A4
     $PageSetup.PaperSize = 7  # wdPaperA4
 
+    # Issue #692: 用紙の向き: 横 (ランドスケープ)
+    $PageSetup.Orientation = 1  # wdOrientLandscape
+
     # 余白: やや狭い (1.27cm = 36ポイント)
     # Word の「やや狭い」は上下左右 1.27cm (0.5インチ)
     $NarrowMargin = 36  # ポイント (1.27cm ≈ 36pt)
@@ -56,6 +59,7 @@ try {
     $PageSetup.LeftMargin = $NarrowMargin
     $PageSetup.RightMargin = $NarrowMargin
 
+    Write-Host "  用紙の向き: A4横 (ランドスケープ)" -ForegroundColor Gray
     Write-Host "  余白: 上下左右 1.27cm (やや狭い)" -ForegroundColor Gray
 
     # フッターにページ番号を追加


### PR DESCRIPTION
## Summary
- `create-reference-doc.ps1` に `$PageSetup.Orientation = 1`（wdOrientLandscape）を追加
- reference.docx を再生成することで、全マニュアルがA4横レイアウトで出力される

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `create-reference-doc.ps1` | PageSetup に `Orientation = 1` を追加、コメントとログ出力を更新 |

## 適用手順
マージ後、以下の手順でマニュアルを再生成してください：
```powershell
# 1. reference.docx を再生成
.\create-reference-doc.ps1

# 2. docx を再生成
.\convert-to-docx.ps1 -Force

# 3. 必要に応じて pdf を再生成
.\convert-to-pdf.ps1 -Force
```

## Test plan
- [x] `.\create-reference-doc.ps1` を実行し、reference.docx が生成されることを確認
- [x] reference.docx をWordで開き、ページ設定がA4横になっていることを確認
- [ ] `.\convert-to-docx.ps1 -Force` でマニュアルを再変換し、docxがA4横になっていることを確認
- [ ] `.\convert-to-pdf.ps1 -Force` でPDFを再生成し、A4横で出力されることを確認

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)