### PR TITLE
fix: プレビューの月計・累計行で受入・払出が0の場合も表示（#842）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -743,8 +743,9 @@ namespace ICCardManager.Services
                 var monthlyRow = new TableRow { Background = new SolidColorBrush(Color.FromRgb(240, 240, 240)) };
                 monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Center));
                 monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Label, true, TextAlignment.Left));
-                monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Income > 0 ? data.MonthlyTotal.Income.ToString("N0") : "", true, TextAlignment.Right));
-                monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Expense > 0 ? data.MonthlyTotal.Expense.ToString("N0") : "", true, TextAlignment.Right));
+                // Issue #842: 月計行は0も表示（Issue #451のExcel側と同様）
+                monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Income.ToString("N0"), true, TextAlignment.Right));
+                monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Expense.ToString("N0"), true, TextAlignment.Right));
                 monthlyRow.Cells.Add(CreateDataCell(data.MonthlyTotal.Balance?.ToString("N0") ?? "", true, TextAlignment.Right));
                 monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
                 monthlyRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
@@ -756,8 +757,9 @@ namespace ICCardManager.Services
                     var cumulativeRow = new TableRow { Background = new SolidColorBrush(Color.FromRgb(230, 230, 230)) };
                     cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Center));
                     cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Label, true, TextAlignment.Left));
-                    cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Income > 0 ? data.CumulativeTotal.Income.ToString("N0") : "", true, TextAlignment.Right));
-                    cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Expense > 0 ? data.CumulativeTotal.Expense.ToString("N0") : "", true, TextAlignment.Right));
+                    // Issue #842: 累計行も0を表示（Issue #451のExcel側と同様）
+                    cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Income.ToString("N0"), true, TextAlignment.Right));
+                    cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Expense.ToString("N0"), true, TextAlignment.Right));
                     cumulativeRow.Cells.Add(CreateDataCell(data.CumulativeTotal.Balance?.ToString("N0") ?? "", true, TextAlignment.Right));
                     cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));
                     cumulativeRow.Cells.Add(CreateDataCell("", true, TextAlignment.Left));


### PR DESCRIPTION
## Summary

- `PrintService.cs`のFlowDocumentレンダリングで、月計行・累計行の受入金額・払出金額が0の場合に空欄になっていたのを修正
- 原因: `Income > 0 ? Income.ToString("N0") : ""` という条件で0を空文字にしていた
- 修正: 条件を削除し、`Income.ToString("N0")` で常に表示（Excel出力のReportServiceと同じ動作に）

Closes #842

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `PrintService.cs` | 月計行・累計行の受入/払出セルから `> 0` 条件を削除 |
| `PrintServiceTests.cs` | 0値が正しく保持されるテスト2件追加 |

## Test plan

- [x] `dotnet build` — 0エラー、0警告
- [x] `dotnet test` — 単体テスト全1378件パス（新規2件含む）
- [x] 手動テスト: データなし月のプレビュー → 月計行の受入・払出に「0」が表示されること
- [ ] 手動テスト: チャージのみの月のプレビュー → 月計行の払出に「0」が表示されること
- [ ] 手動テスト: 利用のみの月のプレビュー → 月計行の受入に「0」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)