### PR TITLE
fix: チャージ・新規購入・ポイント還元・払戻しの氏名欄を空欄にする（#807）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/DebugDataService.cs
+++ b/ICCardManager/src/ICCardManager/Services/DebugDataService.cs
@@ -174,7 +174,7 @@ namespace ICCardManager.Services
                             Income = chargeAmount,
                             Expense = 0,
                             Balance = balance,
-                            StaffName = staffName,
+                            StaffName = null,  // チャージは機械操作のため氏名不要
                             Note = "テストデータ"
                         };
                         var chargeLedgerId = await _ledgerRepository.InsertAsync(chargeLedger);
@@ -499,7 +499,7 @@ namespace ICCardManager.Services
                 Income = pointAmount,
                 Expense = 0,
                 Balance = balance,
-                StaffName = staffName,
+                StaffName = null,  // ポイント還元は機械操作のため氏名不要
                 Note = "テストデータ（ポイント還元）"
             };
             var pointLedgerId = await _ledgerRepository.InsertAsync(pointLedger);
@@ -591,7 +591,7 @@ namespace ICCardManager.Services
                 Income = chargeAmount,
                 Expense = 0,
                 Balance = balance,
-                StaffName = staffName,
+                StaffName = null,  // チャージは機械操作のため氏名不要
                 Note = "テストデータ（残高回復チャージ）"
             };
             var recoveryChargeId = await _ledgerRepository.InsertAsync(recoveryCharge);
@@ -694,7 +694,7 @@ namespace ICCardManager.Services
                 Income = purchaseAmount,
                 Expense = 0,
                 Balance = balance,
-                StaffName = staffName,
+                StaffName = null,  // 新規購入は機械操作のため氏名不要
                 Note = "テストデータ（新規購入: 2000円カード、デポジット500円を除く）"
             };
             await _ledgerRepository.InsertAsync(purchaseLedger);
@@ -722,7 +722,7 @@ namespace ICCardManager.Services
                         Income = chargeAmount,
                         Expense = 0,
                         Balance = balance,
-                        StaffName = staffName,
+                        StaffName = null,  // チャージは機械操作のため氏名不要
                         Note = "テストデータ"
                     };
                     var chargeLedgerId = await _ledgerRepository.InsertAsync(chargeLedger);
@@ -780,7 +780,7 @@ namespace ICCardManager.Services
                 Income = 0,
                 Expense = balance,
                 Balance = 0,
-                StaffName = staffName,
+                StaffName = null,  // 払戻しは機械操作のため氏名不要
                 Note = "テストデータ（払い戻し）"
             };
             await _ledgerRepository.InsertAsync(refundLedger);

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -750,7 +750,7 @@ namespace ICCardManager.Services
                         Income = income,
                         Expense = 0,
                         Balance = balance,
-                        StaffName = staffName
+                        StaffName = null  // チャージは機械操作のため氏名不要
                     };
 
                     var ledgerId = await _ledgerRepository.InsertAsync(chargeLedger);
@@ -817,7 +817,7 @@ namespace ICCardManager.Services
                         Income = 0,
                         Expense = expense,
                         Balance = balance,
-                        StaffName = staffName
+                        StaffName = usageDetails.All(d => d.IsPointRedemption) ? null : staffName
                     };
 
                     var ledgerId = await _ledgerRepository.InsertAsync(usageLedger);


### PR DESCRIPTION
## Summary
- チャージ・ポイント還元・新規購入・払戻しは機械操作であり、職員が行うものではないため、LedgerのStaffNameをnullに設定するよう修正
- LendingService.CreateUsageLedgersAsync: チャージLedgerのStaffName=null、ポイント還元のみの利用LedgerもStaffName=null
- DebugDataService: テストデータの6箇所を同様に修正（通常利用レコードはそのまま維持）
- LendingServiceTests: 3件のテスト追加（チャージ/ポイント還元のみ/混在パターン）

Closes #807

## Test plan
- [x] 新規テスト3件がすべてパス
- [x] 既存テスト13件（StaffName関連）がすべてパス
- [x] 全テスト1345件がすべてパス（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)