### PR TITLE
feat: 帳票作成画面の「先月」「今月」ボタンをハイライト表示

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
@@ -54,6 +54,12 @@ public partial class ReportViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<string> _createdFiles = new();
 
+    [ObservableProperty]
+    private bool _isLastMonthSelected;
+
+    [ObservableProperty]
+    private bool _isThisMonthSelected;
+
     /// <summary>
     /// 年の選択肢（過去5年分）
     /// </summary>
@@ -116,6 +122,34 @@ public partial class ReportViewModel : ViewModelBase
         var lastMonth = now.AddMonths(-1);
         SelectedYear = lastMonth.Year;
         SelectedMonth = lastMonth.Month;
+    }
+
+    /// <summary>
+    /// 選択年が変更されたときにボタンのハイライト状態を更新
+    /// </summary>
+    partial void OnSelectedYearChanged(int value)
+    {
+        UpdateMonthButtonHighlights();
+    }
+
+    /// <summary>
+    /// 選択月が変更されたときにボタンのハイライト状態を更新
+    /// </summary>
+    partial void OnSelectedMonthChanged(int value)
+    {
+        UpdateMonthButtonHighlights();
+    }
+
+    /// <summary>
+    /// 「先月」「今月」ボタンのハイライト状態を更新
+    /// </summary>
+    internal void UpdateMonthButtonHighlights()
+    {
+        var now = DateTime.Now;
+        var lastMonth = now.AddMonths(-1);
+
+        IsThisMonthSelected = (SelectedYear == now.Year && SelectedMonth == now.Month);
+        IsLastMonthSelected = (SelectedYear == lastMonth.Year && SelectedMonth == lastMonth.Month);
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -44,17 +44,43 @@
                                 Command="{Binding SelectLastMonthCommand}"
                                 Padding="15,6"
                                 Margin="0,0,10,0"
-                                Background="{DynamicResource ReturnBackgroundBrush}"
-                                BorderBrush="{DynamicResource HeaderBackgroundBrush}"
                                 AutomationProperties.Name="先月を選択"
-                                ToolTip="対象年月を先月に設定"/>
+                                ToolTip="対象年月を先月に設定">
+                            <Button.Style>
+                                <Style TargetType="Button">
+                                    <Setter Property="Background" Value="{DynamicResource ReturnBackgroundBrush}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource HeaderBackgroundBrush}"/>
+                                    <Setter Property="FontWeight" Value="Normal"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsLastMonthSelected}" Value="True">
+                                            <Setter Property="Background" Value="{DynamicResource HeaderBackgroundBrush}"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                            <Setter Property="FontWeight" Value="Bold"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
                         <Button Content="今月"
                                 Command="{Binding SelectThisMonthCommand}"
                                 Padding="15,6"
-                                Background="{DynamicResource ReturnBackgroundBrush}"
-                                BorderBrush="{DynamicResource HeaderBackgroundBrush}"
                                 AutomationProperties.Name="今月を選択"
-                                ToolTip="対象年月を今月に設定"/>
+                                ToolTip="対象年月を今月に設定">
+                            <Button.Style>
+                                <Style TargetType="Button">
+                                    <Setter Property="Background" Value="{DynamicResource ReturnBackgroundBrush}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource HeaderBackgroundBrush}"/>
+                                    <Setter Property="FontWeight" Value="Normal"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsThisMonthSelected}" Value="True">
+                                            <Setter Property="Background" Value="{DynamicResource HeaderBackgroundBrush}"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource OnPrimaryBrush}"/>
+                                            <Setter Property="FontWeight" Value="Bold"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
                     </StackPanel>
                     <!-- 年月選択（その他の月用） -->
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,0">

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -408,6 +408,118 @@ public class ReportViewModelTests
 
     #endregion
 
+    #region Issue #825: 月ボタンハイライトテスト
+
+    /// <summary>
+    /// 初期状態（先月がデフォルト）でIsLastMonthSelectedがtrueであること
+    /// </summary>
+    [Fact]
+    public void Constructor_ShouldHighlightLastMonthButton()
+    {
+        // Assert
+        _viewModel.IsLastMonthSelected.Should().BeTrue();
+        _viewModel.IsThisMonthSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 「今月」を選択するとIsThisMonthSelectedがtrue、IsLastMonthSelectedがfalseになること
+    /// </summary>
+    [Fact]
+    public void SelectThisMonth_ShouldHighlightThisMonthButton()
+    {
+        // Act
+        _viewModel.SelectThisMonth();
+
+        // Assert
+        _viewModel.IsThisMonthSelected.Should().BeTrue();
+        _viewModel.IsLastMonthSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 「先月」を選択するとIsLastMonthSelectedがtrue、IsThisMonthSelectedがfalseになること
+    /// </summary>
+    [Fact]
+    public void SelectLastMonth_ShouldHighlightLastMonthButton()
+    {
+        // Arrange - 先に今月に切り替え
+        _viewModel.SelectThisMonth();
+        _viewModel.IsThisMonthSelected.Should().BeTrue();
+
+        // Act
+        _viewModel.SelectLastMonth();
+
+        // Assert
+        _viewModel.IsLastMonthSelected.Should().BeTrue();
+        _viewModel.IsThisMonthSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 先月でも今月でもない年月を選択すると、両方のハイライトがfalseになること
+    /// </summary>
+    [Fact]
+    public void ManualSelection_OtherMonth_ShouldNotHighlightAnyButton()
+    {
+        // Arrange - 先月でも今月でもない月を設定
+        _viewModel.SelectedYear = 2020;
+        _viewModel.SelectedMonth = 6;
+
+        // Assert
+        _viewModel.IsLastMonthSelected.Should().BeFalse();
+        _viewModel.IsThisMonthSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 年だけ変更して月が今月と同じでも、年が違えばハイライトされないこと
+    /// </summary>
+    [Fact]
+    public void ManualSelection_SameMonthDifferentYear_ShouldNotHighlight()
+    {
+        // Arrange
+        var now = DateTime.Now;
+        _viewModel.SelectedYear = now.Year - 1;
+        _viewModel.SelectedMonth = now.Month;
+
+        // Assert
+        _viewModel.IsThisMonthSelected.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// コンボボックスで先月と同じ年月を手動選択してもハイライトされること
+    /// </summary>
+    [Fact]
+    public void ManualSelection_MatchingLastMonth_ShouldHighlight()
+    {
+        // Arrange - 一度別の月にする
+        _viewModel.SelectedYear = 2020;
+        _viewModel.SelectedMonth = 6;
+        _viewModel.IsLastMonthSelected.Should().BeFalse();
+
+        // Act - コンボボックスで先月と同じ値を手動設定
+        var lastMonth = DateTime.Now.AddMonths(-1);
+        _viewModel.SelectedYear = lastMonth.Year;
+        _viewModel.SelectedMonth = lastMonth.Month;
+
+        // Assert
+        _viewModel.IsLastMonthSelected.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// コンボボックスで今月と同じ年月を手動選択してもハイライトされること
+    /// </summary>
+    [Fact]
+    public void ManualSelection_MatchingThisMonth_ShouldHighlight()
+    {
+        // Act - コンボボックスで今月と同じ値を手動設定
+        var now = DateTime.Now;
+        _viewModel.SelectedYear = now.Year;
+        _viewModel.SelectedMonth = now.Month;
+
+        // Assert
+        _viewModel.IsThisMonthSelected.Should().BeTrue();
+    }
+
+    #endregion
+
     #region 個別チェックボックス連動テスト
 
     /// <summary>


### PR DESCRIPTION
## Summary
- 帳票作成画面の「先月」「今月」クイック選択ボタンが、選択中の年月と一致するときにハイライト表示されるようにした
- ハイライト時: 青背景(`HeaderBackgroundBrush`) + 白文字(`OnPrimaryBrush`) + 太字
- 非ハイライト時: 従来通り薄い水色背景(`ReturnBackgroundBrush`)

Closes #825

## 変更内容

### ViewModel (`ReportViewModel.cs`)
- `IsLastMonthSelected` / `IsThisMonthSelected` プロパティを追加
- `OnSelectedYearChanged` / `OnSelectedMonthChanged` コールバックで年月変更時に自動更新
- コンボボックスによる手動選択でも、該当月であればハイライトが連動

### View (`ReportDialog.xaml`)
- 「先月」「今月」ボタンに `DataTrigger` スタイルを追加
- ローカルプロパティ設定を `Style.Setter` に移動（WPFの優先順位でDataTriggerが正しく動作するため）

### テスト (`ReportViewModelTests.cs`)
- 7件のテストを追加:
  - 初期状態で先月ハイライト
  - 今月選択時のハイライト
  - 先月選択時のハイライト
  - 先月でも今月でもない月ではハイライトなし
  - 同じ月でも年が異なればハイライトなし
  - コンボボックスで先月/今月を手動選択してもハイライト

## Test plan
- [x] 全1356ユニットテスト合格
- [x] アプリ起動 → F1で帳票画面を開く → 「先月」ボタンが青くハイライトされていること
- [x] 「今月」ボタンをクリック → 「今月」がハイライトされ、「先月」のハイライトが解除されること
- [x] 「先月」ボタンをクリック → 「先月」がハイライトされ、「今月」のハイライトが解除されること
- [x] コンボボックスで先月でも今月でもない月（例: 2020年6月）を選択 → 両方ともハイライトなし
- [x] コンボボックスで先月と同じ年月を選択 → 「先月」がハイライトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)