### PR TITLE
fix: 繰越額が履歴逆算値で上書きされるバグを修正（#819）

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -465,8 +465,10 @@ namespace ICCardManager.ViewModels
                         {
                             // 履歴がある場合: 初期残高を逆算してから初期レコード作成
                             var preHistoryBalance = CalculatePreHistoryBalance(filteredHistory);
+                            // Issue #819: ユーザーが繰越額を明示的に入力した場合はそちらを優先
+                            var initialBalance = modeResult.CarryoverBalance ?? preHistoryBalance;
                             await CreateInitialLedgerAsync(EditCardIdm, modeResult,
-                                overrideDate: importFromDate, overrideBalance: preHistoryBalance);
+                                overrideDate: importFromDate, overrideBalance: initialBalance);
 
                             // 履歴をインポート
                             var importResult = await _lendingService.ImportHistoryForRegistrationAsync(


### PR DESCRIPTION
## Summary

- 紙の出納簿からの繰越モードで、ユーザーが入力した繰越額がカード内の履歴から逆算した値で上書きされていた問題を修正
- `modeResult.CarryoverBalance`（ユーザー入力）が `CalculatePreHistoryBalance()`（履歴逆算）より優先されるよう修正

## Root Cause

`CardManageViewModel.SaveAsync()` の履歴インポートパスで、`CalculatePreHistoryBalance()` の戻り値を `overrideBalance` として `CreateInitialLedgerAsync()` に渡していた。`CreateInitialLedgerAsync` 内の優先順位は `overrideBalance ?? CarryoverBalance ?? _preReadBalance` のため、ユーザー入力値が常に無視されていた。

## Fix

呼び出し側で `modeResult.CarryoverBalance ?? preHistoryBalance` とし、ユーザーが繰越額を明示的に入力した場合はそちらを優先するようにした。

## Test plan

- [x] 新規テスト2件を追加（繰越額指定あり/なし × 履歴あり）
- [x] 全1349件のユニットテストがパス
- [x] 実機で「紙の出納簿からの繰越」選択→繰越額入力→正しい繰越額が反映されることを確認

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)