### PR TITLE
fix: Releaseビルドで起動エラー時のスタックトレースを非表示にする（#716）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -134,7 +134,11 @@ namespace ICCardManager
             }
             catch (Exception ex)
             {
+#if DEBUG
                 var errorMessage = $"起動エラー: {ex.Message}\n\n{ex.StackTrace}";
+#else
+                var errorMessage = $"起動エラーが発生しました。\n\n{ex.Message}\n\n詳細はログファイルを確認してください。";
+#endif
 
                 // クリップボードにコピー可能なエラーダイアログを表示
                 var result = MessageBox.Show(


### PR DESCRIPTION
## Summary
- `App.xaml.cs` の起動エラーハンドラで、Releaseビルド時にスタックトレースをユーザーに表示しないよう修正
- `#if DEBUG` プリプロセッサディレクティブで分岐し、Release時は「詳細はログファイルを確認してください」と案内
- クリップボードコピー機能はDebug/Release両方で維持（Releaseでもex.Messageはコピー可能）

Closes #716

## Test plan
- [x] Debugビルドが0エラーで成功
- [x] Releaseビルドが0エラーで成功
- [x] 全1219テストがパス
- [ ] Debugビルドで起動エラーを発生させた場合、スタックトレースが表示されること
- [ ] Releaseビルドで起動エラーを発生させた場合、スタックトレースが表示されず「ログファイルを確認してください」と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)