### PR TITLE
perf: .Result呼び出しをasync/awaitに置換してデッドロックリスクを解消（#717）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -486,7 +486,7 @@ namespace ICCardManager
 
                 // VACUUM（月次実行）
                 var settingsRepository = ServiceProvider.GetRequiredService<ISettingsRepository>();
-                var settings = settingsRepository.GetAppSettingsAsync().Result;
+                var settings = settingsRepository.GetAppSettings();
 
                 var today = DateTime.Now;
                 if (today.Day >= 10)

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -509,10 +509,11 @@ public partial class MainViewModel : ViewModelBase
 
         await Task.WhenAll(settingsTask, cardsTask, balancesTask, staffTask);
 
-        var settings = settingsTask.Result;
-        var cards = cardsTask.Result;
-        var balances = balancesTask.Result;
-        var staffDict = staffTask.Result.ToDictionary(s => s.StaffIdm, s => s.Name);
+        // awaitを使用してデッドロックを防止（Task.WhenAll後でも.Resultは避ける）
+        var settings = await settingsTask;
+        var cards = await cardsTask;
+        var balances = await balancesTask;
+        var staffDict = (await staffTask).ToDictionary(s => s.StaffIdm, s => s.Name);
 
         var dashboardItems = new List<CardBalanceDashboardItem>();
 


### PR DESCRIPTION
## Summary
- **App.xaml.cs**: `settingsRepository.GetAppSettingsAsync().Result` → 同期版 `settingsRepository.GetAppSettings()` に置換
  - `OnStartup` → `PerformStartupTasks()` はUIスレッド上の同期呼び出しチェーンのため、同期版APIを使うのが正しい
  - `ISettingsRepository` に既に同期版 `GetAppSettings()` が用意されていた
- **MainViewModel.cs**: `Task.WhenAll` 後の4箇所の `.Result` → `await` に置換
  - `RefreshDashboardAsync()` は既に async メソッドなので、await を使うのが自然
  - 同ファイルの `HandleCardInStaffWaitingStateAsync()` では既にこのパターンで修正済みだった（コメント付き）

Closes #717

## Test plan
- [x] ビルドが0エラーで成功
- [x] 全1219テストがパス
- [x] アプリケーション起動が正常に完了すること（設定読み込み・VACUUM判定が動作すること）
- [ ] メイン画面のカード残高ダッシュボードが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)