### PR TITLE
fix: 物品出納簿のドキュメントプロパティ日時を出力時に更新（#752）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -415,6 +415,15 @@ namespace ICCardManager.Services
                     // Issue #457: 印刷範囲を設定（全データを含む）
                     SetPrintArea(worksheet, currentRow, rowsOnCurrentPage, RowsPerPage);
 
+                    // Issue #752: ドキュメントプロパティの日時を更新
+                    // ClosedXMLはSaveAs時にCreated/Modifiedを自動更新しないため、明示的に設定する
+                    var now = DateTime.Now;
+                    if (!isExistingFile)
+                    {
+                        workbook.Properties.Created = now;
+                    }
+                    workbook.Properties.Modified = now;
+
                     // ファイルを保存
                     workbook.SaveAs(outputPath);
                 }


### PR DESCRIPTION
## Summary
- 物品出納簿（Excelファイル）の出力時に、ClosedXMLのドキュメントプロパティ（`Properties.Modified`/`Properties.Created`）を明示的に現在時刻に設定するよう修正
- ClosedXMLは `SaveAs()` 時にこれらのプロパティを自動更新しないため、既存ファイルを再出力した際に古い日時が残っていた

## Root Cause
ClosedXMLの `XLWorkbook.Properties.Modified` は、`SaveAs()` を呼んでも自動で更新されません。既存ファイルを開いて再保存した場合、前回保存時の `Modified` 日時がそのまま引き継がれるため、Excelの「ファイル情報」に表示される更新日時が古いままになっていました。

## Changes
- `ReportService.cs`: `SaveAs()` の前に `workbook.Properties.Modified = DateTime.Now` を設定。新規ファイル（テンプレートから作成）の場合は `Properties.Created` も設定
- `ReportServiceTests.cs`: 2件のテストを追加

## Test plan
- [x] 単体テスト追加（2件）:
  - 新規ファイル: Created/Modifiedが現在時刻に設定される
  - 既存ファイル再出力: Modifiedが現在時刻に更新される（Createdは維持）
- [ ] 手動テスト: 同じ月の帳票を2回出力し、Excelの「ファイル > 情報」で更新日時が2回目の出力時刻になっていること

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)