### PR TITLE
fix: 月次繰越行の受入金額欄を空欄に修正（#753）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -164,7 +164,7 @@ namespace ICCardManager.Services
                     {
                         DateDisplay = WarekiConverter.ToWareki(carryoverDate),
                         Summary = SummaryGenerator.GetCarryoverFromPreviousMonthSummary(previousMonth),
-                        Income = previousMonthBalance.Value,
+                        // Issue #753: 月次繰越の受入欄は空欄（受入金額を表示するのは4月の前年度繰越のみ）
                         Balance = previousMonthBalance.Value,
                         IsBold = true
                     });


### PR DESCRIPTION
## Summary
- `PrintService.cs` の月次繰越行（○月より繰越）で `Income = previousMonthBalance.Value` を設定していたのを除去
- 受入金額欄に値が入るのは **4月の前年度繰越行のみ** が正しい動作
- `ReportService.cs`（Excel出力）側は既に Issue #481 で修正済みだったが、`PrintService.cs`（履歴一覧・印刷プレビュー）側が未修正だった

### 修正前後の比較

| 行タイプ | 受入金額（修正前） | 受入金額（修正後） | 残額 |
|---|---|---|---|
| 4月：前年度より繰越 | 3,000 | 3,000 | 3,000 |
| 5月：4月より繰越 | ~~4,400~~ | **空欄** | 4,400 |
| 6月：5月より繰越 | ~~4,100~~ | **空欄** | 4,100 |

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `Services/PrintService.cs` | 月次繰越行の `Income` 設定を除去（`null` のまま） |
| `Tests/Services/PrintServiceTests.cs` | TC001の期待値を修正 + TC003b（新規テスト）を追加 |

## Test plan
- [x] 新規テスト TC003b: 月次繰越行の受入金額が null であることを検証
- [x] 既存テスト TC001: 期待値を `Be(4400)` → `BeNull()` に修正
- [x] 全1249テストパス
- [x] 手動確認: アプリで6月等を表示し、繰越行の受入金額欄が空欄であること
- [ ] 手動確認: 4月の前年度繰越行には受入金額が正しく表示されること
- [x] 手動確認: 帳票出力（Excel）でも同様に正しいこと

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)