### PR TITLE
fix: 履歴一覧の受入金額を緑色から黒色に変更（#749）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -413,7 +413,6 @@
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                                            <Setter Property="Foreground" Value="Green"/>
                                             <Setter Property="FontWeight" Value="Bold"/>
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>


### PR DESCRIPTION
## Summary
- 履歴一覧画面（MainWindow）の受入金額列から `Foreground="Green"` を削除し、デフォルトの黒色テキストに変更

## Changes
- `MainWindow.xaml`: 受入列の `ElementStyle` から `Foreground="Green"` Setter を削除（太字は維持）

## Test plan
- [x] 手動テスト: 履歴一覧画面で受入金額が黒色（太字）で表示されること
- [x] 手動テスト: 払出・残高など他の列の表示に影響がないこと

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)