### PR TITLE
fix: 起動時にic_card.is_lentとledger.is_lent_recordの整合性を修復（#790）

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -39,6 +39,16 @@ namespace ICCardManager.Data.Repositories
         Task<Ledger> GetLentRecordAsync(string cardIdm);
 
         /// <summary>
+        /// 全カードの貸出中レコードを一括取得（整合性チェック用）
+        /// </summary>
+        /// <remarks>
+        /// Issue #790対応: 起動時にic_card.is_lentとledger.is_lent_recordの
+        /// 整合性をチェック・修復するために使用。
+        /// </remarks>
+        /// <returns>全カードの貸出中レコードのリスト</returns>
+        Task<List<Ledger>> GetAllLentRecordsAsync();
+
+        /// <summary>
         /// 利用履歴を登録
         /// </summary>
         Task<int> InsertAsync(Ledger ledger);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -120,6 +120,28 @@ LIMIT 1";
         }
 
         /// <inheritdoc/>
+        public async Task<List<Ledger>> GetAllLentRecordsAsync()
+        {
+            var connection = _dbContext.GetConnection();
+            var result = new List<Ledger>();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"SELECT id, card_idm, lender_idm, date, summary, income, expense, balance,
+       staff_name, note, returner_idm, lent_at, returned_at, is_lent_record
+FROM ledger
+WHERE is_lent_record = 1
+ORDER BY lent_at DESC";
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.Add(MapToLedger(reader));
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc/>
         public async Task<int> InsertAsync(Ledger ledger)
         {
             var connection = _dbContext.GetConnection();

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -402,6 +402,9 @@ public partial class MainViewModel : ViewModelBase
     {
         using (BeginBusy("初期化中..."))
         {
+            // Issue #790: 起動時に貸出状態の整合性をチェック・修復
+            await _lendingService.RepairLentStatusConsistencyAsync();
+
             // Issue #504: 初期化処理を並列化して高速化
             // 設定取得は他の処理と並列で実行可能
             var settingsTask = _settingsRepository.GetAppSettingsAsync();


### PR DESCRIPTION
## Summary
- カード一覧では「在庫」と表示されるのに、履歴一覧では「（貸出中）」レコードが残存する不整合（#790）を修正
- 起動時に`ledger.is_lent_record`の有無を正（source of truth）として`ic_card.is_lent`フラグを自動修復する整合性チェックを追加
- 貸出中レコードあり＋is_lent=0 → is_lent=1に修復、貸出中レコードなし＋is_lent=1 → is_lent=0に修復

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `ILedgerRepository.cs` | `GetAllLentRecordsAsync`インターフェース追加 |
| `LedgerRepository.cs` | `GetAllLentRecordsAsync`実装（全貸出中レコード一括取得） |
| `LendingService.cs` | `RepairLentStatusConsistencyAsync`追加（整合性修復ロジック） |
| `MainViewModel.cs` | `InitializeAsync`で起動時に整合性チェック実行 |
| `LendingServiceTests.cs` | テスト6件追加 |

## Test plan
- [x] 新規テスト6件すべてパス
- [x] 全1295テスト合格（リグレッションなし）
- [x] 手動テスト: カードを貸出→アプリ再起動→カード一覧で「貸出中」表示を確認
- [ ] 手動テスト: DB直接編集で`is_lent=0`に書き換え→アプリ再起動→自動修復で「貸出中」に復帰

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)