### PR TITLE
feat: 履歴画面に行の挿入・削除・修正機能を追加（#635）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -195,6 +195,7 @@ namespace ICCardManager
             services.AddSingleton<OperationLogger>();
             services.AddSingleton<LedgerMergeService>();
             services.AddSingleton<LedgerSplitService>();
+            services.AddSingleton<LedgerConsistencyChecker>();
             services.AddSingleton<CsvExportService>();
             services.AddSingleton<CsvImportService>();
             services.AddSingleton<IToastNotificationService, ToastNotificationService>();
@@ -235,6 +236,7 @@ namespace ICCardManager
             services.AddTransient<LedgerDetailViewModel>();
             services.AddTransient<SystemManageViewModel>();
             services.AddTransient<IncompleteBusStopViewModel>();
+            services.AddTransient<LedgerRowEditViewModel>();
     #if DEBUG
             // Issue #640: 仮想タッチ設定ダイアログ
             services.AddTransient<VirtualCardViewModel>();
@@ -255,6 +257,7 @@ namespace ICCardManager
             services.AddTransient<Views.Dialogs.LedgerEditDialog>();
             services.AddTransient<Views.Dialogs.SystemManageDialog>();
             services.AddTransient<Views.Dialogs.IncompleteBusStopDialog>();
+            services.AddTransient<Views.Dialogs.LedgerRowEditDialog>();
     #if DEBUG
             services.AddTransient<Views.Dialogs.VirtualCardDialog>();
     #endif

--- a/ICCardManager/src/ICCardManager/Services/LedgerConsistencyChecker.cs
+++ b/ICCardManager/src/ICCardManager/Services/LedgerConsistencyChecker.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 残高チェーンの整合性をチェック・修正するサービス（Issue #635）
+    /// </summary>
+    /// <remarks>
+    /// 各行の残高が「前行の残高 + 受入 - 払出」と一致するかを検証します。
+    /// 行の追加・削除・修正後に呼び出し、不整合があれば自動修正を提案します。
+    /// </remarks>
+    internal class LedgerConsistencyChecker
+    {
+        private readonly ILedgerRepository _ledgerRepository;
+
+        public LedgerConsistencyChecker(ILedgerRepository ledgerRepository)
+        {
+            _ledgerRepository = ledgerRepository;
+        }
+
+        /// <summary>
+        /// 指定期間の残高チェーンの整合性をチェック
+        /// </summary>
+        /// <param name="cardIdm">カードIDm</param>
+        /// <param name="fromDate">開始日</param>
+        /// <param name="toDate">終了日</param>
+        /// <returns>整合性チェック結果</returns>
+        public async Task<ConsistencyResult> CheckBalanceConsistencyAsync(
+            string cardIdm, DateTime fromDate, DateTime toDate)
+        {
+            var ledgers = (await _ledgerRepository.GetByDateRangeAsync(cardIdm, fromDate, toDate))
+                .OrderBy(l => l.Date)
+                .ThenBy(l => l.Id)
+                .ToList();
+
+            return CheckConsistency(ledgers, cardIdm, fromDate);
+        }
+
+        /// <summary>
+        /// 指定期間の残高チェーンを再計算して修正
+        /// </summary>
+        /// <param name="cardIdm">カードIDm</param>
+        /// <param name="fromDate">開始日</param>
+        /// <param name="toDate">終了日</param>
+        /// <returns>修正した件数</returns>
+        public async Task<int> RecalculateBalancesAsync(
+            string cardIdm, DateTime fromDate, DateTime toDate)
+        {
+            var ledgers = (await _ledgerRepository.GetByDateRangeAsync(cardIdm, fromDate, toDate))
+                .OrderBy(l => l.Date)
+                .ThenBy(l => l.Id)
+                .ToList();
+
+            if (ledgers.Count == 0) return 0;
+
+            // 期間の直前のレコードから前残高を取得
+            var previousLedger = await _ledgerRepository.GetLatestBeforeDateAsync(cardIdm, fromDate);
+            var previousBalance = previousLedger?.Balance ?? 0;
+
+            var fixedCount = 0;
+            foreach (var ledger in ledgers)
+            {
+                var expectedBalance = previousBalance + ledger.Income - ledger.Expense;
+
+                if (ledger.Balance != expectedBalance)
+                {
+                    ledger.Balance = expectedBalance;
+                    await _ledgerRepository.UpdateAsync(ledger);
+                    fixedCount++;
+                }
+
+                previousBalance = ledger.Balance;
+            }
+
+            return fixedCount;
+        }
+
+        /// <summary>
+        /// 残高チェーンの整合性をチェック（内部ロジック）
+        /// </summary>
+        internal ConsistencyResult CheckConsistency(
+            List<Ledger> ledgers, string cardIdm, DateTime fromDate)
+        {
+            var result = new ConsistencyResult { IsConsistent = true };
+
+            if (ledgers.Count == 0) return result;
+
+            // 期間の直前のレコードから前残高を取得する処理は非同期なので、
+            // 最初の行は前行がないためスキップし、2行目以降をチェック
+            for (int i = 1; i < ledgers.Count; i++)
+            {
+                var previousBalance = ledgers[i - 1].Balance;
+                var current = ledgers[i];
+                var expectedBalance = previousBalance + current.Income - current.Expense;
+
+                if (current.Balance != expectedBalance)
+                {
+                    result.IsConsistent = false;
+                    result.Inconsistencies.Add((current.Id, expectedBalance, current.Balance));
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 前残高を含めた完全な整合性チェック（非同期版）
+        /// </summary>
+        internal async Task<ConsistencyResult> CheckConsistencyWithPreviousAsync(
+            List<Ledger> ledgers, string cardIdm, DateTime fromDate)
+        {
+            var result = new ConsistencyResult { IsConsistent = true };
+
+            if (ledgers.Count == 0) return result;
+
+            // 期間の直前のレコードから前残高を取得
+            var previousLedger = await _ledgerRepository.GetLatestBeforeDateAsync(cardIdm, fromDate);
+            var previousBalance = previousLedger?.Balance ?? 0;
+
+            foreach (var ledger in ledgers)
+            {
+                var expectedBalance = previousBalance + ledger.Income - ledger.Expense;
+
+                if (ledger.Balance != expectedBalance)
+                {
+                    result.IsConsistent = false;
+                    result.Inconsistencies.Add((ledger.Id, expectedBalance, ledger.Balance));
+                }
+
+                previousBalance = ledger.Balance;
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// 残高整合性チェック結果
+    /// </summary>
+    internal class ConsistencyResult
+    {
+        /// <summary>
+        /// 整合性があるかどうか
+        /// </summary>
+        public bool IsConsistent { get; set; }
+
+        /// <summary>
+        /// 不整合箇所リスト（LedgerId, 期待される残高, 実際の残高）
+        /// </summary>
+        public List<(int LedgerId, int ExpectedBalance, int ActualBalance)> Inconsistencies { get; set; } = new();
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
@@ -302,6 +302,32 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 履歴挿入のログを記録（Issue #635: 行の追加）
+        /// </summary>
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="ledger">挿入した履歴データ</param>
+        public async Task LogLedgerInsertAsync(string? operatorIdm, Ledger ledger)
+        {
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
+
+            var log = new OperationLog
+            {
+                Timestamp = DateTime.Now,
+                OperatorIdm = actualIdm,
+                OperatorName = operatorName,
+                TargetTable = Tables.Ledger,
+                TargetId = ledger.Id.ToString(),
+                Action = Actions.Insert,
+                BeforeData = null,
+                AfterData = SerializeToJson(ledger)
+            };
+
+            await _operationLogRepository.InsertAsync(log);
+        }
+
+        /// <summary>
         /// 履歴削除のログを記録
         /// </summary>
         public async Task LogLedgerDeleteAsync(string operatorIdm, Ledger ledger)

--- a/ICCardManager/src/ICCardManager/ViewModels/LedgerRowEditViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/LedgerRowEditViewModel.cs
@@ -1,0 +1,600 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
+using ICCardManager.Models;
+using ICCardManager.Services;
+
+namespace ICCardManager.ViewModels
+{
+    /// <summary>
+    /// 行の追加/全項目編集モード
+    /// </summary>
+    public enum LedgerRowEditMode
+    {
+        /// <summary>行の追加</summary>
+        Add,
+        /// <summary>全項目修正</summary>
+        Edit
+    }
+
+    /// <summary>
+    /// 履歴行の追加/全項目編集ダイアログのViewModel（Issue #635）
+    /// </summary>
+    /// <remarks>
+    /// <para>Addモード: 日付・摘要・金額等を入力し、挿入位置プレビューで位置を確認して挿入</para>
+    /// <para>Editモード: 既存行の全項目（日付・金額含む）を変更可能</para>
+    /// </remarks>
+    public partial class LedgerRowEditViewModel : ViewModelBase
+    {
+        private readonly ILedgerRepository _ledgerRepository;
+        private readonly IStaffRepository _staffRepository;
+        private readonly OperationLogger _operationLogger;
+
+        private string _cardIdm = string.Empty;
+        private string? _operatorIdm;
+        private int _editLedgerId;
+
+        /// <summary>
+        /// 編集モード（Add/Edit）
+        /// </summary>
+        [ObservableProperty]
+        private LedgerRowEditMode _mode;
+
+        /// <summary>
+        /// ダイアログタイトル
+        /// </summary>
+        [ObservableProperty]
+        private string _dialogTitle = "履歴行の追加";
+
+        /// <summary>
+        /// 日付
+        /// </summary>
+        [ObservableProperty]
+        private DateTime _editDate = DateTime.Today;
+
+        /// <summary>
+        /// 摘要
+        /// </summary>
+        [ObservableProperty]
+        private string _summary = string.Empty;
+
+        /// <summary>
+        /// 受入金額
+        /// </summary>
+        [ObservableProperty]
+        private int _income;
+
+        /// <summary>
+        /// 払出金額
+        /// </summary>
+        [ObservableProperty]
+        private int _expense;
+
+        /// <summary>
+        /// 残高
+        /// </summary>
+        [ObservableProperty]
+        private int _balance;
+
+        /// <summary>
+        /// 残高を自動計算するか
+        /// </summary>
+        [ObservableProperty]
+        private bool _isAutoBalance = true;
+
+        /// <summary>
+        /// 備考
+        /// </summary>
+        [ObservableProperty]
+        private string _note = string.Empty;
+
+        /// <summary>
+        /// 職員リスト
+        /// </summary>
+        [ObservableProperty]
+        private ObservableCollection<Staff> _staffList = new();
+
+        /// <summary>
+        /// 選択中の職員
+        /// </summary>
+        [ObservableProperty]
+        private Staff? _selectedStaff;
+
+        /// <summary>
+        /// 挿入位置前後の行（Addモード用）
+        /// </summary>
+        [ObservableProperty]
+        private ObservableCollection<LedgerDto> _contextRows = new();
+
+        /// <summary>
+        /// 挿入位置（ContextRows内のインデックス）
+        /// </summary>
+        [ObservableProperty]
+        private int _insertIndex;
+
+        /// <summary>
+        /// 挿入位置の直前行の残高
+        /// </summary>
+        [ObservableProperty]
+        private int _previousBalance;
+
+        /// <summary>
+        /// 挿入位置プレビューを表示するか（Addモードのみ）
+        /// </summary>
+        public bool IsAddMode => Mode == LedgerRowEditMode.Add;
+
+        /// <summary>
+        /// バリデーションエラーメッセージ
+        /// </summary>
+        [ObservableProperty]
+        private string _validationMessage = string.Empty;
+
+        /// <summary>
+        /// 警告メッセージ
+        /// </summary>
+        [ObservableProperty]
+        private string _warningMessage = string.Empty;
+
+        /// <summary>
+        /// ステータスメッセージ
+        /// </summary>
+        [ObservableProperty]
+        private string _statusMessage = string.Empty;
+
+        /// <summary>
+        /// 保存完了フラグ（ダイアログを閉じる通知用）
+        /// </summary>
+        [ObservableProperty]
+        private bool _isSaved;
+
+        /// <summary>
+        /// 保存が可能か
+        /// </summary>
+        [ObservableProperty]
+        private bool _canSave;
+
+        /// <summary>
+        /// 全行リスト（挿入位置計算用）
+        /// </summary>
+        private List<LedgerDto> _allLedgers = new();
+
+        public LedgerRowEditViewModel(
+            ILedgerRepository ledgerRepository,
+            IStaffRepository staffRepository,
+            OperationLogger operationLogger)
+        {
+            _ledgerRepository = ledgerRepository;
+            _staffRepository = staffRepository;
+            _operationLogger = operationLogger;
+        }
+
+        /// <summary>
+        /// Addモードで初期化
+        /// </summary>
+        /// <param name="cardIdm">対象カードIDm</param>
+        /// <param name="allLedgers">表示中の全履歴（挿入位置プレビュー用）</param>
+        /// <param name="operatorIdm">認証済み職員IDm</param>
+        public async Task InitializeForAddAsync(string cardIdm, List<LedgerDto> allLedgers, string operatorIdm)
+        {
+            _cardIdm = cardIdm;
+            _operatorIdm = operatorIdm;
+            _allLedgers = allLedgers;
+
+            Mode = LedgerRowEditMode.Add;
+            DialogTitle = "履歴行の追加";
+            EditDate = DateTime.Today;
+
+            await LoadStaffListAsync();
+
+            // 挿入位置を末尾に設定
+            InsertIndex = _allLedgers.Count;
+            UpdateContextRows();
+            RecalculateBalance();
+            Validate();
+
+            OnPropertyChanged(nameof(IsAddMode));
+        }
+
+        /// <summary>
+        /// Editモードで初期化
+        /// </summary>
+        /// <param name="ledgerDto">編集対象</param>
+        /// <param name="operatorIdm">認証済み職員IDm</param>
+        public async Task InitializeForEditAsync(LedgerDto ledgerDto, string operatorIdm)
+        {
+            _operatorIdm = operatorIdm;
+            _cardIdm = ledgerDto.CardIdm;
+            _editLedgerId = ledgerDto.Id;
+
+            Mode = LedgerRowEditMode.Edit;
+            DialogTitle = "履歴行の修正";
+
+            // 完全なLedgerオブジェクトを取得
+            var ledger = await _ledgerRepository.GetByIdAsync(ledgerDto.Id);
+            if (ledger == null) return;
+
+            EditDate = ledger.Date;
+            Summary = ledger.Summary;
+            Income = ledger.Income;
+            Expense = ledger.Expense;
+            Balance = ledger.Balance;
+            IsAutoBalance = false; // 編集モードでは手動入力開始
+            Note = ledger.Note ?? string.Empty;
+
+            await LoadStaffListAsync();
+
+            // 現在の利用者を選択
+            SelectedStaff = StaffList.FirstOrDefault(s => s.StaffIdm == ledger.LenderIdm);
+
+            Validate();
+            OnPropertyChanged(nameof(IsAddMode));
+        }
+
+        /// <summary>
+        /// 職員リストを読み込み
+        /// </summary>
+        private async Task LoadStaffListAsync()
+        {
+            var staffMembers = await _staffRepository.GetAllAsync();
+            StaffList.Clear();
+            foreach (var staff in staffMembers.OrderBy(s => s.Name))
+            {
+                StaffList.Add(staff);
+            }
+        }
+
+        /// <summary>
+        /// Income変更時のコールバック
+        /// </summary>
+        partial void OnIncomeChanged(int value)
+        {
+            RecalculateBalance();
+            Validate();
+        }
+
+        /// <summary>
+        /// Expense変更時のコールバック
+        /// </summary>
+        partial void OnExpenseChanged(int value)
+        {
+            RecalculateBalance();
+            Validate();
+        }
+
+        /// <summary>
+        /// IsAutoBalance変更時のコールバック
+        /// </summary>
+        partial void OnIsAutoBalanceChanged(bool value)
+        {
+            if (value)
+            {
+                RecalculateBalance();
+            }
+            Validate();
+        }
+
+        /// <summary>
+        /// Balance変更時のコールバック
+        /// </summary>
+        partial void OnBalanceChanged(int value)
+        {
+            Validate();
+        }
+
+        /// <summary>
+        /// Summary変更時のコールバック
+        /// </summary>
+        partial void OnSummaryChanged(string value)
+        {
+            Validate();
+        }
+
+        /// <summary>
+        /// EditDate変更時のコールバック
+        /// </summary>
+        partial void OnEditDateChanged(DateTime value)
+        {
+            if (Mode == LedgerRowEditMode.Add && _allLedgers.Count > 0)
+            {
+                // 日付に基づいて挿入位置を自動調整
+                var newIndex = _allLedgers.Count;
+                for (int i = 0; i < _allLedgers.Count; i++)
+                {
+                    if (_allLedgers[i].Date > value)
+                    {
+                        newIndex = i;
+                        break;
+                    }
+                }
+                InsertIndex = newIndex;
+                UpdateContextRows();
+                RecalculateBalance();
+            }
+            Validate();
+        }
+
+        /// <summary>
+        /// 挿入位置を1つ上に移動
+        /// </summary>
+        [RelayCommand]
+        private void MoveInsertPositionUp()
+        {
+            if (InsertIndex > 0)
+            {
+                InsertIndex--;
+                UpdateContextRows();
+                RecalculateBalance();
+                Validate();
+            }
+        }
+
+        /// <summary>
+        /// 挿入位置を1つ下に移動
+        /// </summary>
+        [RelayCommand]
+        private void MoveInsertPositionDown()
+        {
+            if (InsertIndex < _allLedgers.Count)
+            {
+                InsertIndex++;
+                UpdateContextRows();
+                RecalculateBalance();
+                Validate();
+            }
+        }
+
+        /// <summary>
+        /// 挿入位置前後のコンテキスト行を更新
+        /// </summary>
+        private void UpdateContextRows()
+        {
+            ContextRows.Clear();
+
+            // 挿入位置の前後2行ずつを表示
+            var startIdx = Math.Max(0, InsertIndex - 2);
+            var endIdx = Math.Min(_allLedgers.Count, InsertIndex + 2);
+
+            for (int i = startIdx; i < endIdx; i++)
+            {
+                ContextRows.Add(_allLedgers[i]);
+            }
+        }
+
+        /// <summary>
+        /// 残高を再計算
+        /// </summary>
+        private void RecalculateBalance()
+        {
+            if (!IsAutoBalance) return;
+
+            if (Mode == LedgerRowEditMode.Add)
+            {
+                // 挿入位置の直前行の残高を取得
+                if (InsertIndex > 0 && InsertIndex <= _allLedgers.Count)
+                {
+                    PreviousBalance = _allLedgers[InsertIndex - 1].Balance;
+                }
+                else
+                {
+                    PreviousBalance = 0;
+                }
+            }
+
+            Balance = PreviousBalance + Income - Expense;
+        }
+
+        /// <summary>
+        /// バリデーション
+        /// </summary>
+        private void Validate()
+        {
+            ValidationMessage = string.Empty;
+            WarningMessage = string.Empty;
+            CanSave = true;
+
+            // 摘要が空かチェック
+            if (string.IsNullOrWhiteSpace(Summary))
+            {
+                ValidationMessage = "摘要を入力してください";
+                CanSave = false;
+                return;
+            }
+
+            // 受入・払出が両方0かチェック（繰越等の特殊パターンは除外）
+            var isSpecialSummary = Summary.Contains("繰越") ||
+                                   Summary.Contains("新規購入") ||
+                                   Summary == "ポイント還元";
+            if (Income == 0 && Expense == 0 && !isSpecialSummary)
+            {
+                WarningMessage = "受入と払出が両方0円です。繰越等でなければ金額を入力してください。";
+            }
+
+            // 残高が負になるチェック
+            if (Balance < 0)
+            {
+                ValidationMessage = "残高がマイナスになります";
+                CanSave = false;
+                return;
+            }
+
+            // Income/Expenseが負かチェック
+            if (Income < 0)
+            {
+                ValidationMessage = "受入金額は0以上にしてください";
+                CanSave = false;
+                return;
+            }
+            if (Expense < 0)
+            {
+                ValidationMessage = "払出金額は0以上にしてください";
+                CanSave = false;
+                return;
+            }
+
+            // Addモードの場合の日付チェック
+            if (Mode == LedgerRowEditMode.Add && _allLedgers.Count > 0)
+            {
+                // 挿入位置の前後と日付の整合性をチェック
+                if (InsertIndex > 0 && _allLedgers[InsertIndex - 1].Date > EditDate)
+                {
+                    WarningMessage = "日付が前の行より古くなっています。挿入位置を確認してください。";
+                }
+                if (InsertIndex < _allLedgers.Count && _allLedgers[InsertIndex].Date < EditDate)
+                {
+                    WarningMessage = "日付が次の行より新しくなっています。挿入位置を確認してください。";
+                }
+            }
+        }
+
+        /// <summary>
+        /// 利用者の選択をクリア
+        /// </summary>
+        [RelayCommand]
+        private void ClearStaff()
+        {
+            SelectedStaff = null;
+        }
+
+        /// <summary>
+        /// 保存
+        /// </summary>
+        [RelayCommand]
+        private async Task Save()
+        {
+            if (!CanSave) return;
+
+            IsBusy = true;
+            BusyMessage = "保存中...";
+            StatusMessage = string.Empty;
+
+            try
+            {
+                if (Mode == LedgerRowEditMode.Add)
+                {
+                    await SaveAddAsync();
+                }
+                else
+                {
+                    await SaveEditAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"エラー: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// 追加モードの保存処理
+        /// </summary>
+        private async Task SaveAddAsync()
+        {
+            var newLedger = new Ledger
+            {
+                CardIdm = _cardIdm,
+                Date = EditDate,
+                Summary = Summary,
+                Income = Income,
+                Expense = Expense,
+                Balance = Balance,
+                StaffName = SelectedStaff?.Name,
+                LenderIdm = SelectedStaff?.StaffIdm,
+                Note = Note,
+                IsLentRecord = false
+            };
+
+            var newId = await _ledgerRepository.InsertAsync(newLedger);
+            if (newId > 0)
+            {
+                newLedger.Id = newId;
+                await _operationLogger.LogLedgerInsertAsync(_operatorIdm, newLedger);
+                IsSaved = true;
+            }
+            else
+            {
+                StatusMessage = "保存に失敗しました";
+            }
+        }
+
+        /// <summary>
+        /// 編集モードの保存処理
+        /// </summary>
+        private async Task SaveEditAsync()
+        {
+            var ledger = await _ledgerRepository.GetByIdAsync(_editLedgerId);
+            if (ledger == null)
+            {
+                StatusMessage = "履歴データが見つかりません";
+                return;
+            }
+
+            // 変更前のスナップショット
+            var beforeLedger = new Ledger
+            {
+                Id = ledger.Id,
+                CardIdm = ledger.CardIdm,
+                LenderIdm = ledger.LenderIdm,
+                Date = ledger.Date,
+                Summary = ledger.Summary,
+                Income = ledger.Income,
+                Expense = ledger.Expense,
+                Balance = ledger.Balance,
+                StaffName = ledger.StaffName,
+                Note = ledger.Note,
+                ReturnerIdm = ledger.ReturnerIdm,
+                LentAt = ledger.LentAt,
+                ReturnedAt = ledger.ReturnedAt,
+                IsLentRecord = ledger.IsLentRecord
+            };
+
+            // 値を更新
+            ledger.Date = EditDate;
+            ledger.Summary = Summary;
+            ledger.Income = Income;
+            ledger.Expense = Expense;
+            ledger.Balance = Balance;
+            ledger.Note = Note;
+
+            if (SelectedStaff != null)
+            {
+                ledger.LenderIdm = SelectedStaff.StaffIdm;
+                ledger.StaffName = SelectedStaff.Name;
+            }
+            else
+            {
+                ledger.LenderIdm = null;
+                ledger.StaffName = null;
+            }
+
+            var result = await _ledgerRepository.UpdateAsync(ledger);
+            if (result)
+            {
+                await _operationLogger.LogLedgerUpdateAsync(_operatorIdm, beforeLedger, ledger);
+                IsSaved = true;
+            }
+            else
+            {
+                StatusMessage = "保存に失敗しました";
+            }
+        }
+
+        /// <summary>
+        /// キャンセル
+        /// </summary>
+        [RelayCommand]
+        private void Cancel()
+        {
+            // 何もせずに閉じる（IsSavedはfalseのまま）
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml
@@ -1,0 +1,336 @@
+<Window x:Class="ICCardManager.Views.Dialogs.LedgerRowEditDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ICCardManager.ViewModels"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:LedgerRowEditViewModel}"
+        Title="{Binding DialogTitle}"
+        Height="620"
+        Width="700"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        AutomationProperties.Name="履歴行の追加・修正ダイアログ"
+        AutomationProperties.HelpText="履歴の行を追加または全項目を修正できます。">
+
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <conv:InverseBoolConverter x:Key="InvertBoolConverter"
+                                    xmlns:conv="clr-namespace:ICCardManager.Views.Converters"/>
+    </Window.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- 入力フィールド -->
+        <Grid Grid.Row="0" Margin="0,0,0,10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="80"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- 日付 -->
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="日付:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <DatePicker Grid.Row="0" Grid.Column="1"
+                        SelectedDate="{Binding EditDate}"
+                        FontSize="{DynamicResource BaseFontSize}"
+                        Margin="0,0,0,8"
+                        AutomationProperties.Name="出納日付"
+                        ToolTip="出納年月日を選択してください"/>
+
+            <!-- 摘要 -->
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="摘要:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding Summary, UpdateSourceTrigger=PropertyChanged}"
+                     FontSize="{DynamicResource BaseFontSize}"
+                     Padding="10,6"
+                     Margin="0,0,0,8"
+                     AutomationProperties.Name="摘要"
+                     ToolTip="摘要（例: 鉄道（博多駅～天神）、役務費によりチャージ）"/>
+
+            <!-- 受入金額 -->
+            <TextBlock Grid.Row="2" Grid.Column="0"
+                       Text="受入:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBox Text="{Binding Income, UpdateSourceTrigger=PropertyChanged}"
+                         FontSize="{DynamicResource BaseFontSize}"
+                         Padding="10,6"
+                         Width="120"
+                         AutomationProperties.Name="受入金額"
+                         ToolTip="チャージ額（受入金額）"/>
+                <TextBlock Text="円" VerticalAlignment="Center" Margin="5,0,0,0"
+                           FontSize="{DynamicResource BaseFontSize}"/>
+            </StackPanel>
+
+            <!-- 払出金額 -->
+            <TextBlock Grid.Row="3" Grid.Column="0"
+                       Text="払出:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBox Text="{Binding Expense, UpdateSourceTrigger=PropertyChanged}"
+                         FontSize="{DynamicResource BaseFontSize}"
+                         Padding="10,6"
+                         Width="120"
+                         AutomationProperties.Name="払出金額"
+                         ToolTip="利用額（払出金額）"/>
+                <TextBlock Text="円" VerticalAlignment="Center" Margin="5,0,0,0"
+                           FontSize="{DynamicResource BaseFontSize}"/>
+            </StackPanel>
+
+            <!-- 残高 -->
+            <TextBlock Grid.Row="4" Grid.Column="0"
+                       Text="残高:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBox Text="{Binding Balance, UpdateSourceTrigger=PropertyChanged}"
+                         FontSize="{DynamicResource BaseFontSize}"
+                         Padding="10,6"
+                         Width="120"
+                         IsEnabled="{Binding IsAutoBalance, Converter={StaticResource InvertBoolConverter}}"
+                         AutomationProperties.Name="残高"
+                         ToolTip="残高（自動計算ONの場合は自動で計算されます）"/>
+                <TextBlock Text="円" VerticalAlignment="Center" Margin="5,0,0,0"
+                           FontSize="{DynamicResource BaseFontSize}"/>
+                <CheckBox Content="自動計算"
+                          IsChecked="{Binding IsAutoBalance}"
+                          VerticalAlignment="Center"
+                          Margin="15,0,0,0"
+                          FontSize="{DynamicResource BaseFontSize}"
+                          AutomationProperties.Name="残高を自動計算"
+                          ToolTip="ONにすると、前行の残高 + 受入 - 払出 で自動計算されます"/>
+            </StackPanel>
+
+            <!-- 利用者 -->
+            <TextBlock Grid.Row="5" Grid.Column="0"
+                       Text="利用者:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,0,8"/>
+            <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+                <ComboBox ItemsSource="{Binding StaffList}"
+                          SelectedItem="{Binding SelectedStaff}"
+                          DisplayMemberPath="Name"
+                          FontSize="{DynamicResource BaseFontSize}"
+                          MinWidth="150"
+                          AutomationProperties.Name="利用者を選択"
+                          ToolTip="利用者を選択（任意）"/>
+                <Button Content="×"
+                        Command="{Binding ClearStaffCommand}"
+                        FontSize="{DynamicResource BaseFontSize}"
+                        Padding="6,1"
+                        Margin="4,0,0,0"
+                        VerticalAlignment="Center"
+                        AutomationProperties.Name="利用者をクリア"
+                        ToolTip="利用者の選択を解除して空欄にします"/>
+            </StackPanel>
+
+            <!-- 備考 -->
+            <TextBlock Grid.Row="6" Grid.Column="0"
+                       Text="備考:"
+                       FontSize="{DynamicResource BaseFontSize}"
+                       VerticalAlignment="Top"
+                       Margin="0,6,0,0"/>
+            <TextBox Grid.Row="6" Grid.Column="1"
+                     Text="{Binding Note, UpdateSourceTrigger=PropertyChanged}"
+                     FontSize="{DynamicResource BaseFontSize}"
+                     Padding="10,6"
+                     TextWrapping="Wrap"
+                     AcceptsReturn="True"
+                     MinHeight="50"
+                     AutomationProperties.Name="備考"
+                     ToolTip="備考（任意）"/>
+        </Grid>
+
+        <!-- 挿入位置プレビュー（Addモードのみ） -->
+        <Border Grid.Row="1"
+                Background="#F5F5F5"
+                CornerRadius="4"
+                Padding="10"
+                Margin="0,5,0,5"
+                Visibility="{Binding IsAddMode, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel>
+                <TextBlock Text="■ 挿入位置プレビュー"
+                           FontWeight="Bold"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           Margin="0,0,0,5"/>
+
+                <ItemsControl x:Name="InsertPreviewList" ItemsSource="{Binding ContextRows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock FontSize="{DynamicResource SmallFontSize}"
+                                       FontFamily="Consolas, MS Gothic"
+                                       Margin="5,1">
+                                <Run Text="{Binding DateDisplay, Mode=OneWay}"/>
+                                <Run Text="  "/>
+                                <Run Text="{Binding Summary, Mode=OneWay}"/>
+                                <Run Text="  "/>
+                                <Run Text="{Binding BalanceDisplay, Mode=OneWay}"/>
+                            </TextBlock>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- 挿入位置マーカー -->
+                <Border Background="#FFF3E0" CornerRadius="4" Padding="8,4" Margin="0,3">
+                    <TextBlock Text="▶▶▶ ここに挿入 ◀◀◀"
+                               Foreground="#E65100"
+                               FontWeight="Bold"
+                               FontSize="{DynamicResource BaseFontSize}"
+                               HorizontalAlignment="Center"/>
+                </Border>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,0">
+                    <Button Content="▲ 上へ"
+                            Command="{Binding MoveInsertPositionUpCommand}"
+                            Padding="12,4"
+                            Margin="0,0,10,0"
+                            AutomationProperties.Name="挿入位置を上へ"
+                            ToolTip="挿入位置を1つ上に移動"/>
+                    <Button Content="▼ 下へ"
+                            Command="{Binding MoveInsertPositionDownCommand}"
+                            Padding="12,4"
+                            AutomationProperties.Name="挿入位置を下へ"
+                            ToolTip="挿入位置を1つ下に移動"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <!-- 警告表示エリア -->
+        <StackPanel Grid.Row="2" Margin="0,5,0,5">
+            <!-- バリデーションエラー -->
+            <TextBlock Text="{Binding ValidationMessage}"
+                       Foreground="#D32F2F"
+                       FontSize="{DynamicResource SmallFontSize}"
+                       FontWeight="Bold">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Visible"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ValidationMessage}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+
+            <!-- 警告メッセージ -->
+            <Border Background="#FFF3E0"
+                    CornerRadius="4"
+                    Padding="10,5"
+                    Margin="0,3,0,0">
+                <TextBlock Text="{Binding WarningMessage}"
+                           Foreground="#E65100"
+                           FontSize="{DynamicResource SmallFontSize}">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Visible"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding WarningMessage}" Value="">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Visible"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding WarningMessage}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
+
+            <!-- ステータスメッセージ -->
+            <TextBlock Text="{Binding StatusMessage}"
+                       Foreground="#D32F2F"
+                       FontSize="{DynamicResource SmallFontSize}">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Visible"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding StatusMessage}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </StackPanel>
+
+        <!-- ボタン -->
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,10,0,0">
+            <Button Content="キャンセル"
+                    Command="{Binding CancelCommand}"
+                    Click="CancelButton_Click"
+                    Padding="20,10"
+                    Margin="0,0,10,0"
+                    IsCancel="True"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    AutomationProperties.Name="キャンセル"
+                    ToolTip="変更を破棄してダイアログを閉じる (Escape)"/>
+            <Button Content="保存"
+                    Command="{Binding SaveCommand}"
+                    IsEnabled="{Binding CanSave}"
+                    Padding="25,10"
+                    Background="#4CAF50"
+                    Foreground="White"
+                    IsDefault="True"
+                    FontSize="{DynamicResource BaseFontSize}"
+                    AutomationProperties.Name="保存"
+                    ToolTip="保存 (Enter)"/>
+        </StackPanel>
+
+        <!-- 処理中オーバーレイ -->
+        <Border Grid.RowSpan="5"
+                Background="#80000000"
+                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="200" Height="4"/>
+                <TextBlock Text="{Binding BusyMessage}"
+                           Foreground="White"
+                           FontSize="{DynamicResource BaseFontSize}"
+                           Margin="0,10,0,0"
+                           HorizontalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using ICCardManager.Dtos;
+using ICCardManager.ViewModels;
+
+namespace ICCardManager.Views.Dialogs
+{
+    /// <summary>
+    /// 履歴行の追加/全項目修正ダイアログ（Issue #635）
+    /// </summary>
+    public partial class LedgerRowEditDialog : Window
+    {
+        private readonly LedgerRowEditViewModel _viewModel;
+
+        public LedgerRowEditDialog(LedgerRowEditViewModel viewModel)
+        {
+            InitializeComponent();
+
+            _viewModel = viewModel;
+            DataContext = _viewModel;
+
+            // 保存完了時に自動的に閉じる
+            _viewModel.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(LedgerRowEditViewModel.IsSaved) && _viewModel.IsSaved)
+                {
+                    DialogResult = true;
+                    Close();
+                }
+            };
+        }
+
+        /// <summary>
+        /// 追加モードで初期化
+        /// </summary>
+        /// <param name="cardIdm">対象カードIDm</param>
+        /// <param name="allLedgers">表示中の全履歴</param>
+        /// <param name="operatorIdm">認証済み職員IDm</param>
+        public async Task InitializeForAddAsync(string cardIdm, List<LedgerDto> allLedgers, string operatorIdm)
+        {
+            await _viewModel.InitializeForAddAsync(cardIdm, allLedgers, operatorIdm);
+        }
+
+        /// <summary>
+        /// 編集モードで初期化
+        /// </summary>
+        /// <param name="ledgerDto">編集対象</param>
+        /// <param name="operatorIdm">認証済み職員IDm</param>
+        public async Task InitializeForEditAsync(LedgerDto ledgerDto, string operatorIdm)
+        {
+            await _viewModel.InitializeForEditAsync(ledgerDto, operatorIdm);
+        }
+
+        /// <summary>
+        /// キャンセルボタンクリック
+        /// </summary>
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -308,6 +308,15 @@
                                         Padding="12,6"
                                         ToolTip="任意の年月を選択"/>
 
+                                <!-- 行操作ボタン（Issue #635） -->
+                                <Border Width="1" Background="#BDBDBD" Margin="10,2"/>
+                                <Button Content="＋ 行を追加"
+                                        Command="{Binding AddLedgerRowCommand}"
+                                        Padding="12,6"
+                                        ToolTip="履歴に新しい行を挿入します"
+                                        AutomationProperties.Name="履歴行を追加"
+                                        AutomationProperties.HelpText="手動で履歴行を追加します（日付・摘要・金額等を入力）"/>
+
                                 <!-- 統合ボタン（Issue #548） -->
                                 <Border Width="1" Background="#BDBDBD" Margin="10,2"/>
                                 <Button Content="📦 チェックした履歴を統合"
@@ -432,7 +441,7 @@
                                 </DataGridTextColumn>
                                 <DataGridTextColumn Header="利用者" Binding="{Binding StaffName}" Width="80"/>
                                 <DataGridTextColumn Header="備考" Binding="{Binding Note}" Width="80"/>
-                                <DataGridTemplateColumn Header="操作" Width="110">
+                                <DataGridTemplateColumn Header="操作" Width="210">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -441,13 +450,26 @@
                                                         CommandParameter="{Binding}"
                                                         IsEnabled="{Binding HasDetails}"
                                                         Padding="8,2"
-                                                        Margin="0,0,5,0"
+                                                        Margin="0,0,3,0"
                                                         ToolTip="利用詳細を表示"/>
                                                 <Button Content="変更"
                                                         Command="{Binding DataContext.EditLedgerCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                                         CommandParameter="{Binding}"
                                                         Padding="8,2"
-                                                        ToolTip="履歴内容を変更"/>
+                                                        Margin="0,0,3,0"
+                                                        ToolTip="摘要・備考・利用者を変更"/>
+                                                <Button Content="修正"
+                                                        Command="{Binding DataContext.EditLedgerFullCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                        CommandParameter="{Binding}"
+                                                        Padding="8,2"
+                                                        Margin="0,0,3,0"
+                                                        ToolTip="全項目（日付・金額含む）を修正"/>
+                                                <Button Content="削除"
+                                                        Command="{Binding DataContext.DeleteLedgerRowCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                                        CommandParameter="{Binding}"
+                                                        Padding="8,2"
+                                                        Foreground="#D32F2F"
+                                                        ToolTip="この行を削除"/>
                                             </StackPanel>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerConsistencyCheckerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerConsistencyCheckerTests.cs
@@ -1,0 +1,229 @@
+using FluentAssertions;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Moq;
+using Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// LedgerConsistencyCheckerの単体テスト（Issue #635）
+/// </summary>
+public class LedgerConsistencyCheckerTests
+{
+    private readonly Mock<ILedgerRepository> _ledgerRepoMock;
+    private readonly LedgerConsistencyChecker _checker;
+
+    private const string TestCardIdm = "0102030405060708";
+
+    public LedgerConsistencyCheckerTests()
+    {
+        _ledgerRepoMock = new Mock<ILedgerRepository>();
+        _checker = new LedgerConsistencyChecker(_ledgerRepoMock.Object);
+    }
+
+    #region CheckConsistency（同期版・内部ロジック）
+
+    [Fact]
+    public void CheckConsistency_EmptyList_ReturnsConsistent()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>();
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, DateTime.Today);
+
+        // Assert
+        result.IsConsistent.Should().BeTrue();
+        result.Inconsistencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckConsistency_SingleRow_ReturnsConsistent()
+    {
+        // Arrange: 1行だけなら前行がないのでチェックしない
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 1000, Expense = 0, Balance = 1000 }
+        };
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, DateTime.Today);
+
+        // Assert
+        result.IsConsistent.Should().BeTrue();
+        result.Inconsistencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckConsistency_ConsistentChain_ReturnsConsistent()
+    {
+        // Arrange: 正常な残高チェーン
+        //  Row1: Balance=1000 (チャージ1000円)
+        //  Row2: Balance=800  (1000 + 0 - 200 = 800)
+        //  Row3: Balance=580  (800 + 0 - 220 = 580)
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 1000, Expense = 0, Balance = 1000, Date = new DateTime(2026, 1, 1) },
+            new Ledger { Id = 2, Income = 0, Expense = 200, Balance = 800, Date = new DateTime(2026, 1, 2) },
+            new Ledger { Id = 3, Income = 0, Expense = 220, Balance = 580, Date = new DateTime(2026, 1, 3) }
+        };
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, new DateTime(2026, 1, 1));
+
+        // Assert
+        result.IsConsistent.Should().BeTrue();
+        result.Inconsistencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckConsistency_InconsistentChain_DetectsInconsistency()
+    {
+        // Arrange: 2行目の残高が不整合（期待値800だが750になっている）
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 1000, Expense = 0, Balance = 1000, Date = new DateTime(2026, 1, 1) },
+            new Ledger { Id = 2, Income = 0, Expense = 200, Balance = 750, Date = new DateTime(2026, 1, 2) },
+            new Ledger { Id = 3, Income = 0, Expense = 220, Balance = 530, Date = new DateTime(2026, 1, 3) }
+        };
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, new DateTime(2026, 1, 1));
+
+        // Assert
+        result.IsConsistent.Should().BeFalse();
+        result.Inconsistencies.Should().HaveCount(1);
+        result.Inconsistencies[0].LedgerId.Should().Be(2);
+        result.Inconsistencies[0].ExpectedBalance.Should().Be(800);
+        result.Inconsistencies[0].ActualBalance.Should().Be(750);
+    }
+
+    [Fact]
+    public void CheckConsistency_MultipleInconsistencies_DetectsAll()
+    {
+        // Arrange: 2行目と3行目両方不整合
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 1000, Expense = 0, Balance = 1000, Date = new DateTime(2026, 1, 1) },
+            new Ledger { Id = 2, Income = 0, Expense = 200, Balance = 750, Date = new DateTime(2026, 1, 2) },
+            new Ledger { Id = 3, Income = 0, Expense = 100, Balance = 700, Date = new DateTime(2026, 1, 3) }
+        };
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, new DateTime(2026, 1, 1));
+
+        // Assert
+        result.IsConsistent.Should().BeFalse();
+        // Row2: expected 1000+0-200=800, actual 750 → 不整合
+        // Row3: expected 750+0-100=650, actual 700 → 不整合
+        result.Inconsistencies.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void CheckConsistency_WithChargeAndUsage_ConsistentChain()
+    {
+        // Arrange: チャージと利用が混在する正常チェーン
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 0, Expense = 0, Balance = 500, Date = new DateTime(2026, 1, 1) },   // 繰越
+            new Ledger { Id = 2, Income = 3000, Expense = 0, Balance = 3500, Date = new DateTime(2026, 1, 5) }, // チャージ
+            new Ledger { Id = 3, Income = 0, Expense = 210, Balance = 3290, Date = new DateTime(2026, 1, 10) }  // 利用
+        };
+
+        // Act
+        var result = _checker.CheckConsistency(ledgers, TestCardIdm, new DateTime(2026, 1, 1));
+
+        // Assert
+        result.IsConsistent.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region RecalculateBalancesAsync
+
+    [Fact]
+    public async Task RecalculateBalancesAsync_FixesInconsistentBalances()
+    {
+        // Arrange
+        var fromDate = new DateTime(2026, 1, 1);
+        var toDate = new DateTime(2026, 1, 31);
+
+        // 前月残高
+        _ledgerRepoMock.Setup(r => r.GetLatestBeforeDateAsync(TestCardIdm, fromDate))
+            .ReturnsAsync(new Ledger { Balance = 500 });
+
+        // 不整合のある行データ
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 3000, Expense = 0, Balance = 3500, Date = new DateTime(2026, 1, 5) },
+            new Ledger { Id = 2, Income = 0, Expense = 210, Balance = 3000, Date = new DateTime(2026, 1, 10) }  // 期待値3290
+        };
+
+        _ledgerRepoMock.Setup(r => r.GetByDateRangeAsync(TestCardIdm, fromDate, toDate))
+            .ReturnsAsync(ledgers);
+        _ledgerRepoMock.Setup(r => r.UpdateAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var fixedCount = await _checker.RecalculateBalancesAsync(TestCardIdm, fromDate, toDate);
+
+        // Assert
+        fixedCount.Should().Be(1, "2行目の残高だけ不整合");
+        ledgers[1].Balance.Should().Be(3290);
+        _ledgerRepoMock.Verify(r => r.UpdateAsync(It.Is<Ledger>(l => l.Id == 2)), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecalculateBalancesAsync_NoPreviousLedger_StartsFromZero()
+    {
+        // Arrange: 前月データなし
+        var fromDate = new DateTime(2026, 1, 1);
+        var toDate = new DateTime(2026, 1, 31);
+
+        _ledgerRepoMock.Setup(r => r.GetLatestBeforeDateAsync(TestCardIdm, fromDate))
+            .ReturnsAsync((Ledger)null);
+
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 1, Income = 1000, Expense = 0, Balance = 999, Date = new DateTime(2026, 1, 1) }
+        };
+
+        _ledgerRepoMock.Setup(r => r.GetByDateRangeAsync(TestCardIdm, fromDate, toDate))
+            .ReturnsAsync(ledgers);
+        _ledgerRepoMock.Setup(r => r.UpdateAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var fixedCount = await _checker.RecalculateBalancesAsync(TestCardIdm, fromDate, toDate);
+
+        // Assert
+        fixedCount.Should().Be(1);
+        ledgers[0].Balance.Should().Be(1000, "前残高0 + 1000 - 0 = 1000");
+    }
+
+    [Fact]
+    public async Task RecalculateBalancesAsync_EmptyList_ReturnsZero()
+    {
+        // Arrange
+        var fromDate = new DateTime(2026, 1, 1);
+        var toDate = new DateTime(2026, 1, 31);
+
+        _ledgerRepoMock.Setup(r => r.GetByDateRangeAsync(TestCardIdm, fromDate, toDate))
+            .ReturnsAsync(new List<Ledger>());
+
+        // Act
+        var fixedCount = await _checker.RecalculateBalancesAsync(TestCardIdm, fromDate, toDate);
+
+        // Assert
+        fixedCount.Should().Be(0);
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerRowEditViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerRowEditViewModelTests.cs
@@ -1,0 +1,479 @@
+using FluentAssertions;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Dtos;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using ICCardManager.ViewModels;
+using Moq;
+using Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// LedgerRowEditViewModelの単体テスト（Issue #635）
+/// </summary>
+public class LedgerRowEditViewModelTests
+{
+    private readonly Mock<ILedgerRepository> _ledgerRepoMock;
+    private readonly Mock<IStaffRepository> _staffRepoMock;
+    private readonly Mock<IOperationLogRepository> _operationLogRepoMock;
+    private readonly OperationLogger _operationLogger;
+    private readonly LedgerRowEditViewModel _viewModel;
+
+    private const string TestCardIdm = "0102030405060708";
+    private const string TestOperatorIdm = "FFFF000000000001";
+
+    private readonly Staff _staffA = new Staff { StaffIdm = "AAAA000000000001", Name = "田中太郎" };
+    private readonly Staff _staffB = new Staff { StaffIdm = "BBBB000000000002", Name = "山田花子" };
+
+    public LedgerRowEditViewModelTests()
+    {
+        _ledgerRepoMock = new Mock<ILedgerRepository>();
+        _staffRepoMock = new Mock<IStaffRepository>();
+        _operationLogRepoMock = new Mock<IOperationLogRepository>();
+        _operationLogger = new OperationLogger(
+            _operationLogRepoMock.Object,
+            _staffRepoMock.Object);
+
+        _staffRepoMock.Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new List<Staff> { _staffA, _staffB });
+
+        _viewModel = new LedgerRowEditViewModel(
+            _ledgerRepoMock.Object,
+            _staffRepoMock.Object,
+            _operationLogger);
+    }
+
+    /// <summary>
+    /// テスト用の履歴行リストを作成
+    /// </summary>
+    private List<LedgerDto> CreateTestLedgers()
+    {
+        return new List<LedgerDto>
+        {
+            new LedgerDto
+            {
+                Id = 1, CardIdm = TestCardIdm,
+                Date = new DateTime(2026, 1, 10), DateDisplay = "R8.1.10",
+                Summary = "鉄道（天神～博多）", Income = 0, Expense = 210, Balance = 2300
+            },
+            new LedgerDto
+            {
+                Id = 2, CardIdm = TestCardIdm,
+                Date = new DateTime(2026, 1, 10), DateDisplay = "R8.1.10",
+                Summary = "鉄道（博多～天神）", Income = 0, Expense = 210, Balance = 2090
+            },
+            new LedgerDto
+            {
+                Id = 3, CardIdm = TestCardIdm,
+                Date = new DateTime(2026, 1, 11), DateDisplay = "R8.1.11",
+                Summary = "鉄道（天神～六本松）", Income = 0, Expense = 200, Balance = 1890
+            }
+        };
+    }
+
+    #region Addモード初期化
+
+    [Fact]
+    public async Task InitializeForAdd_SetsAddMode()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+
+        // Act
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Assert
+        _viewModel.Mode.Should().Be(LedgerRowEditMode.Add);
+        _viewModel.DialogTitle.Should().Be("履歴行の追加");
+        _viewModel.IsAddMode.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InitializeForAdd_LoadsStaffList()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+
+        // Act
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Assert
+        _viewModel.StaffList.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task InitializeForAdd_SetsInsertIndexToEnd()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+
+        // Act
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Assert
+        _viewModel.InsertIndex.Should().Be(3, "末尾に挿入");
+    }
+
+    #endregion
+
+    #region Addモード: 残高自動計算
+
+    [Fact]
+    public async Task AddMode_AutoBalance_CalculatesFromPreviousRow()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 受入3000円を設定
+        _viewModel.Income = 3000;
+        _viewModel.Expense = 0;
+
+        // Assert: 前行の残高1890 + 3000 - 0 = 4890
+        _viewModel.PreviousBalance.Should().Be(1890);
+        _viewModel.Balance.Should().Be(4890);
+    }
+
+    [Fact]
+    public async Task AddMode_AutoBalance_UpdatesWhenExpenseChanges()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 払出200円を設定
+        _viewModel.Income = 0;
+        _viewModel.Expense = 200;
+
+        // Assert: 1890 + 0 - 200 = 1690
+        _viewModel.Balance.Should().Be(1690);
+    }
+
+    [Fact]
+    public async Task AddMode_ManualBalance_DoesNotAutoCalculate()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 自動計算をOFF → 手動入力
+        _viewModel.IsAutoBalance = false;
+        _viewModel.Balance = 9999;
+        _viewModel.Income = 100;
+
+        // Assert: 手動入力の値が維持される（自動計算されない）
+        _viewModel.Balance.Should().Be(9999);
+    }
+
+    #endregion
+
+    #region Addモード: 挿入位置の移動
+
+    [Fact]
+    public async Task AddMode_MoveUp_DecrementsInsertIndex()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+        _viewModel.InsertIndex.Should().Be(3);
+
+        // Act
+        _viewModel.MoveInsertPositionUpCommand.Execute(null);
+
+        // Assert
+        _viewModel.InsertIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AddMode_MoveDown_AtEnd_DoesNotExceedCount()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+        _viewModel.InsertIndex.Should().Be(3);
+
+        // Act: 既に末尾なので下に移動しても変わらない
+        _viewModel.MoveInsertPositionDownCommand.Execute(null);
+
+        // Assert
+        _viewModel.InsertIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task AddMode_MoveUp_RecalculatesBalance()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+        _viewModel.Expense = 100;
+
+        // 初期状態: InsertIndex=3, PreviousBalance=1890, Balance=1790
+        _viewModel.Balance.Should().Be(1790);
+
+        // Act: 1つ上に移動 → InsertIndex=2, PreviousBalance=2090
+        _viewModel.MoveInsertPositionUpCommand.Execute(null);
+
+        // Assert
+        _viewModel.InsertIndex.Should().Be(2);
+        _viewModel.PreviousBalance.Should().Be(2090);
+        _viewModel.Balance.Should().Be(1990, "2090 + 0 - 100 = 1990");
+    }
+
+    #endregion
+
+    #region Editモード初期化
+
+    [Fact]
+    public async Task InitializeForEdit_SetsEditMode()
+    {
+        // Arrange
+        var ledger = new Ledger
+        {
+            Id = 1, CardIdm = TestCardIdm,
+            Date = new DateTime(2026, 1, 10),
+            Summary = "鉄道（天神～博多）",
+            Income = 0, Expense = 210, Balance = 2300,
+            LenderIdm = _staffA.StaffIdm,
+            StaffName = _staffA.Name,
+            Note = "テスト備考"
+        };
+        _ledgerRepoMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(ledger);
+
+        var dto = new LedgerDto
+        {
+            Id = 1, CardIdm = TestCardIdm,
+            Date = new DateTime(2026, 1, 10), DateDisplay = "R8.1.10",
+            Summary = "鉄道（天神～博多）",
+            Income = 0, Expense = 210, Balance = 2300,
+            StaffName = _staffA.Name, Note = "テスト備考"
+        };
+
+        // Act
+        await _viewModel.InitializeForEditAsync(dto, TestOperatorIdm);
+
+        // Assert
+        _viewModel.Mode.Should().Be(LedgerRowEditMode.Edit);
+        _viewModel.DialogTitle.Should().Be("履歴行の修正");
+        _viewModel.IsAddMode.Should().BeFalse();
+        _viewModel.Summary.Should().Be("鉄道（天神～博多）");
+        _viewModel.Income.Should().Be(0);
+        _viewModel.Expense.Should().Be(210);
+        _viewModel.Balance.Should().Be(2300);
+        _viewModel.Note.Should().Be("テスト備考");
+        _viewModel.SelectedStaff.Should().NotBeNull();
+        _viewModel.SelectedStaff!.StaffIdm.Should().Be(_staffA.StaffIdm);
+    }
+
+    #endregion
+
+    #region バリデーション
+
+    [Fact]
+    public async Task Validation_EmptySummary_CannotSave()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 摘要を空にする
+        _viewModel.Summary = "";
+
+        // Assert
+        _viewModel.CanSave.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("摘要");
+    }
+
+    [Fact]
+    public async Task Validation_NegativeBalance_CannotSave()
+    {
+        // Arrange
+        var allLedgers = new List<LedgerDto>
+        {
+            new LedgerDto { Id = 1, Date = new DateTime(2026, 1, 1), Balance = 100 }
+        };
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: PreviousBalance=100, Expense=200 → Balance=-100
+        _viewModel.Summary = "テスト";
+        _viewModel.Income = 0;
+        _viewModel.Expense = 200;
+
+        // Assert
+        _viewModel.CanSave.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("マイナス");
+    }
+
+    [Fact]
+    public async Task Validation_NegativeIncome_CannotSave()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act
+        _viewModel.Summary = "テスト";
+        _viewModel.Income = -100;
+
+        // Assert
+        _viewModel.CanSave.Should().BeFalse();
+        _viewModel.ValidationMessage.Should().Contain("受入");
+    }
+
+    [Fact]
+    public async Task Validation_BothZeroAmount_ShowsWarning()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 受入・払出ともに0
+        _viewModel.Summary = "テスト";
+        _viewModel.Income = 0;
+        _viewModel.Expense = 0;
+
+        // Assert: 警告は出るがCanSaveはtrue
+        _viewModel.CanSave.Should().BeTrue();
+        _viewModel.WarningMessage.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Validation_CarryoverWithZeroAmount_NoWarning()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        // Act: 繰越は受入・払出0でもOK
+        _viewModel.Summary = "3月から繰越";
+        _viewModel.Income = 0;
+        _viewModel.Expense = 0;
+
+        // Assert
+        _viewModel.CanSave.Should().BeTrue();
+        _viewModel.WarningMessage.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region 保存処理
+
+    [Fact]
+    public async Task SaveAdd_CallsInsertAsync()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        _viewModel.Summary = "鉄道（博多～天神）";
+        _viewModel.Income = 0;
+        _viewModel.Expense = 210;
+
+        _ledgerRepoMock.Setup(r => r.InsertAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(100);
+
+        // Act
+        await _viewModel.SaveCommand.ExecuteAsync(null);
+
+        // Assert
+        _viewModel.IsSaved.Should().BeTrue();
+        _ledgerRepoMock.Verify(r => r.InsertAsync(It.Is<Ledger>(l =>
+            l.CardIdm == TestCardIdm &&
+            l.Summary == "鉄道（博多～天神）" &&
+            l.Expense == 210
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAdd_LogsOperation()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        _viewModel.Summary = "テスト摘要";
+        _viewModel.Income = 500;
+
+        _ledgerRepoMock.Setup(r => r.InsertAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(100);
+
+        _staffRepoMock.Setup(r => r.GetByIdmAsync(TestOperatorIdm, It.IsAny<bool>()))
+            .ReturnsAsync(new Staff { StaffIdm = TestOperatorIdm, Name = "操作者" });
+
+        // Act
+        await _viewModel.SaveCommand.ExecuteAsync(null);
+
+        // Assert: 操作ログが記録される
+        _operationLogRepoMock.Verify(r => r.InsertAsync(It.Is<OperationLog>(log =>
+            log.Action == OperationLogger.Actions.Insert &&
+            log.TargetTable == OperationLogger.Tables.Ledger
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveEdit_CallsUpdateAsync()
+    {
+        // Arrange
+        var ledger = new Ledger
+        {
+            Id = 1, CardIdm = TestCardIdm,
+            Date = new DateTime(2026, 1, 10),
+            Summary = "元の摘要",
+            Income = 0, Expense = 210, Balance = 2300,
+            LenderIdm = _staffA.StaffIdm,
+            StaffName = _staffA.Name
+        };
+        _ledgerRepoMock.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(ledger);
+        _ledgerRepoMock.Setup(r => r.UpdateAsync(It.IsAny<Ledger>())).ReturnsAsync(true);
+
+        _staffRepoMock.Setup(r => r.GetByIdmAsync(TestOperatorIdm, It.IsAny<bool>()))
+            .ReturnsAsync(new Staff { StaffIdm = TestOperatorIdm, Name = "操作者" });
+
+        var dto = new LedgerDto
+        {
+            Id = 1, CardIdm = TestCardIdm,
+            Date = new DateTime(2026, 1, 10), DateDisplay = "R8.1.10",
+            Summary = "元の摘要", Income = 0, Expense = 210, Balance = 2300,
+            StaffName = _staffA.Name
+        };
+        await _viewModel.InitializeForEditAsync(dto, TestOperatorIdm);
+
+        // Act: 摘要を変更して保存
+        _viewModel.Summary = "変更後の摘要";
+        await _viewModel.SaveCommand.ExecuteAsync(null);
+
+        // Assert
+        _viewModel.IsSaved.Should().BeTrue();
+        _ledgerRepoMock.Verify(r => r.UpdateAsync(It.Is<Ledger>(l =>
+            l.Summary == "変更後の摘要"
+        )), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAdd_InsertFails_ShowsError()
+    {
+        // Arrange
+        var allLedgers = CreateTestLedgers();
+        await _viewModel.InitializeForAddAsync(TestCardIdm, allLedgers, TestOperatorIdm);
+
+        _viewModel.Summary = "テスト";
+        _viewModel.Income = 500;
+
+        _ledgerRepoMock.Setup(r => r.InsertAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(0); // 失敗
+
+        // Act
+        await _viewModel.SaveCommand.ExecuteAsync(null);
+
+        // Assert
+        _viewModel.IsSaved.Should().BeFalse();
+        _viewModel.StatusMessage.Should().Contain("失敗");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- 履歴画面から直接行の追加・削除・全項目修正を行えるようにした
- 残高チェーンの整合性チェック＆自動修正機能を実装
- 単体テスト28件を追加（全1,208件パス）

## 変更内容

### 新規ファイル
| ファイル | 内容 |
|----------|------|
| `Services/LedgerConsistencyChecker.cs` | 残高チェーン整合性チェック＆再計算サービス |
| `ViewModels/LedgerRowEditViewModel.cs` | 行追加/全項目編集ダイアログのViewModel（Add/Editデュアルモード） |
| `Views/Dialogs/LedgerRowEditDialog.xaml` | ダイアログUI（挿入位置プレビュー、自動残高計算、バリデーション） |
| `Views/Dialogs/LedgerRowEditDialog.xaml.cs` | ダイアログ code-behind |
| `Tests/Services/LedgerConsistencyCheckerTests.cs` | 整合性チェッカーの単体テスト（8件） |
| `Tests/ViewModels/LedgerRowEditViewModelTests.cs` | ViewModelの単体テスト（20件） |

### 変更ファイル
| ファイル | 内容 |
|----------|------|
| `Services/OperationLogger.cs` | `LogLedgerInsertAsync` メソッド追加 |
| `ViewModels/MainViewModel.cs` | `AddLedgerRow` / `DeleteLedgerRow` / `EditLedgerFull` コマンド追加 |
| `Views/MainWindow.xaml` | ツールバーに「＋ 行を追加」ボタン、各行に「修正」「削除」ボタン追加 |
| `App.xaml.cs` | DI登録追加 |

## 主な機能
1. **行の追加**: 日付・摘要・金額を入力、挿入位置プレビューで位置確認＆上下移動、残高自動計算
2. **行の削除**: 確認ダイアログ付き（貸出中レコードは削除不可）
3. **全項目修正**: 日付・金額含む全フィールドを変更可能
4. **残高整合性チェック**: 追加・削除・修正後に自動チェック、不整合があれば自動修正を提案
5. **認証**: 各操作で職員証認証が必要

## Test plan
- [x] `LedgerConsistencyChecker` の単体テスト（8件）がパスすること
- [x] `LedgerRowEditViewModel` の単体テスト（20件）がパスすること
- [x] 既存テスト（1,180件）に影響がないこと
- [x] 行追加: 履歴画面 →「行を追加」→ 各項目入力 → 挿入位置プレビュー確認 → 保存 → 一覧に反映
- [ ] 行削除: 履歴画面 → 行の「削除」→ 確認ダイアログ → 削除 → 一覧から消える
- [ ] 全項目修正: 履歴画面 → 行の「修正」→ 日付・金額を変更 → 保存 → 一覧に反映
- [ ] 残高整合性チェック: 行追加後に残高不整合 → 自動修正の確認ダイアログ → 修正実行
- [ ] 貸出中レコードの削除がブロックされること
- [ ] 各操作で職員証認証が必要であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)