### PR TITLE
docs: 物品出納簿のExcel出力スクリーンショットを追加（#746）

### DIFF
--- a/ICCardManager/docs/manual/ユーザーマニュアル.md
+++ b/ICCardManager/docs/manual/ユーザーマニュアル.md
@@ -475,6 +475,8 @@
    - 作成されたファイルの一覧が表示されます
    - ファイル名をクリックすると直接開けます
 
+![物品出納簿（Excel出力例）](../screenshots/report_excel.png)
+
 ### 6.3 印刷プレビュー
 
 ![印刷プレビュー画面](../screenshots/print_preview.png)

--- a/ICCardManager/tools/TakeScreenshots.ps1
+++ b/ICCardManager/tools/TakeScreenshots.ps1
@@ -12,7 +12,7 @@
     必須画面（7枚）のみを取得します。
 
 .PARAMETER All
-    オプション画面も含むすべての画面（17枚）を取得します。
+    オプション画面も含むすべての画面（18枚）を取得します。
 
 .PARAMETER OutputDir
     出力先ディレクトリを指定します。デフォルトは docs/screenshots/ です。
@@ -264,6 +264,11 @@ $optionalScreens = @(
         Title = "帳票プレビュー画面"
         Instructions = "帳票作成画面で「プレビュー」ボタンをクリックし、プレビューが表示されたら"
         ForegroundOnly = $true
+    },
+    @{
+        Name = "report_excel.png"
+        Title = "物品出納簿（Excel出力例）"
+        Instructions = "帳票作成で出力したExcelファイルを開き、表示されたら（※手動でPrtScで撮影してください）"
     },
     @{
         Name = "installer_options.png"


### PR DESCRIPTION
## Summary
- ユーザーマニュアルの「6.2 物品出納簿の出力」セクションに、出力されたExcelファイルのスクリーンショット参照（`report_excel.png`）を追加
- `TakeScreenshots.ps1` に `report_excel.png` の撮影ステップを追加（手動PrtSc撮影）
  - Excelは ICCardManager とは別プロセスのため、スクリプトによる自動キャプチャ不可
  - `installer_options.png` と同様の手動撮影方式
- ヘルプテキストの合計枚数を更新（17枚→18枚）

## Test plan
- [ ] `TakeScreenshots.ps1 -All` を実行し、`report_excel.png` の撮影ステップが正しく表示されることを確認
- [ ] 帳票作成画面で物品出納簿を出力し、Excelで開いた状態のスクリーンショットを手動で撮影
- [ ] `docs/screenshots/report_excel.png` として保存
- [ ] ユーザーマニュアルのMarkdownプレビューでスクリーンショットが正しく表示されることを確認

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)