### PR TITLE
fix: XMLドキュメントの不足paramタグを追加しCS1573警告を解消（#701）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -1905,7 +1905,11 @@ namespace ICCardManager.Services
         /// 履歴データの変更点を検出
         /// </summary>
         /// <param name="existingLedger">既存の履歴</param>
+        /// <param name="newDate">新しい日付</param>
         /// <param name="newSummary">新しい摘要</param>
+        /// <param name="newIncome">新しい受入金額</param>
+        /// <param name="newExpense">新しい払出金額</param>
+        /// <param name="newBalance">新しい残高</param>
         /// <param name="newStaffName">新しい利用者名</param>
         /// <param name="newNote">新しい備考</param>
         /// <param name="changes">変更点リスト（検出結果が追加される）</param>

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -331,6 +331,7 @@ namespace ICCardManager.Services
         /// <param name="staffIdm">返却者の職員証IDm（16桁の16進数文字列）</param>
         /// <param name="cardIdm">返却対象のICカードIDm（16桁の16進数文字列）</param>
         /// <param name="usageDetails">ICカードから読み取った利用履歴詳細（貸出時刻以降のみ使用）</param>
+        /// <param name="skipDuplicateCheck">重複チェックをスキップするかどうか（既定値: false）</param>
         /// <returns>返却結果。成功時は残額や警告情報も含まれます</returns>
         /// <remarks>
         /// <para>処理フロー：</para>


### PR DESCRIPTION
## Summary
- `CsvImportService.DetectLedgerChanges` に不足していた4つの `<param>` タグ（`newDate`, `newIncome`, `newExpense`, `newBalance`）を追加
- `LendingService.ReturnAsync` に不足していた1つの `<param>` タグ（`skipDuplicateCheck`）を追加
- これにより本体プロジェクトのCS1573警告が0件になりました

## Test plan
- [x] ビルドが成功し、CS1573警告が出ないことを確認
- [x] 全1,208テストがパスすることを確認

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)