### PR TITLE
fix: DataGridがフォントサイズ設定に追従しない問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
@@ -11,6 +11,7 @@
         Width="650"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="バス停名入力ダイアログ"
         AutomationProperties.HelpText="バス利用の乗車・降車バス停名を入力します。過去の入力履歴から候補が表示されます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardManageDialog.xaml
@@ -13,6 +13,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         KeyDown="Window_KeyDown"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="交通系ICカード管理ダイアログ"
         AutomationProperties.HelpText="交通系ICカードの登録・編集・削除ができます。カードをタッチして新規登録できます。Escキーで閉じます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardRegistrationModeDialog.xaml
@@ -7,6 +7,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="カード登録方法選択ダイアログ"
         AutomationProperties.HelpText="交通系ICカードを新規購入として登録するか、紙の出納簿からの繰越として登録するかを選択します">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/CardTypeSelectionDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/CardTypeSelectionDialog.xaml
@@ -7,6 +7,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="カード種別選択ダイアログ"
         AutomationProperties.HelpText="未登録カードを職員証または交通系ICカードとして登録するかを選択します">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -13,6 +13,7 @@
         ResizeMode="CanResize"
         MinHeight="600"
         MinWidth="700"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="データエクスポート/インポートダイアログ"
         AutomationProperties.HelpText="カード、職員、履歴データのCSVエクスポート・インポートができます。Escapeキーで閉じます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -11,6 +11,7 @@
         Width="900"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="利用履歴ダイアログ"
         AutomationProperties.HelpText="交通系ICカードの利用履歴を表示します。期間を選択して確認できます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml
@@ -13,6 +13,7 @@
         MinWidth="600"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="バス停名未入力履歴一覧ダイアログ"
         AutomationProperties.HelpText="バス停名が未入力の利用履歴を確認できます。項目を選択してバス停名を入力ボタンを押すと、バス停名入力画面に遷移します。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerDetailDialog.xaml
@@ -11,6 +11,7 @@
         Width="850"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="利用履歴詳細ダイアログ"
         AutomationProperties.HelpText="選択した履歴の詳細を表示・編集します。行の間をクリックして分割線を挿入/削除できます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/LedgerRowEditDialog.xaml
@@ -11,6 +11,7 @@
         Width="700"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="履歴行の追加・修正ダイアログ"
         AutomationProperties.HelpText="履歴の行を追加または全項目を修正できます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/MergeHistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/MergeHistoryDialog.xaml
@@ -8,6 +8,7 @@
         MinWidth="400"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="統合履歴選択ダイアログ"
         AutomationProperties.HelpText="元に戻したい統合履歴を選択して取り消しボタンを押します">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/OperationLogDialog.xaml
@@ -11,6 +11,7 @@
         Width="1000"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="操作ログダイアログ"
         AutomationProperties.HelpText="システムの操作履歴を検索・表示します。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/PrintPreviewDialog.xaml
@@ -13,6 +13,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         PreviewKeyDown="Window_PreviewKeyDown"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="印刷プレビューダイアログ"
         AutomationProperties.HelpText="帳票の印刷プレビューを表示します。ズームやページ送りができます。←→キーでページ移動できます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -11,6 +11,7 @@
         Width="700"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="帳票作成ダイアログ"
         AutomationProperties.HelpText="物品出納簿をExcel形式で作成します。対象年月とカードを選択してください。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -11,6 +11,7 @@
         Width="550"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="設定ダイアログ"
         AutomationProperties.HelpText="アプリケーションの各種設定を変更できます。Escapeキーでキャンセルできます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffAuthDialog.xaml
@@ -7,6 +7,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="職員証認証ダイアログ"
         AutomationProperties.HelpText="重要な操作を行うために職員証による認証が必要です">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/StaffManageDialog.xaml
@@ -14,6 +14,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
         KeyDown="Window_KeyDown"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="職員管理ダイアログ"
         AutomationProperties.HelpText="職員の登録・編集・削除ができます。職員証をタッチして新規登録できます。Escキーで閉じます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SystemManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SystemManageDialog.xaml
@@ -13,6 +13,7 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Loaded="Window_Loaded"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="システム管理ダイアログ"
         AutomationProperties.HelpText="操作ログの確認、データベースのバックアップとリストアを行います。Escapeキーで閉じます。">
 

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/VirtualCardDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/VirtualCardDialog.xaml
@@ -5,6 +5,7 @@
         Width="700" Height="550"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResizeWithGrip"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="仮想交通系ICカード設定ダイアログ"
         AutomationProperties.HelpText="DEBUG専用。仮想的にICカードをタッチしてテストできます。最大20件の履歴を指定できます。">
     <Grid Margin="16">

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -16,6 +16,7 @@
         MinHeight="600"
         WindowStartupLocation="CenterScreen"
         AutomationProperties.Name="交通系ICカード管理システム メインウィンドウ"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.HelpText="職員証をタッチしてから交通系ICカードをタッチすると貸出または返却ができます">
 
     <Window.Resources>

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml
@@ -15,6 +15,7 @@
         ShowInTaskbar="False"
         ShowActivated="False"
         ResizeMode="NoResize"
+        FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="通知ウィンドウ"
         AutomationProperties.LiveSetting="Assertive">
 


### PR DESCRIPTION
## Summary
- 全20個のWindow/DialogにFontSize="{DynamicResource BaseFontSize}"を追加
- WPFのプロパティ継承により、DataGridのセル内テキストを含む全子コントロールがフォントサイズ設定に追従するようになる

Closes #823

## 原因
Window要素にFontSizeバインディングが設定されておらず、システムデフォルト（12px）が使われていた。個別のTextBlockには`{DynamicResource BaseFontSize}`が設定されていたが、DataGridのセル内テキストには設定がなく、フォントサイズ変更の影響を受けなかった。

## 修正内容
全Window宣言に`FontSize="{DynamicResource BaseFontSize}"`を追加。WPFの`FontSize` inherited propertyの仕組みにより、DataGridを含む全子コントロールに自動的に伝播する。

## Test plan
- [x] 設定ダイアログでフォントサイズを変更し、メイン画面の履歴一覧DataGridの文字サイズが変わることを確認
- [ ] 各ダイアログ（職員管理、カード管理、操作ログ等）のDataGridも同様に確認
- [x] 小/中/大/特大の全サイズで表示が崩れないことを確認
- [ ] 全1349ユニットテスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)