### PR TITLE
chore: リリースビルド時にマニュアルへバージョンを自動注入する

### DIFF
--- a/ICCardManager/docs/DISTRIBUTION.md
+++ b/ICCardManager/docs/DISTRIBUTION.md
@@ -221,6 +221,35 @@ installer/output/ICCardManager_Setup_1.0.7.exe
 
 更新履歴は `README.md` の「更新履歴」セクションに記載します。
 
+## リリース手順
+
+リリースは2つのフェーズに分けて実施します。
+
+### Phase 1: ソース更新（Claude Code / WSL）
+
+以下の作業はClaude Code（WSL環境）から実行できます。
+
+1. `src/ICCardManager/ICCardManager.csproj` の `<Version>`、`<FileVersion>`、`<AssemblyVersion>` を更新
+2. `README.md` の「更新履歴」セクションに新バージョンのエントリを追加
+3. マニュアル `.md` ファイルの `**バージョン**: X.Y.Z` 行を更新（GitHub閲覧用）
+4. コミット・プッシュ → PR → mainにマージ
+5. タグ作成・プッシュ: `git tag vX.Y.Z && git push origin vX.Y.Z`
+6. `gh release create vX.Y.Z` でリリースノートを作成
+
+### Phase 2: インストーラービルド（Windows PowerShell）
+
+> **重要**: 以下は必ずWindowsネイティブのPowerShellから実行してください。
+> WSLから `powershell.exe` を呼び出すと日本語ファイル名が文字化けし、
+> マニュアル変換が失敗します。
+
+7. Windows PowerShell を開き、`installer/` ディレクトリに移動
+8. `.\build-installer.ps1` を実行（マニュアル変換 + インストーラー作成を自動実行）
+9. `gh release upload vX.Y.Z .\output\ICCardManager_Setup_X.Y.Z.exe` でインストーラーをアップロード
+
+> **補足**: `build-installer.ps1` は `.csproj` からバージョンを自動取得し、
+> マニュアルの `.docx` に正しいバージョンを注入します（`-Force -Version` オプション）。
+> マニュアル `.md` のバージョン文字列が未更新でも、`.docx` には正しいバージョンが反映されます。
+
 ## セキュリティに関する注意
 
 - データベース（`iccard.db`）には個人情報（職員名、ICカードIDm）が含まれます

--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -856,6 +856,8 @@ dotnet publish -c Release
 - `appsettings.json` - 設定ファイル（オプション）
 - `Resources/` - テンプレート等のリソース
 
+**リリース手順の詳細**については `docs/DISTRIBUTION.md` の「リリース手順」セクションを参照。インストーラービルド（マニュアル変換含む）はWindowsネイティブのPowerShellから実行する必要がある。
+
 ### 8.3 デバッグモードとリリースモード
 
 | 機能 | DEBUG | RELEASE |

--- a/ICCardManager/installer/build-installer.ps1
+++ b/ICCardManager/installer/build-installer.ps1
@@ -279,9 +279,11 @@ if (-not $PandocPath) {
     Write-Host "  警告: 変換スクリプトが見つかりません: $ConvertDocxScript" -ForegroundColor Yellow
 } else {
     # Issue #643: .mdが.docxより新しい場合に変換
+    # -Force: リリースビルドでは常に再変換（古い.docxの残存を防止）
+    # -Version: .csprojのバージョンを.docxに注入（Issue #789）
     Push-Location $ManualDir
     try {
-        & $ConvertDocxScript -NoMermaid
+        & $ConvertDocxScript -NoMermaid -Force -Version $Version
         if ($LASTEXITCODE -eq 0) {
             Write-Host "  docx変換完了" -ForegroundColor Green
         } else {


### PR DESCRIPTION
## Summary

- `convert-to-docx.ps1` に `-Version` パラメータを追加し、`.md` ファイルを変更せずに stdin 経由でバージョン文字列を `.docx` に注入する仕組みを実装
- `build-installer.ps1` から `-Force -Version` オプションで呼び出すよう変更し、リリースビルド時に常に最新バージョンが反映されるようにした
- `DISTRIBUTION.md` に WSL（Phase 1）と Windows PowerShell（Phase 2）の 2 フェーズリリース手順を追記
- `開発者ガイド.md` から `DISTRIBUTION.md` への参照を追加

### 背景

WSL から `build-installer.ps1` を実行すると日本語ファイル名の文字化けでマニュアル変換が失敗し、前回ビルドの古い `.docx`（旧バージョン）がインストーラーにそのまま同梱される問題があった。

## Test plan

- [x] Windows PowerShell で `convert-to-docx.ps1 -Force -Version 99.99.99` を実行し、バージョン追従対象マニュアル（ユーザー/概要版/管理者）の `.docx` にバージョン `99.99.99` が反映されることを確認
- [x] `はじめに.docx` と `開発者ガイド.docx` のバージョンが変更されないことを確認
- [x] `build-installer.ps1` を実行し、インストーラーが正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)