### PR TITLE
feat: 操作ログエクスポートをCSVからExcel形式に変更（#786）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -206,6 +206,7 @@ namespace ICCardManager
             services.AddSingleton<LedgerSplitService>();
             services.AddSingleton<LedgerConsistencyChecker>();
             services.AddSingleton<CsvExportService>();
+            services.AddSingleton<OperationLogExcelExportService>();
             services.AddSingleton<CsvImportService>();
             services.AddSingleton<IToastNotificationService, ToastNotificationService>();
             services.AddSingleton<IDialogService, DialogService>();

--- a/ICCardManager/src/ICCardManager/Services/OperationLogExcelExportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogExcelExportService.cs
@@ -1,0 +1,381 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ClosedXML.Excel;
+using ICCardManager.Models;
+
+namespace ICCardManager.Services;
+
+/// <summary>
+/// 操作ログをExcelファイルにエクスポートするサービス
+/// </summary>
+public class OperationLogExcelExportService
+{
+    // ヘッダー背景色（青）
+    private static readonly XLColor HeaderBackground = XLColor.FromHtml("#4472C4");
+
+    // 操作種別ごとの文字色
+    private static readonly XLColor ColorGreen = XLColor.FromHtml("#2E7D32");
+    private static readonly XLColor ColorOrange = XLColor.FromHtml("#E65100");
+    private static readonly XLColor ColorRed = XLColor.FromHtml("#C62828");
+    private static readonly XLColor ColorBlue = XLColor.FromHtml("#1565C0");
+
+    /// <summary>
+    /// 操作ログをExcelファイルにエクスポート
+    /// </summary>
+    public async Task ExportAsync(IEnumerable<OperationLog> logs, string filePath)
+    {
+        await Task.Run(() =>
+        {
+            using var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add("操作ログ");
+
+            // ヘッダー行を作成
+            WriteHeader(worksheet);
+
+            // データ行を書き込み
+            var row = 2;
+            foreach (var log in logs)
+            {
+                WriteDataRow(worksheet, row, log);
+                row++;
+            }
+
+            // 書式設定
+            ApplyFormatting(worksheet, row - 1);
+
+            workbook.SaveAs(filePath);
+        });
+    }
+
+    /// <summary>
+    /// ヘッダー行を書き込み
+    /// </summary>
+    private static void WriteHeader(IXLWorksheet worksheet)
+    {
+        var headers = new[] { "日時", "操作種別", "対象", "対象ID", "操作者", "変更内容", "変更前", "変更後" };
+        for (var i = 0; i < headers.Length; i++)
+        {
+            worksheet.Cell(1, i + 1).Value = headers[i];
+        }
+
+        var headerRange = worksheet.Range(1, 1, 1, headers.Length);
+        headerRange.Style.Font.Bold = true;
+        headerRange.Style.Font.FontColor = XLColor.White;
+        headerRange.Style.Fill.BackgroundColor = HeaderBackground;
+    }
+
+    /// <summary>
+    /// データ行を書き込み
+    /// </summary>
+    private static void WriteDataRow(IXLWorksheet worksheet, int row, OperationLog log)
+    {
+        // A: 日時
+        worksheet.Cell(row, 1).Value = log.Timestamp.ToString("yyyy/MM/dd HH:mm:ss");
+
+        // B: 操作種別
+        var actionDisplay = GetActionDisplayName(log.Action);
+        worksheet.Cell(row, 2).Value = actionDisplay;
+
+        // 操作種別の文字色
+        var actionColor = GetActionColor(log.Action);
+        if (actionColor != null)
+        {
+            worksheet.Cell(row, 2).Style.Font.FontColor = actionColor;
+            worksheet.Cell(row, 2).Style.Font.Bold = true;
+        }
+
+        // C: 対象
+        worksheet.Cell(row, 3).Value = GetTargetTableDisplayName(log.TargetTable);
+
+        // D: 対象ID
+        worksheet.Cell(row, 4).Value = log.TargetId ?? "";
+
+        // E: 操作者
+        worksheet.Cell(row, 5).Value = log.OperatorName;
+
+        // F: 変更内容
+        worksheet.Cell(row, 6).Value = GetChangeSummary(
+            log.TargetTable, log.BeforeData, log.AfterData);
+
+        // G: 変更前
+        worksheet.Cell(row, 7).Value = FormatJsonToReadable(
+            log.TargetTable, log.BeforeData);
+
+        // H: 変更後
+        worksheet.Cell(row, 8).Value = FormatJsonToReadable(
+            log.TargetTable, log.AfterData);
+    }
+
+    /// <summary>
+    /// 書式設定を適用
+    /// </summary>
+    private static void ApplyFormatting(IXLWorksheet worksheet, int lastDataRow)
+    {
+        // 列幅の設定
+        worksheet.Column(1).Width = 20;  // 日時
+        worksheet.Column(2).Width = 10;  // 操作種別
+        worksheet.Column(3).Width = 18;  // 対象
+        worksheet.Column(4).Width = 20;  // 対象ID
+        worksheet.Column(5).Width = 12;  // 操作者
+        worksheet.Column(6).Width = 40;  // 変更内容
+        worksheet.Column(7).Width = 50;  // 変更前
+        worksheet.Column(8).Width = 50;  // 変更後
+
+        // 全データセルにWrapText
+        if (lastDataRow >= 2)
+        {
+            var dataRange = worksheet.Range(2, 1, lastDataRow, 8);
+            dataRange.Style.Alignment.WrapText = true;
+            dataRange.Style.Alignment.Vertical = XLAlignmentVerticalValues.Top;
+        }
+
+        // 1行目固定（フリーズペイン）
+        worksheet.SheetView.FreezeRows(1);
+
+        // オートフィルター
+        if (lastDataRow >= 1)
+        {
+            worksheet.RangeUsed()?.SetAutoFilter();
+        }
+    }
+
+    /// <summary>
+    /// 操作種別の文字色を取得
+    /// </summary>
+    private static XLColor? GetActionColor(string? action)
+    {
+        return action switch
+        {
+            "INSERT" or "RESTORE" => ColorGreen,
+            "UPDATE" => ColorOrange,
+            "DELETE" => ColorRed,
+            "MERGE" or "SPLIT" => ColorBlue,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// 操作種別の表示名を取得
+    /// </summary>
+    internal static string GetActionDisplayName(string? action)
+    {
+        return action switch
+        {
+            "INSERT" => "登録",
+            "UPDATE" => "更新",
+            "DELETE" => "削除",
+            "RESTORE" => "復元",
+            "MERGE" => "統合",
+            "SPLIT" => "分割",
+            _ => action ?? ""
+        };
+    }
+
+    /// <summary>
+    /// 対象テーブルの表示名を取得
+    /// </summary>
+    internal static string GetTargetTableDisplayName(string? targetTable)
+    {
+        return targetTable switch
+        {
+            "staff" => "職員",
+            "ic_card" => "交通系ICカード",
+            "ledger" => "利用履歴",
+            _ => targetTable ?? ""
+        };
+    }
+
+    /// <summary>
+    /// JSONを人間が読める形式に整形
+    /// </summary>
+    internal static string FormatJsonToReadable(string? targetTable, string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+            return "";
+
+        try
+        {
+            // JSON配列の場合
+            var trimmed = json.TrimStart();
+            if (trimmed.StartsWith("["))
+            {
+                return FormatJsonArrayToReadable(targetTable, json);
+            }
+
+            var doc = JsonDocument.Parse(json);
+            var fieldNameMap = GetFieldNameMap(targetTable);
+
+            var lines = new List<string>();
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                if (!fieldNameMap.TryGetValue(property.Name, out var displayName))
+                    continue;
+
+                var value = FormatPropertyValue(property.Value);
+                lines.Add($"{displayName}: {value}");
+            }
+
+            return string.Join("\n", lines);
+        }
+        catch
+        {
+            // 不正なJSONの場合はそのまま返す
+            return json;
+        }
+    }
+
+    /// <summary>
+    /// JSON配列を人間が読める形式に整形（MERGE/SPLIT用）
+    /// </summary>
+    internal static string FormatJsonArrayToReadable(string? targetTable, string jsonArray)
+    {
+        try
+        {
+            var doc = JsonDocument.Parse(jsonArray);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return jsonArray;
+            }
+
+            var fieldNameMap = GetFieldNameMap(targetTable);
+            var sections = new List<string>();
+            var index = 1;
+
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                var lines = new List<string>();
+                lines.Add($"[{index}]");
+
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (!fieldNameMap.TryGetValue(property.Name, out var displayName))
+                        continue;
+
+                    var value = FormatPropertyValue(property.Value);
+                    lines.Add($"  {displayName}: {value}");
+                }
+
+                sections.Add(string.Join("\n", lines));
+                index++;
+            }
+
+            return string.Join("\n", sections);
+        }
+        catch
+        {
+            return jsonArray;
+        }
+    }
+
+    /// <summary>
+    /// 変更内容のサマリーを生成（UPDATE時の差分表示）
+    /// </summary>
+    internal static string GetChangeSummary(string? targetTable, string? beforeJson, string? afterJson)
+    {
+        if (string.IsNullOrEmpty(beforeJson) || string.IsNullOrEmpty(afterJson))
+            return "";
+
+        try
+        {
+            var beforeDoc = JsonDocument.Parse(beforeJson);
+            var afterDoc = JsonDocument.Parse(afterJson);
+
+            // 配列JSONの場合はサマリーを生成しない
+            if (beforeDoc.RootElement.ValueKind == JsonValueKind.Array ||
+                afterDoc.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                return "";
+            }
+
+            var fieldNameMap = GetFieldNameMap(targetTable);
+            var changes = new List<string>();
+
+            foreach (var kvp in fieldNameMap)
+            {
+                var propertyName = kvp.Key;
+                var displayName = kvp.Value;
+
+                string? beforeValue = null;
+                string? afterValue = null;
+
+                if (beforeDoc.RootElement.TryGetProperty(propertyName, out var beforeProp))
+                    beforeValue = FormatPropertyValue(beforeProp);
+                if (afterDoc.RootElement.TryGetProperty(propertyName, out var afterProp))
+                    afterValue = FormatPropertyValue(afterProp);
+
+                if (beforeValue != afterValue)
+                {
+                    var beforeDisplay = string.IsNullOrEmpty(beforeValue) ? "（なし）" : beforeValue;
+                    var afterDisplay = string.IsNullOrEmpty(afterValue) ? "（なし）" : afterValue;
+                    changes.Add($"{displayName}: {beforeDisplay} → {afterDisplay}");
+                }
+            }
+
+            return string.Join("\n", changes);
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    /// <summary>
+    /// テーブルごとのフィールド名マッピングを取得
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> GetFieldNameMap(string? targetTable)
+    {
+        return targetTable switch
+        {
+            "staff" => new Dictionary<string, string>
+            {
+                { "StaffIdm", "職員証IDm" },
+                { "Name", "氏名" },
+                { "Number", "職員番号" },
+                { "Note", "備考" },
+                { "IsDeleted", "削除済み" },
+            },
+            "ic_card" => new Dictionary<string, string>
+            {
+                { "CardIdm", "カードIDm" },
+                { "CardType", "カード種別" },
+                { "CardNumber", "管理番号" },
+                { "Note", "備考" },
+                { "IsDeleted", "削除済み" },
+                { "IsRefunded", "払戻済み" },
+                { "IsLent", "貸出中" },
+                { "StartingPageNumber", "開始ページ番号" },
+            },
+            "ledger" => new Dictionary<string, string>
+            {
+                { "Id", "ID" },
+                { "CardIdm", "カードIDm" },
+                { "Date", "日付" },
+                { "Summary", "摘要" },
+                { "Income", "受入金額" },
+                { "Expense", "払出金額" },
+                { "Balance", "残額" },
+                { "StaffName", "利用者" },
+                { "Note", "備考" },
+            },
+            _ => new Dictionary<string, string>()
+        };
+    }
+
+    /// <summary>
+    /// JSONプロパティ値を表示用文字列に変換
+    /// </summary>
+    private static string FormatPropertyValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.True => "はい",
+            JsonValueKind.False => "いいえ",
+            JsonValueKind.Null => "",
+            JsonValueKind.Number => element.ToString(),
+            _ => element.ToString()
+        };
+    }
+}

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
@@ -303,16 +303,16 @@
 
             <!-- エクスポートボタン -->
             <StackPanel Grid.Column="0" Orientation="Horizontal">
-                <Button Content="CSVエクスポート"
-                        Command="{Binding ExportToCsvCommand}"
+                <Button Content="Excelエクスポート"
+                        Command="{Binding ExportToExcelCommand}"
                         Padding="15,8"
-                        ToolTip="検索結果をCSVファイルに出力"/>
+                        ToolTip="検索結果をExcelファイルに出力"/>
                 <Button Content="開く"
                         Command="{Binding OpenExportedFileCommand}"
                         Padding="10,8"
                         Margin="5,0,0,0"
                         Visibility="{Binding LastExportedFile, Converter={StaticResource BoolToVisibilityConverter}}"
-                        ToolTip="出力したCSVファイルを開く"/>
+                        ToolTip="出力したExcelファイルを開く"/>
             </StackPanel>
 
             <!-- ステータスメッセージ -->

--- a/ICCardManager/tests/ICCardManager.Tests/Services/OperationLogExcelExportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/OperationLogExcelExportServiceTests.cs
@@ -1,0 +1,413 @@
+using System.IO;
+using ClosedXML.Excel;
+using FluentAssertions;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Xunit;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// OperationLogExcelExportServiceの単体テスト
+/// </summary>
+public class OperationLogExcelExportServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly OperationLogExcelExportService _service;
+
+    public OperationLogExcelExportServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"OpLogExcelTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+        _service = new OperationLogExcelExportService();
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testDirectory))
+                Directory.Delete(_testDirectory, true);
+        }
+        catch { /* テスト後のクリーンアップ失敗は無視 */ }
+    }
+
+    #region GetActionDisplayName
+
+    [Theory]
+    [InlineData("INSERT", "登録")]
+    [InlineData("UPDATE", "更新")]
+    [InlineData("DELETE", "削除")]
+    [InlineData("RESTORE", "復元")]
+    [InlineData("MERGE", "統合")]
+    [InlineData("SPLIT", "分割")]
+    public void GetActionDisplayName_全6種別を正しく変換(string action, string expected)
+    {
+        var result = OperationLogExcelExportService.GetActionDisplayName(action);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetActionDisplayName_未知の値はそのまま返す()
+    {
+        var result = OperationLogExcelExportService.GetActionDisplayName("UNKNOWN");
+        result.Should().Be("UNKNOWN");
+    }
+
+    [Fact]
+    public void GetActionDisplayName_nullは空文字を返す()
+    {
+        var result = OperationLogExcelExportService.GetActionDisplayName(null);
+        result.Should().Be("");
+    }
+
+    #endregion
+
+    #region GetTargetTableDisplayName
+
+    [Theory]
+    [InlineData("staff", "職員")]
+    [InlineData("ic_card", "交通系ICカード")]
+    [InlineData("ledger", "利用履歴")]
+    public void GetTargetTableDisplayName_全3テーブルを正しく変換(string table, string expected)
+    {
+        var result = OperationLogExcelExportService.GetTargetTableDisplayName(table);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetTargetTableDisplayName_未知のテーブルはそのまま返す()
+    {
+        var result = OperationLogExcelExportService.GetTargetTableDisplayName("unknown_table");
+        result.Should().Be("unknown_table");
+    }
+
+    [Fact]
+    public void GetTargetTableDisplayName_nullは空文字を返す()
+    {
+        var result = OperationLogExcelExportService.GetTargetTableDisplayName(null);
+        result.Should().Be("");
+    }
+
+    #endregion
+
+    #region FormatJsonToReadable
+
+    [Fact]
+    public void FormatJsonToReadable_Staff_職員JSONを日本語に整形()
+    {
+        var json = @"{""StaffIdm"":""0123456789ABCDEF"",""Name"":""田中太郎"",""Number"":""001"",""Note"":""総務課"",""IsDeleted"":false}";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("staff", json);
+
+        result.Should().Contain("職員証IDm: 0123456789ABCDEF");
+        result.Should().Contain("氏名: 田中太郎");
+        result.Should().Contain("職員番号: 001");
+        result.Should().Contain("備考: 総務課");
+        result.Should().Contain("削除済み: いいえ");
+    }
+
+    [Fact]
+    public void FormatJsonToReadable_IcCard_ICカードJSONを日本語に整形()
+    {
+        var json = @"{""CardIdm"":""FEDCBA9876543210"",""CardType"":""はやかけん"",""CardNumber"":""001"",""Note"":""1号車用"",""IsDeleted"":false,""IsRefunded"":false,""IsLent"":true,""StartingPageNumber"":1}";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("ic_card", json);
+
+        result.Should().Contain("カードIDm: FEDCBA9876543210");
+        result.Should().Contain("カード種別: はやかけん");
+        result.Should().Contain("管理番号: 001");
+        result.Should().Contain("備考: 1号車用");
+        result.Should().Contain("貸出中: はい");
+        result.Should().Contain("開始ページ番号: 1");
+    }
+
+    [Fact]
+    public void FormatJsonToReadable_Ledger_出納簿JSONを日本語に整形()
+    {
+        var json = @"{""Id"":42,""CardIdm"":""AAAA"",""Date"":""2025-07-01"",""Summary"":""鉄道（博多～天神）"",""Income"":0,""Expense"":210,""Balance"":790,""StaffName"":""田中太郎"",""Note"":""""}";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("ledger", json);
+
+        result.Should().Contain("ID: 42");
+        result.Should().Contain("カードIDm: AAAA");
+        result.Should().Contain("日付: 2025-07-01");
+        result.Should().Contain("摘要: 鉄道（博多～天神）");
+        result.Should().Contain("受入金額: 0");
+        result.Should().Contain("払出金額: 210");
+        result.Should().Contain("残額: 790");
+        result.Should().Contain("利用者: 田中太郎");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void FormatJsonToReadable_NullOrEmpty_空文字列を返す(string? json)
+    {
+        var result = OperationLogExcelExportService.FormatJsonToReadable("staff", json);
+        result.Should().Be("");
+    }
+
+    [Fact]
+    public void FormatJsonToReadable_InvalidJson_生文字列をそのまま返す()
+    {
+        var invalidJson = "これはJSONではない";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("staff", invalidJson);
+
+        result.Should().Be(invalidJson);
+    }
+
+    [Fact]
+    public void FormatJsonToReadable_BooleanValues_はいいいえに変換()
+    {
+        var json = @"{""StaffIdm"":""ABC"",""Name"":""テスト"",""IsDeleted"":true}";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("staff", json);
+
+        result.Should().Contain("削除済み: はい");
+    }
+
+    [Fact]
+    public void FormatJsonToReadable_スキップ対象フィールドは出力されない()
+    {
+        // DeletedAt は内部管理データのため表示されないこと
+        var json = @"{""StaffIdm"":""ABC"",""Name"":""テスト"",""DeletedAt"":""2025-01-01"",""Number"":""001""}";
+
+        var result = OperationLogExcelExportService.FormatJsonToReadable("staff", json);
+
+        result.Should().NotContain("DeletedAt");
+        result.Should().NotContain("削除日時");
+        result.Should().Contain("氏名: テスト");
+    }
+
+    #endregion
+
+    #region FormatJsonArrayToReadable
+
+    [Fact]
+    public void FormatJsonArrayToReadable_Array_番号付きで整形()
+    {
+        var jsonArray = @"[{""Id"":1,""CardIdm"":""AAA"",""Date"":""2025-07-01"",""Summary"":""鉄道A"",""Income"":0,""Expense"":200,""Balance"":800,""StaffName"":""田中"",""Note"":""""},{""Id"":2,""CardIdm"":""AAA"",""Date"":""2025-07-02"",""Summary"":""鉄道B"",""Income"":0,""Expense"":300,""Balance"":500,""StaffName"":""鈴木"",""Note"":""""}]";
+
+        var result = OperationLogExcelExportService.FormatJsonArrayToReadable("ledger", jsonArray);
+
+        result.Should().Contain("[1]");
+        result.Should().Contain("[2]");
+        result.Should().Contain("摘要: 鉄道A");
+        result.Should().Contain("摘要: 鉄道B");
+        result.Should().Contain("利用者: 田中");
+        result.Should().Contain("利用者: 鈴木");
+    }
+
+    #endregion
+
+    #region GetChangeSummary
+
+    [Fact]
+    public void GetChangeSummary_UpdateWithChanges_変更箇所を検出()
+    {
+        var before = @"{""StaffIdm"":""ABC"",""Name"":""田中太郎"",""Number"":""001"",""Note"":""総務課"",""IsDeleted"":false}";
+        var after = @"{""StaffIdm"":""ABC"",""Name"":""田中次郎"",""Number"":""002"",""Note"":""総務課"",""IsDeleted"":false}";
+
+        var result = OperationLogExcelExportService.GetChangeSummary("staff", before, after);
+
+        result.Should().Contain("氏名: 田中太郎 → 田中次郎");
+        result.Should().Contain("職員番号: 001 → 002");
+        // 変更がないフィールドは含まれない
+        result.Should().NotContain("備考");
+        result.Should().NotContain("職員証IDm");
+    }
+
+    [Fact]
+    public void GetChangeSummary_NoChanges_空文字列を返す()
+    {
+        var json = @"{""StaffIdm"":""ABC"",""Name"":""田中太郎"",""Number"":""001""}";
+
+        var result = OperationLogExcelExportService.GetChangeSummary("staff", json, json);
+
+        result.Should().Be("");
+    }
+
+    [Theory]
+    [InlineData(null, @"{""Name"":""田中""}")]
+    [InlineData(@"{""Name"":""田中""}", null)]
+    [InlineData(null, null)]
+    public void GetChangeSummary_NullBeforeOrAfter_空文字列を返す(string? before, string? after)
+    {
+        var result = OperationLogExcelExportService.GetChangeSummary("staff", before, after);
+        result.Should().Be("");
+    }
+
+    [Fact]
+    public void GetChangeSummary_値がnullから設定された場合()
+    {
+        var before = @"{""StaffIdm"":""ABC"",""Name"":""田中太郎"",""Number"":""001"",""Note"":null}";
+        var after = @"{""StaffIdm"":""ABC"",""Name"":""田中太郎"",""Number"":""001"",""Note"":""経理課""}";
+
+        var result = OperationLogExcelExportService.GetChangeSummary("staff", before, after);
+
+        result.Should().Contain("備考: （なし） → 経理課");
+    }
+
+    #endregion
+
+    #region GetFieldNameMap
+
+    [Fact]
+    public void GetFieldNameMap_未知テーブルは空辞書()
+    {
+        var result = OperationLogExcelExportService.GetFieldNameMap("unknown");
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ExportAsync
+
+    [Fact]
+    public async Task ExportAsync_CreatesValidExcelFile_正しいExcelファイルを生成()
+    {
+        var filePath = Path.Combine(_testDirectory, "test_export.xlsx");
+        var logs = new List<OperationLog>
+        {
+            new OperationLog
+            {
+                Id = 1,
+                Timestamp = new DateTime(2025, 7, 1, 10, 30, 0),
+                Action = "INSERT",
+                TargetTable = "staff",
+                TargetId = "ABC123",
+                OperatorName = "管理者",
+                OperatorIdm = "OP001",
+                BeforeData = null,
+                AfterData = @"{""StaffIdm"":""ABC123"",""Name"":""田中太郎"",""Number"":""001"",""Note"":""総務課"",""IsDeleted"":false}"
+            },
+            new OperationLog
+            {
+                Id = 2,
+                Timestamp = new DateTime(2025, 7, 2, 14, 0, 0),
+                Action = "UPDATE",
+                TargetTable = "staff",
+                TargetId = "ABC123",
+                OperatorName = "管理者",
+                OperatorIdm = "OP001",
+                BeforeData = @"{""StaffIdm"":""ABC123"",""Name"":""田中太郎"",""Number"":""001"",""Note"":""総務課"",""IsDeleted"":false}",
+                AfterData = @"{""StaffIdm"":""ABC123"",""Name"":""田中次郎"",""Number"":""002"",""Note"":""総務課"",""IsDeleted"":false}"
+            }
+        };
+
+        await _service.ExportAsync(logs, filePath);
+
+        File.Exists(filePath).Should().BeTrue();
+
+        using var workbook = new XLWorkbook(filePath);
+        var worksheet = workbook.Worksheets.First();
+
+        // ヘッダー行の確認
+        worksheet.Cell(1, 1).Value.ToString().Should().Be("日時");
+        worksheet.Cell(1, 2).Value.ToString().Should().Be("操作種別");
+        worksheet.Cell(1, 3).Value.ToString().Should().Be("対象");
+        worksheet.Cell(1, 4).Value.ToString().Should().Be("対象ID");
+        worksheet.Cell(1, 5).Value.ToString().Should().Be("操作者");
+        worksheet.Cell(1, 6).Value.ToString().Should().Be("変更内容");
+        worksheet.Cell(1, 7).Value.ToString().Should().Be("変更前");
+        worksheet.Cell(1, 8).Value.ToString().Should().Be("変更後");
+
+        // ヘッダーのスタイル確認
+        worksheet.Cell(1, 1).Style.Font.Bold.Should().BeTrue();
+
+        // データ行の確認（1行目: INSERT）
+        worksheet.Cell(2, 1).Value.ToString().Should().Be("2025/07/01 10:30:00");
+        worksheet.Cell(2, 2).Value.ToString().Should().Be("登録");
+        worksheet.Cell(2, 3).Value.ToString().Should().Be("職員");
+        worksheet.Cell(2, 4).Value.ToString().Should().Be("ABC123");
+        worksheet.Cell(2, 5).Value.ToString().Should().Be("管理者");
+
+        // INSERT行の変更後データが整形されていること
+        var afterData = worksheet.Cell(2, 8).Value.ToString();
+        afterData.Should().Contain("氏名: 田中太郎");
+
+        // UPDATE行の変更内容が表示されること
+        var changeSummary = worksheet.Cell(3, 6).Value.ToString();
+        changeSummary.Should().Contain("氏名: 田中太郎 → 田中次郎");
+
+        // ワークシートが存在すること（フリーズペインはFreezeRows(1)で設定済み）
+        worksheet.Name.Should().Be("操作ログ");
+    }
+
+    [Fact]
+    public async Task ExportAsync_EmptyLogs_ヘッダーのみのExcelファイルを生成()
+    {
+        var filePath = Path.Combine(_testDirectory, "empty_export.xlsx");
+
+        await _service.ExportAsync(Enumerable.Empty<OperationLog>(), filePath);
+
+        File.Exists(filePath).Should().BeTrue();
+
+        using var workbook = new XLWorkbook(filePath);
+        var worksheet = workbook.Worksheets.First();
+
+        // ヘッダー行のみ
+        worksheet.Cell(1, 1).Value.ToString().Should().Be("日時");
+        worksheet.Cell(2, 1).Value.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExportAsync_AllActionTypes_全操作種別が正しくエクスポート()
+    {
+        var filePath = Path.Combine(_testDirectory, "all_actions.xlsx");
+        var logs = new List<OperationLog>
+        {
+            CreateLog(1, "INSERT", "staff"),
+            CreateLog(2, "UPDATE", "ic_card"),
+            CreateLog(3, "DELETE", "ledger"),
+            CreateLog(4, "RESTORE", "staff"),
+            CreateLog(5, "MERGE", "ledger"),
+            CreateLog(6, "SPLIT", "ledger"),
+        };
+
+        await _service.ExportAsync(logs, filePath);
+
+        using var workbook = new XLWorkbook(filePath);
+        var worksheet = workbook.Worksheets.First();
+
+        worksheet.Cell(2, 2).Value.ToString().Should().Be("登録");
+        worksheet.Cell(3, 2).Value.ToString().Should().Be("更新");
+        worksheet.Cell(4, 2).Value.ToString().Should().Be("削除");
+        worksheet.Cell(5, 2).Value.ToString().Should().Be("復元");
+        worksheet.Cell(6, 2).Value.ToString().Should().Be("統合");
+        worksheet.Cell(7, 2).Value.ToString().Should().Be("分割");
+
+        // WrapText が有効であること
+        worksheet.Cell(2, 7).Style.Alignment.WrapText.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private static OperationLog CreateLog(int id, string action, string targetTable)
+    {
+        return new OperationLog
+        {
+            Id = id,
+            Timestamp = new DateTime(2025, 7, 1, 10, 0, 0).AddHours(id),
+            Action = action,
+            TargetTable = targetTable,
+            TargetId = $"ID{id:D3}",
+            OperatorName = "テスト管理者",
+            OperatorIdm = "OPERATOR001",
+            BeforeData = action == "INSERT" ? null : @"{""Name"":""テスト""}",
+            AfterData = action == "DELETE" ? null : @"{""Name"":""テスト""}"
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- 操作ログのエクスポート形式をCSVからExcel（.xlsx）に変更
- `before_data`/`after_data`の生JSONを日本語フィールド名で整形表示
- UPDATE時の変更差分サマリー（変更内容列）を自動生成
- 操作種別ごとの色分け・ヘッダー固定・オートフィルター等のExcel書式設定

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `Services/OperationLogExcelExportService.cs` | **新規** — ClosedXMLによるExcelエクスポートサービス |
| `ViewModels/OperationLogSearchViewModel.cs` | `ExportToCsv` → `ExportToExcel` に変更、`EscapeCsvField` 削除 |
| `Views/Dialogs/OperationLogDialog.xaml` | ボタンテキスト・ToolTipを「CSV」→「Excel」に更新 |
| `App.xaml.cs` | `OperationLogExcelExportService` のDI登録追加 |
| `Tests/.../OperationLogExcelExportServiceTests.cs` | **新規** — 32件のユニットテスト |

## Test plan
- [x] `dotnet build` — ビルド成功（0エラー）
- [x] `dotnet test` — 全1329テスト合格（新規32件含む）
- [x] 操作ログ画面 →「Excelエクスポート」ボタンが表示されること
- [x] エクスポート → .xlsx形式で保存ダイアログが開くこと
- [x] 出力Excelでヘッダー行が太字・青背景であること
- [x] 変更前/変更後列がJSON→日本語整形されていること
- [ ] UPDATE行の「変更内容」列に差分が表示されること
- [ ] 操作種別が色分けされていること（登録=緑、更新=橙、削除=赤）
- [x] 「開く」ボタンでExcelファイルが開けること

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)