### PR TITLE
fix: テストプロジェクトのnullable参照型警告を全て解消（#834）

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -1185,7 +1185,7 @@ FEDCBA9876543210,鈴木花子,002,テスト2";
         await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
 
         // ledger_id=999は存在しない
-        _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(999)).ReturnsAsync((Ledger)null);
+        _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(999)).ReturnsAsync((Ledger?)null);
 
         // Act
         var result = await _service.PreviewLedgerDetailsAsync(filePath);

--- a/ICCardManager/tests/ICCardManager.Tests/Services/DebugDataServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/DebugDataServiceTests.cs
@@ -38,12 +38,12 @@ public class DebugDataServiceTests
 
         // 全職員・全カード未登録
         _staffRepoMock.Setup(r => r.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()))
-            .ReturnsAsync((Staff)null);
+            .ReturnsAsync((Staff?)null);
         _staffRepoMock.Setup(r => r.InsertAsync(It.IsAny<Staff>()))
             .ReturnsAsync(true);
 
         _cardRepoMock.Setup(r => r.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()))
-            .ReturnsAsync((IcCard)null);
+            .ReturnsAsync((IcCard?)null);
         _cardRepoMock.Setup(r => r.InsertAsync(It.IsAny<IcCard>()))
             .ReturnsAsync(true);
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
@@ -74,7 +74,7 @@ public class LedgerMergeServiceTests
         string summary,
         int expense,
         int balance,
-        List<LedgerDetail> details = null)
+        List<LedgerDetail>? details = null)
     {
         return new Ledger
         {
@@ -221,7 +221,7 @@ public class LedgerMergeServiceTests
         _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(1))
             .ReturnsAsync(CreateTestLedger(1, TestCardIdm, DateTime.Now, "A", 200, 800));
         _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(999))
-            .ReturnsAsync((Ledger)null);
+            .ReturnsAsync((Ledger?)null);
 
         // Act
         var result = await _service.MergeAsync(new List<int> { 1, 999 });
@@ -596,9 +596,9 @@ public class LedgerMergeServiceTests
         SetupGetByIdMocks(ledger1, ledger2);
         SetupMergeMockSuccess();
 
-        string capturedUndoJson = null;
+        string? capturedUndoJson = null;
         int capturedTargetId = 0;
-        string capturedDescription = null;
+        string? capturedDescription = null;
 
         _ledgerRepositoryMock
             .Setup(x => x.SaveMergeHistoryAsync(
@@ -647,7 +647,7 @@ public class LedgerMergeServiceTests
         SetupGetByIdMocks(ledger1, ledger2);
         SetupMergeMockSuccess();
 
-        string capturedUndoJson = null;
+        string? capturedUndoJson = null;
         _ledgerRepositoryMock
             .Setup(x => x.SaveMergeHistoryAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
             .Callback<int, string, string>((_, _, json) => capturedUndoJson = json)

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
@@ -1959,7 +1959,7 @@ public class LendingServiceTests : IDisposable
             new() { UseDate = new DateTime(2026, 2, 5), Balance = 4790, Amount = 210, EntryStation = "天神", ExitStation = "博多" }
         };
 
-        Ledger capturedLedger = null;
+        Ledger? capturedLedger = null;
         _ledgerRepositoryMock.Setup(x => x.GetExistingDetailKeysAsync(TestCardIdm, It.IsAny<DateTime>()))
             .ReturnsAsync(new HashSet<(DateTime?, int?, bool)>());
         _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync(TestCardIdm, It.IsAny<DateTime>()))

--- a/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTests.cs
@@ -51,8 +51,8 @@ public class PrintServiceTests
         int income,
         int expense,
         int balance,
-        string staffName = null,
-        string note = null)
+        string? staffName = null,
+        string? note = null)
     {
         return new Ledger
         {
@@ -135,7 +135,7 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Rows.Should().HaveCountGreaterOrEqualTo(2); // 繰越行 + データ行
+        result!.Rows.Should().HaveCountGreaterOrEqualTo(2); // 繰越行 + データ行
 
         var carryoverRow = result.Rows.First();
         carryoverRow.Summary.Should().Be("5月より繰越");
@@ -178,7 +178,7 @@ public class PrintServiceTests
         // Assert
         result.Should().NotBeNull();
         // 繰越行なし、データ行のみ
-        result.Rows.Should().HaveCount(1);
+        result!.Rows.Should().HaveCount(1);
         result.Rows.First().Summary.Should().Be("役務費によりチャージ");
     }
 
@@ -213,7 +213,7 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Rows.Should().HaveCountGreaterOrEqualTo(2); // 前年度繰越 + データ行
+        result!.Rows.Should().HaveCountGreaterOrEqualTo(2); // 前年度繰越 + データ行
 
         var carryoverRow = result.Rows.First();
         carryoverRow.Summary.Should().Be("前年度より繰越");
@@ -261,7 +261,7 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        var carryoverRow = result.Rows.First();
+        var carryoverRow = result!.Rows.First();
         carryoverRow.Summary.Should().Be("7月より繰越");
         carryoverRow.Income.Should().BeNull("月次繰越の受入金額は空欄であるべき");
         carryoverRow.Balance.Should().Be(2700, "残額には前月末残高が表示されるべき");
@@ -305,8 +305,8 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.CumulativeTotal.Should().NotBeNull();
-        result.CumulativeTotal.Label.Should().Be("累計");
+        result!.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal!.Label.Should().Be("累計");
         result.CumulativeTotal.Income.Should().Be(5000);  // 5月チャージ
         result.CumulativeTotal.Expense.Should().Be(300);   // 6月利用
         result.CumulativeTotal.Balance.Should().Be(4700);  // 最終残高
@@ -354,8 +354,8 @@ public class PrintServiceTests
         result.Should().NotBeNull();
 
         // 累計行が存在する
-        result.CumulativeTotal.Should().NotBeNull();
-        result.CumulativeTotal.Label.Should().Be("累計");
+        result!.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal!.Label.Should().Be("累計");
         result.CumulativeTotal.Income.Should().Be(5000);   // 4月のチャージ
         result.CumulativeTotal.Expense.Should().Be(600);    // 2月300 + 3月300
         result.CumulativeTotal.Balance.Should().Be(2400);   // 最終残高
@@ -415,7 +415,7 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.MonthlyTotal.Balance.Should().BeNull($"月={month} の月計残額は常にnull（空欄）であるべき");
+        result!.MonthlyTotal.Balance.Should().BeNull($"月={month} の月計残額は常にnull（空欄）であるべき");
     }
 
     #endregion
@@ -462,8 +462,8 @@ public class PrintServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.CumulativeTotal.Should().NotBeNull();
-        result.CumulativeTotal.Income.Should().Be(5000);   // 4月チャージのみ
+        result!.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal!.Income.Should().Be(5000);   // 4月チャージのみ
         result.CumulativeTotal.Expense.Should().Be(1200);   // 300×4回
         result.CumulativeTotal.Balance.Should().Be(3400);   // 最終残高
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -191,7 +191,7 @@ public class CardManageViewModelTests
         // Arrange
         var idm = "0102030405060708";
         // 未登録カード（既存カードなし）のシナリオ
-        _cardRepositoryMock.Setup(r => r.GetByIdmAsync(idm, true)).ReturnsAsync((IcCard)null);
+        _cardRepositoryMock.Setup(r => r.GetByIdmAsync(idm, true)).ReturnsAsync((IcCard?)null);
 
         // Act
         var completed = await _viewModel.StartNewCardWithIdmAsync(idm);

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/IncompleteBusStopViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/IncompleteBusStopViewModelTests.cs
@@ -538,7 +538,7 @@ public class IncompleteBusStopViewModelTests
     public void SelectedLedgerId_WithoutSelectedItem_ShouldReturnNull()
     {
         // Arrange
-        _viewModel.SelectedItem = null;
+        _viewModel.SelectedItem = null!;
 
         // Act & Assert
         _viewModel.SelectedLedgerId.Should().BeNull();
@@ -598,7 +598,7 @@ public class IncompleteBusStopViewModelTests
         // Arrange
         _ledgerRepositoryMock
             .Setup(r => r.GetByIdAsync(999))
-            .ReturnsAsync((Ledger)null);
+            .ReturnsAsync((Ledger?)null);
 
         // Act
         var result = await _viewModel.UpdateItemSummaryAsync(999);

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/VirtualCardViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/VirtualCardViewModelTests.cs
@@ -27,7 +27,7 @@ public class VirtualCardViewModelTests
     }
 
     private static VirtualCardViewModel CreateViewModel(
-        Mock<ILedgerRepository> mockLedgerRepo = null)
+        Mock<ILedgerRepository>? mockLedgerRepo = null)
     {
         mockLedgerRepo ??= CreateMockLedgerRepository();
 
@@ -336,7 +336,7 @@ public class VirtualCardViewModelTests
     public void ApplyAndTouch_NoSelection_DoesNotCreateResult()
     {
         var vm = CreateViewModel();
-        vm.SelectedCard = null;
+        vm.SelectedCard = null!;
 
         vm.ApplyAndTouch();
 


### PR DESCRIPTION
## Summary

- テストプロジェクトで発生していた27件のnullable参照型警告（CS8600/CS8602/CS8625）を全て解消
- `dotnet test` 実行時のビルド出力が「0 個の警告」になり、本来注意すべき警告が見落とされなくなる

## Changes

8つのテストファイルを修正（コード行数の増減はなし: 27行変更）:

| ファイル | 警告数 | 修正内容 |
|----------|--------|----------|
| `PrintServiceTests.cs` | 13件 | `result!.` / `CumulativeTotal!.` でnull-forgiving追加、デフォルト引数をnullable型に |
| `LedgerMergeServiceTests.cs` | 5件 | デフォルト引数・ローカル変数・ReturnsAsyncをnullable型に |
| `VirtualCardViewModelTests.cs` | 2件 | デフォルト引数をnullable型に、プロパティ代入に`null!` |
| `IncompleteBusStopViewModelTests.cs` | 2件 | プロパティ代入に`null!`、ReturnsAsyncをnullable型に |
| `DebugDataServiceTests.cs` | 2件 | ReturnsAsyncをnullable型に |
| `CardManageViewModelTests.cs` | 1件 | ReturnsAsyncをnullable型に |
| `CsvImportServiceTests.cs` | 1件 | ReturnsAsyncをnullable型に |
| `LendingServiceTests.cs` | 1件 | ローカル変数をnullable型に |

## 修正パターン

| 警告 | 修正方法 |
|------|----------|
| CS8625: デフォルト引数 `= null` | パラメータ型を `Type?` に変更 |
| CS8600: `ReturnsAsync((Type)null)` | `ReturnsAsync((Type?)null)` に変更 |
| CS8600: ローカル変数 `Type x = null` | `Type? x = null` に変更 |
| CS8625: プロパティ `= null` | `= null!` に変更 |
| CS8602: NotBeNull()後の逆参照 | `result!.Prop` でnull-forgiving演算子を追加 |

## Test plan

- [x] `dotnet build tests/ICCardManager.Tests` → 0 個の警告、0 エラー
- [x] `dotnet test tests/ICCardManager.Tests` → 1376テスト全成功
- [x] `dotnet test`（全テスト）で警告が出ないことを確認

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)