### PR TITLE
feat: バス停名入力後にハイライト表示してから一覧削除（#709）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
@@ -66,6 +66,7 @@
 
         <!-- DataGrid -->
         <DataGrid Grid.Row="2"
+                  x:Name="BusStopDataGrid"
                   ItemsSource="{Binding Items}"
                   SelectedItem="{Binding SelectedItem}"
                   AutoGenerateColumns="False"

--- a/ICCardManager/src/ICCardManager/Views/Helpers/DataGridHighlightHelper.cs
+++ b/ICCardManager/src/ICCardManager/Views/Helpers/DataGridHighlightHelper.cs
@@ -25,7 +25,8 @@ namespace ICCardManager.Views.Helpers
         /// <param name="dataGrid">対象のDataGrid</param>
         /// <param name="item">ハイライト対象のアイテム</param>
         /// <param name="durationSeconds">フェードアウトの秒数（デフォルト2秒）</param>
-        public static void HighlightRow(DataGrid dataGrid, object item, double durationSeconds = 2.0)
+        /// <param name="onCompleted">アニメーション完了時のコールバック（省略可）</param>
+        public static void HighlightRow(DataGrid dataGrid, object item, double durationSeconds = 2.0, Action onCompleted = null)
         {
             // 選択を一旦解除して選択スタイルの干渉を防ぐ
             dataGrid.SelectedItem = null;
@@ -44,19 +45,19 @@ namespace ICCardManager.Views.Helpers
                     var retryRow = dataGrid.ItemContainerGenerator.ContainerFromItem(item) as DataGridRow;
                     if (retryRow != null)
                     {
-                        AnimateRow(retryRow, durationSeconds);
+                        AnimateRow(retryRow, durationSeconds, onCompleted);
                     }
                 }, DispatcherPriority.ContextIdle);
                 return;
             }
 
-            AnimateRow(row, durationSeconds);
+            AnimateRow(row, durationSeconds, onCompleted);
         }
 
         /// <summary>
         /// 行の背景色アニメーションを実行
         /// </summary>
-        private static void AnimateRow(DataGridRow row, double durationSeconds)
+        private static void AnimateRow(DataGridRow row, double durationSeconds, Action onCompleted = null)
         {
             var brush = new SolidColorBrush(HighlightColor);
             row.Background = brush;
@@ -68,7 +69,11 @@ namespace ICCardManager.Views.Helpers
                 Duration = new Duration(TimeSpan.FromSeconds(durationSeconds)),
                 EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseIn }
             };
-            animation.Completed += (s, e) => row.ClearValue(DataGridRow.BackgroundProperty);
+            animation.Completed += (s, e) =>
+            {
+                row.ClearValue(DataGridRow.BackgroundProperty);
+                onCompleted?.Invoke();
+            };
             brush.BeginAnimation(SolidColorBrush.ColorProperty, animation);
         }
     }


### PR DESCRIPTION
## Summary
- バス停名未入力一覧でバス停名を保存後、更新済み摘要を薄い黄色(#FFF9C4)で2秒間ハイライト表示してから一覧を再読み込み（入力済み項目が消える）するよう改善
- `DataGridHighlightHelper.HighlightRow` に `Action onCompleted` コールバックパラメータを追加（既存呼び出し元は変更不要）
- `IncompleteBusStopViewModel.UpdateItemSummaryAsync()` で DB から更新済み摘要を取得し `Items` コレクション内のアイテムを差し替え
- 摘要にまだ★が残る場合（一部のみ入力）は従来通り即座に一覧を再読み込み

## Test plan
- [x] ビルドが0エラーで成功すること
- [x] 全テスト（既存＋新規5件）がパスすること（1219件）
- [x] バス停名未入力一覧でバス停名を入力・保存 → 該当行の摘要が更新されハイライト表示 → 2秒後に一覧から削除されること
- [ ] 一部のバス停名のみ入力（★が残る場合） → 即座に一覧が再読み込みされること
- [ ] フィルタ設定中に保存 → ハイライト→削除後もフィルタ条件が維持されること

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)