### PR TITLE
fix: IncompleteBusStopDialogのCS4014警告を修正（#736）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
@@ -57,11 +57,11 @@ namespace ICCardManager.Views.Dialogs
                 if (updatedItem != null && !updatedItem.Summary.Contains("★"))
                 {
                     // 摘要が完全に更新された場合：ハイライト→2秒後に一覧から削除
-                    Dispatcher.InvokeAsync(() =>
+                    await Dispatcher.InvokeAsync(() =>
                     {
                         DataGridHighlightHelper.HighlightRow(BusStopDataGrid, updatedItem, 2.0, () =>
                         {
-                            Dispatcher.InvokeAsync(async () => await _viewModel.InitializeAsync());
+                            _ = Dispatcher.InvokeAsync(async () => await _viewModel.InitializeAsync());
                         });
                     }, DispatcherPriority.ContextIdle);
                 }


### PR DESCRIPTION
## Summary
- `IncompleteBusStopDialog.xaml.cs` の `Dispatcher.InvokeAsync()` 呼び出しに `await` を追加し、CS4014 警告を解消
- 内部のコールバックからの `Dispatcher.InvokeAsync()` にはディスカード (`_`) を使用して意図的な fire-and-forget であることを明示

Closes #736

## Test plan
- [x] `dotnet build` で CS4014 警告が出ないことを確認
- [x] 全 1248 テストパス
- [ ] 手動テスト: バス停名未入力一覧で「バス停名を入力」→入力完了後にハイライト→一覧から削除される動作が正常であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)