### PR TITLE
fix: インポート後に履歴一覧・ダッシュボードを即座に更新（#744）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -182,6 +182,11 @@ public partial class DataExportImportViewModel : ViewModelBase
     private bool _isWaitingForCardTouch;
 
     /// <summary>
+    /// インポートが実行されたか（Issue #744: ダイアログ閉じた後のリフレッシュ判定用）
+    /// </summary>
+    public bool HasImported { get; private set; }
+
+    /// <summary>
     /// エクスポート用データタイプの選択肢
     /// </summary>
     public DataType[] ExportDataTypes { get; } = { DataType.Cards, DataType.Staff, DataType.Ledgers };
@@ -512,6 +517,12 @@ public partial class DataExportImportViewModel : ViewModelBase
 
                 LastImportedFile = ImportPreviewFile;
 
+                // Issue #744: インポート実行済みフラグを設定（ダイアログ終了後のリフレッシュ用）
+                if (result.ImportedCount > 0)
+                {
+                    HasImported = true;
+                }
+
                 if (result.Success)
                 {
                     var message = $"インポート完了: {result.ImportedCount}件を登録しました";
@@ -633,6 +644,12 @@ public partial class DataExportImportViewModel : ViewModelBase
                 }
 
                 LastImportedFile = dialog.FileName;
+
+                // Issue #744: インポート実行済みフラグを設定（ダイアログ終了後のリフレッシュ用）
+                if (result.ImportedCount > 0)
+                {
+                    HasImported = true;
+                }
 
                 if (result.Success)
                 {

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1914,11 +1914,22 @@ public partial class MainViewModel : ViewModelBase
     /// データエクスポート/インポート画面を開く
     /// </summary>
     [RelayCommand]
-    public void OpenDataExportImport()
+    public async Task OpenDataExportImportAsync()
     {
         var dialog = App.Current.ServiceProvider.GetRequiredService<Views.Dialogs.DataExportImportDialog>();
         dialog.Owner = System.Windows.Application.Current.MainWindow;
         dialog.ShowDialog();
+
+        // Issue #744: インポートが実行された場合、履歴一覧・ダッシュボードを即座に更新
+        var viewModel = (DataExportImportViewModel)dialog.DataContext;
+        if (viewModel.HasImported)
+        {
+            await RefreshDashboardAsync();
+            if (IsHistoryVisible)
+            {
+                await LoadHistoryLedgersAsync();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- 利用履歴をCSVインポートした後、メイン画面の履歴一覧とダッシュボード（カード残高一覧）が自動で再読み込みされるようにした
- `DataExportImportViewModel` に `HasImported` フラグを追加し、1件以上インポートされた場合に `true` を設定
- `MainViewModel.OpenDataExportImportAsync()` でダイアログ閉じた後に `HasImported` をチェックし、ダッシュボードと履歴を更新

## Changes
- `DataExportImportViewModel.cs`: `HasImported` プロパティ追加、`ExecuteImportAsync()` と `ImportAsync()` の両パスで `ImportedCount > 0` 時にフラグ設定
- `MainViewModel.cs`: `OpenDataExportImport()` を `OpenDataExportImportAsync()` に変更し、ダイアログ終了後に `RefreshDashboardAsync()` + `LoadHistoryLedgersAsync()` を実行
- `DataExportImportViewModelTests.cs`: `HasImported` フラグの5件のテストを追加

## Test plan
- [x] 単体テスト追加（5件）: HasImported フラグの初期値・成功時・0件時・一部エラー時・全件エラー時
- [ ] 手動テスト: 履歴一覧を表示した状態でCSVインポートを実行し、ダイアログを閉じた後に履歴が更新されること
- [ ] 手動テスト: ダッシュボードのカード残高がインポート後に更新されること
- [ ] 手動テスト: インポートせずにダイアログを閉じた場合、不要なリフレッシュが発生しないこと

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)