### PR TITLE
fix: エクスポート後にインポート側のデータ種別が見えなくなる問題を修正（#805）

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -30,22 +30,17 @@
 
     <Grid Margin="20">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" MaxHeight="350"/>  <!-- Row 0: Export/Import設定（スクロール可能） -->
-            <RowDefinition Height="Auto"/>   <!-- Row 1: アクションボタン（常に表示） -->
-            <RowDefinition Height="Auto"/>   <!-- Row 2: Status message -->
-            <RowDefinition Height="*" MinHeight="150"/>  <!-- Row 3: プレビュー結果（サマリー + DataGrid） -->
-            <RowDefinition Height="Auto"/>   <!-- Row 4: エラー一覧 -->
-            <RowDefinition Height="Auto"/>   <!-- Row 5: Close button -->
+            <RowDefinition Height="Auto"/>   <!-- Row 0: エクスポート設定 -->
+            <RowDefinition Height="Auto"/>   <!-- Row 1: インポート設定（スクロール可能） -->
+            <RowDefinition Height="Auto"/>   <!-- Row 2: アクションボタン（常に表示） -->
+            <RowDefinition Height="Auto"/>   <!-- Row 3: Status message -->
+            <RowDefinition Height="*" MinHeight="150"/>  <!-- Row 4: プレビュー結果（サマリー + DataGrid） -->
+            <RowDefinition Height="Auto"/>   <!-- Row 5: エラー一覧 -->
+            <RowDefinition Height="Auto"/>   <!-- Row 6: Close button -->
         </Grid.RowDefinitions>
 
-        <!-- エクスポート/インポート設定（スクロール可能エリア） -->
-        <ScrollViewer Grid.Row="0"
-                      VerticalScrollBarVisibility="Auto"
-                      Margin="0,0,0,10">
-        <StackPanel>
-
-        <!-- エクスポート -->
-        <GroupBox Header="エクスポート" Margin="0,0,0,15" Padding="15">
+        <!-- エクスポート設定 -->
+        <GroupBox Grid.Row="0" Header="エクスポート" Margin="0,0,0,10" Padding="15">
             <StackPanel>
                 <TextBlock Text="データをCSVファイルに出力します"
                            Foreground="{DynamicResource SecondaryTextBrush}"
@@ -159,8 +154,12 @@
             </StackPanel>
         </GroupBox>
 
-        <!-- インポート -->
-        <GroupBox Header="インポート" Margin="0,0,0,15" Padding="15">
+        <!-- インポート設定（スクロール可能エリア） -->
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto"
+                      MaxHeight="250"
+                      Margin="0,0,0,10">
+        <GroupBox Header="インポート" Padding="15">
             <StackPanel>
                 <TextBlock Text="CSVファイルからデータを取り込みます"
                            Foreground="{DynamicResource SecondaryTextBrush}"
@@ -348,12 +347,10 @@
                            Visibility="{Binding LastImportedFile, Converter={StaticResource StringToVisibilityConverter}}"/>
             </StackPanel>
         </GroupBox>
-
-        </StackPanel>
         </ScrollViewer>
 
         <!-- アクションボタン（常に表示） -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,10">
             <Button Content="プレビュー"
                     Command="{Binding PreviewImportCommand}"
                     Padding="15,10"
@@ -381,7 +378,7 @@
         </StackPanel>
 
         <!-- ステータスメッセージ -->
-        <Border Grid.Row="2"
+        <Border Grid.Row="3"
                 Background="{DynamicResource ReturnBackgroundBrush}"
                 Padding="10"
                 Margin="0,0,0,10"
@@ -394,7 +391,7 @@
         </Border>
 
         <!-- プレビュー結果セクション -->
-        <Grid Grid.Row="3" Margin="0,0,0,10"
+        <Grid Grid.Row="4" Margin="0,0,0,10"
               Visibility="{Binding HasPreview, Converter={StaticResource BoolToVisibilityConverter}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>  <!-- サマリーバナー -->
@@ -510,7 +507,7 @@
         </Grid>
 
         <!-- エラー一覧セクション -->
-        <Border Grid.Row="4" Background="{DynamicResource LendingBackgroundBrush}" Padding="10" CornerRadius="3" Margin="0,0,0,10"
+        <Border Grid.Row="5" Background="{DynamicResource LendingBackgroundBrush}" Padding="10" CornerRadius="3" Margin="0,0,0,10"
                 Visibility="{Binding ImportErrors.Count, Converter={StaticResource IntToVisibilityConverter}}">
             <StackPanel>
                 <TextBlock Text="エラー詳細" FontWeight="Bold" FontSize="{DynamicResource BaseFontSize}" Margin="0,0,0,5"/>
@@ -531,7 +528,7 @@
         </Border>
 
         <!-- 閉じるボタン -->
-        <StackPanel Grid.Row="5"
+        <StackPanel Grid.Row="6"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
@@ -545,7 +542,7 @@
         </StackPanel>
 
         <!-- 処理中オーバーレイ -->
-        <Border Grid.RowSpan="6"
+        <Border Grid.RowSpan="7"
                 Background="{DynamicResource OverlayBrush}"
                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary
- エクスポートとインポートが同一ScrollViewer（MaxHeight=350）内にあり、エクスポート成功時に「出力先」セクションが表示されると、インポートのデータ種別ComboBoxがスクロール領域外に押し出されていた
- エクスポートとインポートを**別々のGrid行**に分離し、エクスポートの状態変化がインポートの表示に影響しないよう修正
- インポート側のみにScrollViewer（MaxHeight=250）を設け、利用履歴のカード指定セクション展開時のスクロールに対応

Closes #805

## Test plan
- [x] ビルド成功（0エラー）
- [x] 全テスト1342件パス（リグレッションなし）
- [ ] 以下の手動テストを実施してください:
  1. データエクスポート/インポートダイアログを開く
  2. エクスポートのデータ種別を「利用履歴」に変更
  3. 「CSVエクスポート」を実行
  4. エクスポート完了後、**インポート側の「データ種別」ドロップダウンが見えていること**を確認
  5. インポートのデータ種別を「利用履歴」に変更し、カード指定セクションが表示されスクロール可能であることを確認
  6. ウィンドウを最小サイズ（MinHeight=600）に縮小しても、レイアウトが崩れないことを確認
  7. 文字サイズを「特大」に変更しても、両セクションが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)