### PR TITLE
refactor: 物品出納簿のデータ準備ロジックを統合（#841）

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -198,6 +198,7 @@ namespace ICCardManager
             });
             services.AddSingleton<CardLockManager>();
             services.AddSingleton<LendingService>();
+            services.AddSingleton<IReportDataBuilder, ReportDataBuilder>();
             services.AddSingleton<ReportService>();
             services.AddSingleton<PrintService>();
             services.AddSingleton<BackupService>();

--- a/ICCardManager/src/ICCardManager/Models/MonthlyReportData.cs
+++ b/ICCardManager/src/ICCardManager/Models/MonthlyReportData.cs
@@ -1,0 +1,75 @@
+namespace ICCardManager.Models
+{
+    /// <summary>
+    /// 月次帳票の共通データモデル（ReportService/PrintService共用）
+    /// </summary>
+    /// <remarks>
+    /// Issue #841: ReportService（Excel出力）とPrintService（印刷プレビュー）の
+    /// データ準備ロジックを統合するために導入。
+    /// </remarks>
+    public class MonthlyReportData
+    {
+        /// <summary>カード情報</summary>
+        public IcCard Card { get; set; }
+
+        /// <summary>年</summary>
+        public int Year { get; set; }
+
+        /// <summary>月</summary>
+        public int Month { get; set; }
+
+        /// <summary>前月末残高（null: 新規購入カードで過去データなし）</summary>
+        public int? PrecedingBalance { get; set; }
+
+        /// <summary>繰越行データ（null: 繰越行なし）</summary>
+        public CarryoverRowData Carryover { get; set; }
+
+        /// <summary>フィルタ・並替済みの台帳データ</summary>
+        public System.Collections.Generic.List<Ledger> Ledgers { get; set; } = new();
+
+        /// <summary>月計</summary>
+        public ReportTotalData MonthlyTotal { get; set; } = new();
+
+        /// <summary>累計（4月はnull: 月計と同額のため省略）</summary>
+        public ReportTotalData CumulativeTotal { get; set; }
+
+        /// <summary>次年度繰越額（3月のみ）</summary>
+        public int? CarryoverToNextYear { get; set; }
+    }
+
+    /// <summary>
+    /// 繰越行データ
+    /// </summary>
+    public class CarryoverRowData
+    {
+        /// <summary>繰越日付</summary>
+        public System.DateTime Date { get; set; }
+
+        /// <summary>摘要（「前年度より繰越」or「X月より繰越」）</summary>
+        public string Summary { get; set; } = string.Empty;
+
+        /// <summary>受入金額（4月の前年度繰越のみ値あり、それ以外はnull）</summary>
+        public int? Income { get; set; }
+
+        /// <summary>残額</summary>
+        public int Balance { get; set; }
+    }
+
+    /// <summary>
+    /// 帳票合計データ（月計・累計共用）
+    /// </summary>
+    public class ReportTotalData
+    {
+        /// <summary>ラベル（「X月計」or「累計」）</summary>
+        public string Label { get; set; } = string.Empty;
+
+        /// <summary>受入合計</summary>
+        public int Income { get; set; }
+
+        /// <summary>払出合計</summary>
+        public int Expense { get; set; }
+
+        /// <summary>残額（4月の月計とすべての累計で値あり、それ以外はnull）</summary>
+        public int? Balance { get; set; }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/IReportDataBuilder.cs
+++ b/ICCardManager/src/ICCardManager/Services/IReportDataBuilder.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using ICCardManager.Models;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 月次帳票のデータ準備インターフェース
+    /// </summary>
+    /// <remarks>
+    /// Issue #841: ReportService（Excel出力）とPrintService（印刷プレビュー）の
+    /// 共通データ準備ロジックを統合するために導入。
+    /// </remarks>
+    public interface IReportDataBuilder
+    {
+        /// <summary>
+        /// 月次帳票データを構築する
+        /// </summary>
+        /// <param name="cardIdm">カードIDm</param>
+        /// <param name="year">年</param>
+        /// <param name="month">月</param>
+        /// <returns>帳票データ。カードが見つからない場合はnull</returns>
+        Task<MonthlyReportData> BuildAsync(string cardIdm, int year, int month);
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/ReportDataBuilder.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportDataBuilder.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 月次帳票のデータ準備サービス
+    /// </summary>
+    /// <remarks>
+    /// Issue #841: ReportService（Excel出力）とPrintService（印刷プレビュー）の
+    /// 共通データ準備ロジックを統合。繰越・月計・累計・年度境界の判定を一元化する。
+    /// </remarks>
+    public class ReportDataBuilder : IReportDataBuilder
+    {
+        private readonly ICardRepository _cardRepository;
+        private readonly ILedgerRepository _ledgerRepository;
+
+        public ReportDataBuilder(
+            ICardRepository cardRepository,
+            ILedgerRepository ledgerRepository)
+        {
+            _cardRepository = cardRepository;
+            _ledgerRepository = ledgerRepository;
+        }
+
+        /// <inheritdoc/>
+        public async Task<MonthlyReportData> BuildAsync(string cardIdm, int year, int month)
+        {
+            // カード情報を取得
+            var card = await _cardRepository.GetByIdmAsync(cardIdm, includeDeleted: true);
+            if (card == null)
+            {
+                return null;
+            }
+
+            // 前月末残高を取得（繰越行表示および残高チェーン並替に使用）
+            int? precedingBalance;
+            if (month == 4)
+            {
+                precedingBalance = await _ledgerRepository.GetCarryoverBalanceAsync(cardIdm, year - 1);
+            }
+            else
+            {
+                precedingBalance = await GetPreviousMonthBalanceAsync(cardIdm, year, month);
+            }
+
+            // Issue #784: 残高チェーンに基づいて同一日内の時系列順を復元
+            var ledgers = LedgerOrderHelper.ReorderByBalanceChain(
+                (await _ledgerRepository.GetByMonthAsync(cardIdm, year, month))
+                    .Where(l => l.Summary != SummaryGenerator.GetLendingSummary()),
+                precedingBalance);
+
+            // 繰越行データを生成
+            CarryoverRowData carryover = null;
+            if (precedingBalance.HasValue)
+            {
+                if (month == 4)
+                {
+                    carryover = new CarryoverRowData
+                    {
+                        Date = new DateTime(year, 4, 1),
+                        Summary = SummaryGenerator.GetCarryoverFromPreviousYearSummary(),
+                        Income = precedingBalance.Value,
+                        Balance = precedingBalance.Value
+                    };
+                }
+                else
+                {
+                    int previousMonth = month == 1 ? 12 : month - 1;
+                    carryover = new CarryoverRowData
+                    {
+                        Date = new DateTime(year, month, 1),
+                        Summary = SummaryGenerator.GetCarryoverFromPreviousMonthSummary(previousMonth),
+                        // Issue #753: 月次繰越の受入欄は空欄（受入金額を表示するのは4月の前年度繰越のみ）
+                        Income = null,
+                        Balance = precedingBalance.Value
+                    };
+                }
+            }
+
+            // 月計を計算
+            var monthlyIncome = ledgers.Sum(l => l.Income);
+            var monthlyExpense = ledgers.Sum(l => l.Expense);
+            var monthEndBalance = ledgers.LastOrDefault()?.Balance ?? 0;
+
+            // 累計データを計算（4月の月計残額表示にも使用）
+            var fiscalYearStartYear = month >= 4 ? year : year - 1;
+            var fiscalYearStart = new DateTime(fiscalYearStartYear, 4, 1);
+            var fiscalYearEnd = new DateTime(year, month, DateTime.DaysInMonth(year, month));
+            // Issue #784: 残高チェーンに基づいて時系列順を復元
+            var yearlyLedgers = LedgerOrderHelper.ReorderByBalanceChain(
+                (await _ledgerRepository.GetByDateRangeAsync(cardIdm, fiscalYearStart, fiscalYearEnd))
+                    .Where(l => l.Summary != SummaryGenerator.GetLendingSummary()));
+
+            var yearlyIncome = yearlyLedgers.Sum(l => l.Income);
+            var yearlyExpense = yearlyLedgers.Sum(l => l.Expense);
+            var currentBalance = yearlyLedgers.LastOrDefault()?.Balance ?? monthEndBalance;
+
+            // 月計・累計の組み立て
+            ReportTotalData monthlyTotal;
+            ReportTotalData cumulativeTotal;
+
+            if (month == 4)
+            {
+                // Issue #813: 4月は月計と累計が同額のため累計行を省略し、月計行に残額を表示
+                var aprilBalance = yearlyLedgers.Any()
+                    ? currentBalance
+                    : (precedingBalance ?? 0);
+                monthlyTotal = new ReportTotalData
+                {
+                    Label = SummaryGenerator.GetMonthlySummary(month),
+                    Income = monthlyIncome,
+                    Expense = monthlyExpense,
+                    Balance = aprilBalance
+                };
+                cumulativeTotal = null;
+            }
+            else
+            {
+                monthlyTotal = new ReportTotalData
+                {
+                    Label = SummaryGenerator.GetMonthlySummary(month),
+                    Income = monthlyIncome,
+                    Expense = monthlyExpense,
+                    Balance = null
+                };
+                cumulativeTotal = new ReportTotalData
+                {
+                    Label = SummaryGenerator.GetCumulativeSummary(),
+                    Income = yearlyIncome,
+                    Expense = yearlyExpense,
+                    Balance = currentBalance
+                };
+            }
+
+            // 3月のみ次年度繰越
+            int? carryoverToNextYear = month == 3 ? currentBalance : (int?)null;
+
+            return new MonthlyReportData
+            {
+                Card = card,
+                Year = year,
+                Month = month,
+                PrecedingBalance = precedingBalance,
+                Carryover = carryover,
+                Ledgers = ledgers,
+                MonthlyTotal = monthlyTotal,
+                CumulativeTotal = cumulativeTotal,
+                CarryoverToNextYear = carryoverToNextYear
+            };
+        }
+
+        /// <summary>
+        /// 前月の残高を取得
+        /// </summary>
+        /// <param name="cardIdm">カードIDm</param>
+        /// <param name="year">年</param>
+        /// <param name="month">月</param>
+        /// <returns>前月残高。過去のデータがない場合はnull</returns>
+        private async Task<int?> GetPreviousMonthBalanceAsync(string cardIdm, int year, int month)
+        {
+            // 前月の年月を計算
+            int previousYear, previousMonth;
+            if (month == 1)
+            {
+                previousYear = year - 1;
+                previousMonth = 12;
+            }
+            else
+            {
+                previousYear = year;
+                previousMonth = month - 1;
+            }
+
+            // 前月の履歴を取得し、最後の残高を返す
+            // Issue #784: 残高チェーンに基づいて時系列順を復元
+            var previousLedgers = LedgerOrderHelper.ReorderByBalanceChain(
+                (await _ledgerRepository.GetByMonthAsync(cardIdm, previousYear, previousMonth))
+                    .Where(l => l.Summary != SummaryGenerator.GetLendingSummary()));
+
+            if (previousLedgers.Count > 0)
+            {
+                return previousLedgers.Last().Balance;
+            }
+
+            // 前月のデータがない場合は、さらに前の月から繰り越しを探す
+            // 年度開始月（4月）まで遡って繰越残高を取得
+            var fiscalYearStartYear = month >= 4 ? year : year - 1;
+            var carryover = await _ledgerRepository.GetCarryoverBalanceAsync(cardIdm, fiscalYearStartYear - 1);
+            return carryover;
+        }
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTests.cs
@@ -26,9 +26,10 @@ public class PrintServiceTests
     {
         _cardRepositoryMock = new Mock<ICardRepository>();
         _ledgerRepositoryMock = new Mock<ILedgerRepository>();
-        _printService = new PrintService(
+        var reportDataBuilder = new ReportDataBuilder(
             _cardRepositoryMock.Object,
             _ledgerRepositoryMock.Object);
+        _printService = new PrintService(reportDataBuilder);
     }
 
     #region ヘルパーメソッド

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// ReportDataBuilderの単体テスト（Issue #841: データ準備ロジックの統合）
+/// </summary>
+public class ReportDataBuilderTests
+{
+    private readonly Mock<ICardRepository> _cardRepositoryMock;
+    private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
+    private readonly ReportDataBuilder _builder;
+
+    private const string TestCardIdm = "0102030405060708";
+
+    public ReportDataBuilderTests()
+    {
+        _cardRepositoryMock = new Mock<ICardRepository>();
+        _ledgerRepositoryMock = new Mock<ILedgerRepository>();
+        _builder = new ReportDataBuilder(
+            _cardRepositoryMock.Object,
+            _ledgerRepositoryMock.Object);
+    }
+
+    #region ヘルパーメソッド
+
+    private static IcCard CreateTestCard(string idm = TestCardIdm)
+    {
+        return new IcCard
+        {
+            CardIdm = idm,
+            CardType = "はやかけん",
+            CardNumber = "001"
+        };
+    }
+
+    private static Ledger CreateTestLedger(
+        int id, string cardIdm, DateTime date,
+        string summary, int income, int expense, int balance,
+        string staffName = null, string note = null)
+    {
+        return new Ledger
+        {
+            Id = id,
+            CardIdm = cardIdm,
+            Date = date,
+            Summary = summary,
+            Income = income,
+            Expense = expense,
+            Balance = balance,
+            StaffName = staffName,
+            Note = note
+        };
+    }
+
+    private void SetupCard(string idm = TestCardIdm)
+    {
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(idm, true))
+            .ReturnsAsync(CreateTestCard(idm));
+    }
+
+    private void SetupMonthlyLedgers(string idm, int year, int month, List<Ledger> ledgers)
+    {
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByMonthAsync(idm, year, month))
+            .ReturnsAsync(ledgers);
+    }
+
+    private void SetupDateRangeLedgers(string idm, DateTime from, DateTime to, List<Ledger> ledgers)
+    {
+        _ledgerRepositoryMock
+            .Setup(r => r.GetByDateRangeAsync(idm, from, to))
+            .ReturnsAsync(ledgers);
+    }
+
+    private void SetupCarryoverBalance(string idm, int fiscalYear, int? balance)
+    {
+        _ledgerRepositoryMock
+            .Setup(r => r.GetCarryoverBalanceAsync(idm, fiscalYear))
+            .ReturnsAsync(balance);
+    }
+
+    /// <summary>
+    /// 基本的な月次テストのセットアップ（5月以降用）
+    /// </summary>
+    private void SetupBasicMonth(int year, int month, int previousBalance, List<Ledger> ledgers)
+    {
+        SetupCard();
+
+        // 前月の残高
+        int prevYear = month == 1 ? year - 1 : year;
+        int prevMonth = month == 1 ? 12 : month - 1;
+        SetupMonthlyLedgers(TestCardIdm, prevYear, prevMonth,
+            new List<Ledger>
+            {
+                CreateTestLedger(999, TestCardIdm, new DateTime(prevYear, prevMonth, 15),
+                    "鉄道（テスト）", 0, 100, previousBalance)
+            });
+
+        // 当月の台帳
+        SetupMonthlyLedgers(TestCardIdm, year, month, ledgers);
+
+        // 年度範囲（累計用）
+        var fiscalYearStartYear = month >= 4 ? year : year - 1;
+        var fiscalYearStart = new DateTime(fiscalYearStartYear, 4, 1);
+        var fiscalYearEnd = new DateTime(year, month, DateTime.DaysInMonth(year, month));
+        SetupDateRangeLedgers(TestCardIdm, fiscalYearStart, fiscalYearEnd, ledgers);
+    }
+
+    #endregion
+
+    #region カード不存在テスト
+
+    [Fact]
+    public async Task BuildAsync_CardNotFound_ReturnsNull()
+    {
+        // Arrange
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync((IcCard?)null);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 5);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region 4月テスト（前年度繰越・累計行省略）
+
+    [Fact]
+    public async Task BuildAsync_April_WithPrecedingBalance_HasFiscalYearCarryover()
+    {
+        // Arrange
+        SetupCard();
+        SetupCarryoverBalance(TestCardIdm, 2024, 5000); // 前年度（2024年度）の繰越
+        var ledgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10),
+                "鉄道（天神～博多）", 0, 210, 4790)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 4, ledgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 4, 30), ledgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 4);
+
+        // Assert
+        result.Should().NotBeNull();
+
+        // 繰越行: 前年度繰越（Income=残高）
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Date.Should().Be(new DateTime(2025, 4, 1));
+        result.Carryover.Income.Should().Be(5000);
+        result.Carryover.Balance.Should().Be(5000);
+
+        // 月計: 4月は残額表示あり
+        result.MonthlyTotal.Income.Should().Be(0);
+        result.MonthlyTotal.Expense.Should().Be(210);
+        result.MonthlyTotal.Balance.Should().Be(4790);
+
+        // 累計: 4月はnull（省略）
+        result.CumulativeTotal.Should().BeNull();
+
+        // 次年度繰越: なし（4月）
+        result.CarryoverToNextYear.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildAsync_April_NoPrecedingBalance_NoCarryover()
+    {
+        // Arrange: 新規購入カードで前年度データなし
+        SetupCard();
+        SetupCarryoverBalance(TestCardIdm, 2024, null);
+        var ledgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 5),
+                "役務費によりチャージ", 3000, 0, 3000)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 4, ledgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 4, 30), ledgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 4);
+
+        // Assert
+        result.Carryover.Should().BeNull(); // 繰越行なし
+        result.MonthlyTotal.Balance.Should().Be(3000); // 4月は残額表示
+        result.CumulativeTotal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildAsync_April_NoData_BalanceFallsToPrecedingBalance()
+    {
+        // Arrange: 4月にデータがないが前年度繰越あり
+        SetupCard();
+        SetupCarryoverBalance(TestCardIdm, 2024, 5000);
+        SetupMonthlyLedgers(TestCardIdm, 2025, 4, new List<Ledger>());
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 4, 30), new List<Ledger>());
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 4);
+
+        // Assert: 月計の残額は前年度繰越額にフォールバック
+        result.MonthlyTotal.Balance.Should().Be(5000);
+    }
+
+    #endregion
+
+    #region 通常月テスト（5月～2月）
+
+    [Fact]
+    public async Task BuildAsync_RegularMonth_HasMonthlyCarryoverAndCumulative()
+    {
+        // Arrange: 7月
+        SetupCard();
+        var julyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(10, TestCardIdm, new DateTime(2025, 7, 3),
+                "鉄道（天神～博多）", 0, 210, 3790),
+            CreateTestLedger(11, TestCardIdm, new DateTime(2025, 7, 15),
+                "役務費によりチャージ", 5000, 0, 8790)
+        };
+
+        SetupBasicMonth(2025, 7, 4000, julyLedgers);
+
+        // 年度累計データ（4月～7月全体）
+        var yearlyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10), "鉄道", 0, 500, 4500),
+            CreateTestLedger(10, TestCardIdm, new DateTime(2025, 7, 3), "鉄道", 0, 210, 3790),
+            CreateTestLedger(11, TestCardIdm, new DateTime(2025, 7, 15), "チャージ", 5000, 0, 8790)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 7, 31), yearlyLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 7);
+
+        // Assert
+        // 繰越行: 月次繰越（Income=null）
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Income.Should().BeNull();
+        result.Carryover.Balance.Should().Be(4000);
+
+        // 月計: 残額なし
+        result.MonthlyTotal.Income.Should().Be(5000);
+        result.MonthlyTotal.Expense.Should().Be(210);
+        result.MonthlyTotal.Balance.Should().BeNull();
+
+        // 累計: あり
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(5000);
+        result.CumulativeTotal.Expense.Should().Be(710);
+        result.CumulativeTotal.Balance.Should().Be(8790);
+
+        // 次年度繰越: なし
+        result.CarryoverToNextYear.Should().BeNull();
+    }
+
+    #endregion
+
+    #region 3月テスト（次年度繰越）
+
+    [Fact]
+    public async Task BuildAsync_March_HasCarryoverToNextYear()
+    {
+        // Arrange: 3月（年度末）
+        SetupCard();
+        var marchLedgers = new List<Ledger>
+        {
+            CreateTestLedger(20, TestCardIdm, new DateTime(2026, 3, 5),
+                "鉄道（天神～博多）", 0, 300, 2700)
+        };
+
+        // 前月（2月）の残高
+        SetupMonthlyLedgers(TestCardIdm, 2026, 2,
+            new List<Ledger>
+            {
+                CreateTestLedger(19, TestCardIdm, new DateTime(2026, 2, 20),
+                    "鉄道", 0, 200, 3000)
+            });
+
+        SetupMonthlyLedgers(TestCardIdm, 2026, 3, marchLedgers);
+
+        // 年度累計（2025年4月～2026年3月）
+        var yearlyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10), "鉄道", 0, 500, 4500),
+            CreateTestLedger(20, TestCardIdm, new DateTime(2026, 3, 5), "鉄道", 0, 300, 2700)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2026, 3, 31), yearlyLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2026, 3);
+
+        // Assert
+        result.CarryoverToNextYear.Should().Be(2700);
+        result.CumulativeTotal.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region 台帳フィルタテスト
+
+    [Fact]
+    public async Task BuildAsync_FiltersOutLendingSummary()
+    {
+        // Arrange: 貸出中レコードが含まれる月
+        SetupCard();
+        var ledgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 5, 1),
+                SummaryGenerator.GetLendingSummary(), 0, 0, 4000), // 貸出中（除外対象）
+            CreateTestLedger(2, TestCardIdm, new DateTime(2025, 5, 10),
+                "鉄道（天神～博多）", 0, 210, 3790)
+        };
+
+        SetupBasicMonth(2025, 5, 4000, ledgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 5);
+
+        // Assert: 貸出中レコードはフィルタされ、1件のみ
+        result.Ledgers.Should().HaveCount(1);
+        result.Ledgers[0].Summary.Should().Be("鉄道（天神～博多）");
+    }
+
+    #endregion
+
+    #region 1月テスト（年跨ぎ）
+
+    [Fact]
+    public async Task BuildAsync_January_FiscalYearCrossesCalendarYear()
+    {
+        // Arrange: 1月（前年度4月開始の年度に属する）
+        SetupCard();
+        var janLedgers = new List<Ledger>
+        {
+            CreateTestLedger(30, TestCardIdm, new DateTime(2026, 1, 15),
+                "鉄道（天神～博多）", 0, 210, 2790)
+        };
+
+        // 前月（12月）の残高
+        SetupMonthlyLedgers(TestCardIdm, 2025, 12,
+            new List<Ledger>
+            {
+                CreateTestLedger(29, TestCardIdm, new DateTime(2025, 12, 20),
+                    "鉄道", 0, 100, 3000)
+            });
+
+        SetupMonthlyLedgers(TestCardIdm, 2026, 1, janLedgers);
+
+        // 年度累計（2025年4月～2026年1月）
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2026, 1, 31), janLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2026, 1);
+
+        // Assert
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Balance.Should().Be(3000);
+        result.CumulativeTotal.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region データなし月テスト
+
+    [Fact]
+    public async Task BuildAsync_NoLedgers_ReturnsZeroTotals()
+    {
+        // Arrange: データなしの月
+        SetupCard();
+        SetupBasicMonth(2025, 6, 4000, new List<Ledger>());
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 6);
+
+        // Assert
+        result.Ledgers.Should().BeEmpty();
+        result.MonthlyTotal.Income.Should().Be(0);
+        result.MonthlyTotal.Expense.Should().Be(0);
+        result.MonthlyTotal.Balance.Should().BeNull(); // 通常月は残額なし
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
@@ -32,10 +32,14 @@ public class ReportServiceTests : IDisposable
         _ledgerRepositoryMock = new Mock<ILedgerRepository>();
         _settingsRepositoryMock = new Mock<ISettingsRepository>();
         _settingsRepositoryMock.Setup(s => s.GetAppSettings()).Returns(new AppSettings());
+        var reportDataBuilder = new ReportDataBuilder(
+            _cardRepositoryMock.Object,
+            _ledgerRepositoryMock.Object);
         _reportService = new ReportService(
             _cardRepositoryMock.Object,
             _ledgerRepositoryMock.Object,
-            _settingsRepositoryMock.Object);
+            _settingsRepositoryMock.Object,
+            reportDataBuilder);
     }
 
     public void Dispose()

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -35,8 +35,9 @@ public class ReportViewModelTests
         _settingsRepositoryMock = new Mock<ISettingsRepository>();
         _settingsRepositoryMock.Setup(s => s.GetAppSettings()).Returns(new AppSettings());
         // ReportServiceはコンクリートクラスのため、モックしたリポジトリで実インスタンスを作成
-        _reportService = new ReportService(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object, _settingsRepositoryMock.Object);
-        _printService = new PrintService(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object);
+        var reportDataBuilder = new ReportDataBuilder(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object);
+        _reportService = new ReportService(_cardRepositoryMock.Object, _ledgerRepositoryMock.Object, _settingsRepositoryMock.Object, reportDataBuilder);
+        _printService = new PrintService(reportDataBuilder);
 
         _viewModel = new ReportViewModel(
             _reportService,


### PR DESCRIPTION
## Summary

Closes #841

- `ReportService`（Excel出力）と`PrintService`（印刷プレビュー）に重複していたデータ準備ロジックを`ReportDataBuilder`サービスに統合
- Issue #813で発生した「PrintServiceの修正漏れ」のような問題を構造的に防止
- 副次効果: ReportServiceの年次累計クエリに貸出中フィルタが追加され、PrintServiceとの不整合も解消

### 変更内容

| ファイル | 変更 |
|----------|------|
| `Models/MonthlyReportData.cs` | 新規: 共通データモデル（MonthlyReportData, CarryoverRowData, ReportTotalData） |
| `Services/IReportDataBuilder.cs` | 新規: インターフェース |
| `Services/ReportDataBuilder.cs` | 新規: データ準備ロジック統合（前月残高取得・繰越行生成・月計/累計計算・年度境界処理） |
| `Services/ReportService.cs` | データ準備をReportDataBuilder委譲に置換、GetPreviousMonthBalanceAsync削除 |
| `Services/PrintService.cs` | データ準備をReportDataBuilder委譲に置換、GetPreviousMonthBalanceAsync削除 |
| `App.xaml.cs` | DI登録追加 |
| `Tests/ReportDataBuilderTests.cs` | 新規: 9件のテスト |
| テスト3ファイル | コンストラクタ引数の調整 |

### 統合されたロジック（~150行の重複解消）

- `GetPreviousMonthBalanceAsync` — 両サービスで完全一致していた前月残高取得
- 4月特殊処理（前年度繰越・累計行省略・月計に残額表示）
- 3月特殊処理（次年度繰越行）
- 繰越行の分岐ロジック（4月=前年度繰越 vs 他月=月次繰越）
- 月計・累計の集計計算

## Test plan

- [x] `dotnet build` — 0エラー
- [x] `dotnet test` — 全1395件合格（既存1386件 + 新規9件）
- [x] 手動確認: 4月の帳票出力/プレビューが従来と同一結果であること
- [x] 手動確認: 5月以降の通常月の帳票出力/プレビューが従来と同一結果であること
- [x] 手動確認: 3月（年度末）の帳票出力/プレビューが従来と同一結果であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)