### PR TITLE
test: 未テストコードに単体テスト215件を追加

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/ErrorDialogHelper.cs
+++ b/ICCardManager/src/ICCardManager/Common/ErrorDialogHelper.cs
@@ -93,7 +93,7 @@ namespace ICCardManager.Common
         /// <summary>
         /// 例外からエラー情報を取得
         /// </summary>
-        private static (string Message, string ErrorCode) GetErrorInfo(Exception exception)
+        internal static (string Message, string ErrorCode) GetErrorInfo(Exception exception)
         {
             if (exception is AppException appException)
             {

--- a/ICCardManager/src/ICCardManager/Services/BackupService.cs
+++ b/ICCardManager/src/ICCardManager/Services/BackupService.cs
@@ -50,7 +50,7 @@ namespace ICCardManager.Services
         /// 自動バックアップを実行
         /// </summary>
         /// <returns>作成されたバックアップファイルのパス（失敗時はnull）</returns>
-        public async Task<string> ExecuteAutoBackupAsync()
+        public virtual async Task<string> ExecuteAutoBackupAsync()
         {
             string backupPath = null;
 
@@ -128,7 +128,7 @@ namespace ICCardManager.Services
         /// </summary>
         /// <param name="backupFilePath">バックアップファイルのパス</param>
         /// <returns>成功時はtrue、失敗時はfalse</returns>
-        public bool CreateBackup(string backupFilePath)
+        public virtual bool CreateBackup(string backupFilePath)
         {
             try
             {
@@ -191,7 +191,7 @@ namespace ICCardManager.Services
         /// バックアップからリストア
         /// </summary>
         /// <param name="backupFilePath">リストアするバックアップファイルのパス</param>
-        public bool RestoreFromBackup(string backupFilePath)
+        public virtual bool RestoreFromBackup(string backupFilePath)
         {
             var targetPath = _dbContext.DatabasePath;
             var tempPath = targetPath + ".temp";
@@ -290,7 +290,7 @@ namespace ICCardManager.Services
         /// <summary>
         /// バックアップファイル一覧を取得
         /// </summary>
-        public async Task<IEnumerable<BackupFileInfo>> GetBackupFilesAsync()
+        public virtual async Task<IEnumerable<BackupFileInfo>> GetBackupFilesAsync()
         {
             var settings = await _settingsRepository.GetAppSettingsAsync();
             var backupPath = settings.BackupPath;

--- a/ICCardManager/tests/ICCardManager.Tests/Common/ErrorDialogHelperTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/ErrorDialogHelperTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using ICCardManager.Common;
+using ICCardManager.Common.Exceptions;
+using Xunit;
+
+namespace ICCardManager.Tests.Common;
+
+/// <summary>
+/// ErrorDialogHelperの単体テスト
+/// GetErrorInfoメソッド（internal）の例外→エラー情報マッピングを検証
+/// </summary>
+public class ErrorDialogHelperTests
+{
+    #region GetErrorInfo - AppException系テスト
+
+    [Fact]
+    public void GetErrorInfo_CardReaderExceptionの場合UserFriendlyMessageとErrorCodeを返すこと()
+    {
+        // Arrange
+        var exception = CardReaderException.NotConnected();
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Be(exception.UserFriendlyMessage);
+        errorCode.Should().Be("CR001");
+    }
+
+    [Fact]
+    public void GetErrorInfo_DatabaseExceptionの場合UserFriendlyMessageとErrorCodeを返すこと()
+    {
+        // Arrange
+        var exception = DatabaseException.ConnectionFailed();
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Be(exception.UserFriendlyMessage);
+        errorCode.Should().Be("DB001");
+    }
+
+    [Fact]
+    public void GetErrorInfo_BusinessExceptionの場合UserFriendlyMessageとErrorCodeを返すこと()
+    {
+        // Arrange
+        var exception = BusinessException.CardAlreadyLent("TEST_IDM");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Be(exception.UserFriendlyMessage);
+        errorCode.Should().Be("BIZ001");
+    }
+
+    [Fact]
+    public void GetErrorInfo_ValidationExceptionの場合UserFriendlyMessageとErrorCodeを返すこと()
+    {
+        // Arrange
+        var exception = ValidationException.Required("name", "氏名");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Be(exception.UserFriendlyMessage);
+        errorCode.Should().Be("VAL001");
+    }
+
+    [Fact]
+    public void GetErrorInfo_FileOperationExceptionの場合UserFriendlyMessageとErrorCodeを返すこと()
+    {
+        // Arrange
+        var exception = FileOperationException.FileNotFound("/test/path.txt");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Be(exception.UserFriendlyMessage);
+        errorCode.Should().Be("FILE001");
+    }
+
+    #endregion
+
+    #region GetErrorInfo - 一般例外系テスト
+
+    [Fact]
+    public void GetErrorInfo_UnauthorizedAccessExceptionの場合SYS001を返すこと()
+    {
+        // Arrange
+        var exception = new UnauthorizedAccessException("access denied");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("アクセス権限");
+        errorCode.Should().Be("SYS001");
+    }
+
+    [Fact]
+    public void GetErrorInfo_IOExceptionの場合SYS002を返すこと()
+    {
+        // Arrange
+        var exception = new IOException("file read error");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("読み書き");
+        errorCode.Should().Be("SYS002");
+    }
+
+    [Fact]
+    public void GetErrorInfo_TimeoutExceptionの場合SYS003を返すこと()
+    {
+        // Arrange
+        var exception = new TimeoutException("operation timed out");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("タイムアウト");
+        errorCode.Should().Be("SYS003");
+    }
+
+    [Fact]
+    public void GetErrorInfo_InvalidOperationExceptionの場合SYS004を返すこと()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("invalid state");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("実行できません");
+        errorCode.Should().Be("SYS004");
+    }
+
+    [Fact]
+    public void GetErrorInfo_ArgumentExceptionの場合SYS005を返すこと()
+    {
+        // Arrange
+        var exception = new ArgumentException("bad argument");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("入力値");
+        errorCode.Should().Be("SYS005");
+    }
+
+    [Fact]
+    public void GetErrorInfo_ArgumentNullExceptionの場合SYS005を返すこと()
+    {
+        // ArgumentNullExceptionはArgumentExceptionのサブクラスだが、
+        // switchのOR patternで同じSYS005にマッピングされることを確認
+        // Arrange
+        var exception = new ArgumentNullException("paramName");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("入力値");
+        errorCode.Should().Be("SYS005");
+    }
+
+    [Fact]
+    public void GetErrorInfo_NotSupportedExceptionの場合SYS006を返すこと()
+    {
+        // Arrange
+        var exception = new NotSupportedException("not supported");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("サポートされていません");
+        errorCode.Should().Be("SYS006");
+    }
+
+    [Fact]
+    public void GetErrorInfo_未知の例外の場合SYS999を返すこと()
+    {
+        // Arrange - 一般的なExceptionはどのパターンにもマッチしない
+        var exception = new Exception("unknown error");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        message.Should().Contain("予期しないエラー");
+        errorCode.Should().Be("SYS999");
+    }
+
+    [Fact]
+    public void GetErrorInfo_カスタム例外の場合SYS999を返すこと()
+    {
+        // Arrange - switchパターンに含まれないカスタム例外
+        var exception = new OperationCanceledException("cancelled");
+
+        // Act
+        var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+
+        // Assert
+        errorCode.Should().Be("SYS999");
+    }
+
+    #endregion
+
+    #region エラーコード一貫性テスト
+
+    [Fact]
+    public void GetErrorInfo_全てのシステムエラーコードが空でないこと()
+    {
+        // Arrange
+        var exceptions = new Exception[]
+        {
+            new UnauthorizedAccessException(),
+            new IOException(),
+            new TimeoutException(),
+            new InvalidOperationException(),
+            new ArgumentException(),
+            new ArgumentNullException(),
+            new NotSupportedException(),
+            new Exception(),
+        };
+
+        // Act & Assert
+        foreach (var exception in exceptions)
+        {
+            var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(exception);
+            message.Should().NotBeNullOrEmpty();
+            errorCode.Should().NotBeNullOrEmpty();
+            errorCode.Should().StartWith("SYS");
+        }
+    }
+
+    [Fact]
+    public void GetErrorInfo_AppException系はサブクラスのErrorCodeをそのまま返すこと()
+    {
+        // Arrange - 各AppExceptionサブクラス
+        var testCases = new AppException[]
+        {
+            CardReaderException.ReadFailed("detail"),
+            DatabaseException.QueryFailed("SELECT"),
+            ValidationException.TooLong("field", "フィールド", 50),
+            BusinessException.OperationTimeout(),
+            FileOperationException.WriteFailed("/path"),
+        };
+
+        // Act & Assert
+        foreach (var appException in testCases)
+        {
+            var (message, errorCode) = ErrorDialogHelper.GetErrorInfo(appException);
+            errorCode.Should().Be(appException.ErrorCode,
+                because: $"{appException.GetType().Name}のErrorCodeがそのまま返されるべき");
+            message.Should().Be(appException.UserFriendlyMessage,
+                because: $"{appException.GetType().Name}のUserFriendlyMessageがそのまま返されるべき");
+        }
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Common/Exceptions/AppExceptionTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/Exceptions/AppExceptionTests.cs
@@ -89,6 +89,117 @@ public class AppExceptionTests
         exception.ErrorCode.Should().Be("CR005");
     }
 
+    [Fact]
+    public void CardReaderException_ServiceNotAvailable_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = CardReaderException.ServiceNotAvailable();
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("スマートカードサービス");
+        exception.ErrorCode.Should().Be("CR006");
+    }
+
+    [Fact]
+    public void CardReaderException_ServiceNotAvailable_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new InvalidOperationException("Service stopped");
+
+        // Act
+        var exception = CardReaderException.ServiceNotAvailable(innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+        exception.ErrorCode.Should().Be("CR006");
+    }
+
+    [Fact]
+    public void CardReaderException_MonitorError_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = CardReaderException.MonitorError();
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("監視中にエラー");
+        exception.ErrorCode.Should().Be("CR007");
+    }
+
+    [Fact]
+    public void CardReaderException_MonitorError_WithDetail_IncludesDetailInMessage()
+    {
+        // Act
+        var exception = CardReaderException.MonitorError("polling failed");
+
+        // Assert
+        exception.Message.Should().Contain("polling failed");
+        exception.ErrorCode.Should().Be("CR007");
+    }
+
+    [Fact]
+    public void CardReaderException_MonitorError_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new TimeoutException("poll timeout");
+
+        // Act
+        var exception = CardReaderException.MonitorError("detail", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void CardReaderException_ReconnectFailed_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = CardReaderException.ReconnectFailed(3);
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("再接続に失敗").And.Contain("3回");
+        exception.ErrorCode.Should().Be("CR008");
+        exception.Message.Should().Contain("3 attempts");
+    }
+
+    [Fact]
+    public void CardReaderException_ReconnectFailed_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new IOException("Connection refused");
+
+        // Act
+        var exception = CardReaderException.ReconnectFailed(5, innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+        exception.ErrorCode.Should().Be("CR008");
+    }
+
+    [Fact]
+    public void CardReaderException_CardRemoved_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = CardReaderException.CardRemoved();
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("カードが離されました");
+        exception.ErrorCode.Should().Be("CR009");
+    }
+
+    [Fact]
+    public void CardReaderException_CardRemoved_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new IOException("Card removed");
+
+        // Act
+        var exception = CardReaderException.CardRemoved(innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+        exception.ErrorCode.Should().Be("CR009");
+    }
+
     #endregion
 
     #region DatabaseException Tests
@@ -511,6 +622,304 @@ public class AppExceptionTests
 
     #endregion
 
+    #region FileOperationException Tests
+
+    [Fact]
+    public void FileOperationException_FileNotFound_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.FileNotFound("/path/to/file.txt");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("見つかりません");
+        exception.ErrorCode.Should().Be("FILE001");
+        exception.FilePath.Should().Be("/path/to/file.txt");
+        exception.Message.Should().Contain("/path/to/file.txt");
+    }
+
+    [Fact]
+    public void FileOperationException_FileNotFound_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new FileNotFoundException("not found");
+
+        // Act
+        var exception = FileOperationException.FileNotFound("/path/to/file.txt", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+        exception.ErrorCode.Should().Be("FILE001");
+        exception.FilePath.Should().Be("/path/to/file.txt");
+    }
+
+    [Fact]
+    public void FileOperationException_ReadFailed_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.ReadFailed("/path/to/file.xlsx");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("読み込みに失敗");
+        exception.ErrorCode.Should().Be("FILE002");
+        exception.FilePath.Should().Be("/path/to/file.xlsx");
+        exception.Message.Should().Contain("/path/to/file.xlsx");
+    }
+
+    [Fact]
+    public void FileOperationException_ReadFailed_WithoutPath_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.ReadFailed();
+
+        // Assert
+        exception.ErrorCode.Should().Be("FILE002");
+        exception.Message.Should().Be("Failed to read file");
+    }
+
+    [Fact]
+    public void FileOperationException_ReadFailed_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new IOException("file locked");
+
+        // Act
+        var exception = FileOperationException.ReadFailed("/path", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_WriteFailed_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.WriteFailed("/output/report.xlsx");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("書き込みに失敗");
+        exception.ErrorCode.Should().Be("FILE003");
+        exception.FilePath.Should().Be("/output/report.xlsx");
+    }
+
+    [Fact]
+    public void FileOperationException_WriteFailed_WithoutPath_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.WriteFailed();
+
+        // Assert
+        exception.ErrorCode.Should().Be("FILE003");
+        exception.Message.Should().Be("Failed to write file");
+    }
+
+    [Fact]
+    public void FileOperationException_WriteFailed_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new UnauthorizedAccessException("read-only");
+
+        // Act
+        var exception = FileOperationException.WriteFailed("/path", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_AccessDenied_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.AccessDenied("/protected/file.db");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("アクセス権限");
+        exception.ErrorCode.Should().Be("FILE004");
+        exception.FilePath.Should().Be("/protected/file.db");
+    }
+
+    [Fact]
+    public void FileOperationException_AccessDenied_WithoutPath_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.AccessDenied();
+
+        // Assert
+        exception.ErrorCode.Should().Be("FILE004");
+        exception.Message.Should().Be("File access denied");
+    }
+
+    [Fact]
+    public void FileOperationException_AccessDenied_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new UnauthorizedAccessException("denied");
+
+        // Act
+        var exception = FileOperationException.AccessDenied("/path", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_FileInUse_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.FileInUse("/locked/file.xlsx");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("使用中");
+        exception.ErrorCode.Should().Be("FILE005");
+        exception.FilePath.Should().Be("/locked/file.xlsx");
+    }
+
+    [Fact]
+    public void FileOperationException_FileInUse_WithoutPath_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.FileInUse();
+
+        // Assert
+        exception.ErrorCode.Should().Be("FILE005");
+        exception.Message.Should().Contain("in use");
+    }
+
+    [Fact]
+    public void FileOperationException_FileInUse_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new IOException("sharing violation");
+
+        // Act
+        var exception = FileOperationException.FileInUse("/path", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_InvalidFormat_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.InvalidFormat("/data/file.csv", "Excel (.xlsx)");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("形式が正しくありません").And.Contain("Excel (.xlsx)");
+        exception.ErrorCode.Should().Be("FILE006");
+        exception.FilePath.Should().Be("/data/file.csv");
+    }
+
+    [Fact]
+    public void FileOperationException_InvalidFormat_WithoutExpectedFormat_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.InvalidFormat("/data/file.csv");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Be("ファイル形式が正しくありません。");
+        exception.ErrorCode.Should().Be("FILE006");
+    }
+
+    [Fact]
+    public void FileOperationException_InvalidFormat_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new FormatException("bad format");
+
+        // Act
+        var exception = FileOperationException.InvalidFormat("/path", null, innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_DirectoryCreationFailed_ReturnsCorrectInfo()
+    {
+        // Act
+        var exception = FileOperationException.DirectoryCreationFailed("/new/directory");
+
+        // Assert
+        exception.UserFriendlyMessage.Should().Contain("フォルダの作成に失敗");
+        exception.ErrorCode.Should().Be("FILE007");
+        exception.FilePath.Should().Be("/new/directory");
+    }
+
+    [Fact]
+    public void FileOperationException_DirectoryCreationFailed_WithoutPath_ReturnsGenericMessage()
+    {
+        // Act
+        var exception = FileOperationException.DirectoryCreationFailed();
+
+        // Assert
+        exception.ErrorCode.Should().Be("FILE007");
+        exception.Message.Should().Be("Failed to create directory");
+    }
+
+    [Fact]
+    public void FileOperationException_DirectoryCreationFailed_WithInnerException_PreservesInnerException()
+    {
+        // Arrange
+        var innerException = new UnauthorizedAccessException("no permissions");
+
+        // Act
+        var exception = FileOperationException.DirectoryCreationFailed("/path", innerException);
+
+        // Assert
+        exception.InnerException.Should().BeSameAs(innerException);
+    }
+
+    [Fact]
+    public void FileOperationException_AllInheritFromAppException()
+    {
+        // Arrange & Act
+        var exceptions = new AppException[]
+        {
+            FileOperationException.FileNotFound("/path"),
+            FileOperationException.ReadFailed("/path"),
+            FileOperationException.WriteFailed("/path"),
+            FileOperationException.AccessDenied("/path"),
+            FileOperationException.FileInUse("/path"),
+            FileOperationException.InvalidFormat("/path"),
+            FileOperationException.DirectoryCreationFailed("/path"),
+        };
+
+        // Assert
+        foreach (var exception in exceptions)
+        {
+            exception.Should().BeAssignableTo<AppException>();
+            exception.ErrorCode.Should().NotBeNullOrEmpty();
+            exception.UserFriendlyMessage.Should().NotBeNullOrEmpty();
+        }
+    }
+
+    [Fact]
+    public void FileOperationException_AllHaveFilePath()
+    {
+        // Arrange
+        const string path = "/test/path/file.txt";
+
+        // Act
+        var exceptions = new FileOperationException[]
+        {
+            FileOperationException.FileNotFound(path),
+            FileOperationException.ReadFailed(path),
+            FileOperationException.WriteFailed(path),
+            FileOperationException.AccessDenied(path),
+            FileOperationException.FileInUse(path),
+            FileOperationException.InvalidFormat(path),
+            FileOperationException.DirectoryCreationFailed(path),
+        };
+
+        // Assert
+        foreach (var exception in exceptions)
+        {
+            exception.FilePath.Should().Be(path);
+        }
+    }
+
+    #endregion
+
     #region Error Code Uniqueness Tests
 
     [Fact]
@@ -523,7 +932,11 @@ public class AppExceptionTests
             CardReaderException.ReadFailed().ErrorCode,
             CardReaderException.HistoryReadFailed().ErrorCode,
             CardReaderException.BalanceReadFailed().ErrorCode,
-            CardReaderException.Timeout().ErrorCode
+            CardReaderException.Timeout().ErrorCode,
+            CardReaderException.ServiceNotAvailable().ErrorCode,
+            CardReaderException.MonitorError().ErrorCode,
+            CardReaderException.ReconnectFailed(1).ErrorCode,
+            CardReaderException.CardRemoved().ErrorCode
         };
 
         cardReaderCodes.Should().OnlyHaveUniqueItems();
@@ -556,6 +969,20 @@ public class AppExceptionTests
 
         validationCodes.Should().OnlyHaveUniqueItems();
         validationCodes.Should().AllSatisfy(code => code.Should().StartWith("VAL"));
+
+        var fileOperationCodes = new[]
+        {
+            FileOperationException.FileNotFound("/p").ErrorCode,
+            FileOperationException.ReadFailed("/p").ErrorCode,
+            FileOperationException.WriteFailed("/p").ErrorCode,
+            FileOperationException.AccessDenied("/p").ErrorCode,
+            FileOperationException.FileInUse("/p").ErrorCode,
+            FileOperationException.InvalidFormat("/p").ErrorCode,
+            FileOperationException.DirectoryCreationFailed("/p").ErrorCode
+        };
+
+        fileOperationCodes.Should().OnlyHaveUniqueItems();
+        fileOperationCodes.Should().AllSatisfy(code => code.Should().StartWith("FILE"));
     }
 
     #endregion

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/SystemManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/SystemManageViewModelTests.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using ICCardManager.ViewModels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// SystemManageViewModelの単体テスト
+/// </summary>
+public class SystemManageViewModelTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly Mock<ISettingsRepository> _settingsRepositoryMock;
+    private readonly Mock<BackupService> _backupServiceMock;
+    private readonly SystemManageViewModel _viewModel;
+
+    public SystemManageViewModelTests()
+    {
+        _dbContext = new DbContext(":memory:");
+        _settingsRepositoryMock = new Mock<ISettingsRepository>();
+        var loggerMock = new Mock<ILogger<BackupService>>();
+
+        _backupServiceMock = new Mock<BackupService>(
+            _dbContext,
+            _settingsRepositoryMock.Object,
+            loggerMock.Object);
+
+        _viewModel = new SystemManageViewModel(
+            _backupServiceMock.Object,
+            _settingsRepositoryMock.Object);
+    }
+
+    public void Dispose()
+    {
+        _dbContext?.Dispose();
+    }
+
+    #region 初期状態テスト
+
+    [Fact]
+    public void 初期状態でBackupFilesが空であること()
+    {
+        _viewModel.BackupFiles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void 初期状態でSelectedBackupがnullであること()
+    {
+        _viewModel.SelectedBackup.Should().BeNull();
+    }
+
+    [Fact]
+    public void 初期状態でStatusMessageが空文字であること()
+    {
+        _viewModel.StatusMessage.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void 初期状態でIsStatusErrorがfalseであること()
+    {
+        _viewModel.IsStatusError.Should().BeFalse();
+    }
+
+    [Fact]
+    public void 初期状態でHasSelectedBackupがfalseであること()
+    {
+        _viewModel.HasSelectedBackup.Should().BeFalse();
+    }
+
+    [Fact]
+    public void 初期状態でLastBackupFileが空文字であること()
+    {
+        _viewModel.LastBackupFile.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region LoadBackupsAsync テスト
+
+    [Fact]
+    public async Task LoadBackupsAsync_バックアップファイルがある場合にBackupFilesに追加されること()
+    {
+        // Arrange
+        var backupFiles = new List<BackupFileInfo>
+        {
+            new BackupFileInfo { FileName = "backup_001.db", FilePath = "/backups/backup_001.db", CreatedAt = DateTime.Now.AddDays(-2), FileSize = 1024 },
+            new BackupFileInfo { FileName = "backup_002.db", FilePath = "/backups/backup_002.db", CreatedAt = DateTime.Now.AddDays(-1), FileSize = 2048 },
+            new BackupFileInfo { FileName = "backup_003.db", FilePath = "/backups/backup_003.db", CreatedAt = DateTime.Now, FileSize = 3072 },
+        };
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(backupFiles);
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert
+        _viewModel.BackupFiles.Should().HaveCount(3);
+        _viewModel.StatusMessage.Should().Contain("3件");
+        _viewModel.IsStatusError.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadBackupsAsync_バックアップファイルがない場合にメッセージが表示されること()
+    {
+        // Arrange
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(Enumerable.Empty<BackupFileInfo>());
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert
+        _viewModel.BackupFiles.Should().BeEmpty();
+        _viewModel.StatusMessage.Should().Contain("見つかりません");
+        _viewModel.IsStatusError.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task LoadBackupsAsync_例外発生時にエラーメッセージが表示されること()
+    {
+        // Arrange
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ThrowsAsync(new Exception("disk error"));
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert
+        _viewModel.StatusMessage.Should().Contain("失敗しました").And.Contain("disk error");
+        _viewModel.IsStatusError.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LoadBackupsAsync_2回呼び出しで前回の結果がクリアされること()
+    {
+        // Arrange - 1回目: 3件
+        var firstBatch = new List<BackupFileInfo>
+        {
+            new BackupFileInfo { FileName = "a.db", FilePath = "/a.db", CreatedAt = DateTime.Now },
+            new BackupFileInfo { FileName = "b.db", FilePath = "/b.db", CreatedAt = DateTime.Now },
+            new BackupFileInfo { FileName = "c.db", FilePath = "/c.db", CreatedAt = DateTime.Now },
+        };
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(firstBatch);
+
+        await _viewModel.LoadBackupsAsync();
+        _viewModel.BackupFiles.Should().HaveCount(3);
+
+        // Arrange - 2回目: 1件
+        var secondBatch = new List<BackupFileInfo>
+        {
+            new BackupFileInfo { FileName = "d.db", FilePath = "/d.db", CreatedAt = DateTime.Now },
+        };
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(secondBatch);
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert - 前回の3件がクリアされ、新しい1件のみ
+        _viewModel.BackupFiles.Should().HaveCount(1);
+        _viewModel.BackupFiles[0].FileName.Should().Be("d.db");
+    }
+
+    [Fact]
+    public async Task LoadBackupsAsync_成功時にIsStatusErrorがfalseであること()
+    {
+        // Arrange
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(new[] { new BackupFileInfo { FileName = "a.db", FilePath = "/a.db", CreatedAt = DateTime.Now } });
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert
+        _viewModel.IsStatusError.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region HasSelectedBackup テスト
+
+    [Fact]
+    public void HasSelectedBackup_SelectedBackupが設定された場合trueであること()
+    {
+        // Arrange & Act
+        _viewModel.SelectedBackup = new BackupFileInfo
+        {
+            FileName = "backup_test.db",
+            FilePath = "/backups/backup_test.db",
+            CreatedAt = DateTime.Now
+        };
+
+        // Assert
+        _viewModel.HasSelectedBackup.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSelectedBackup_SelectedBackupをnullに戻すとfalseになること()
+    {
+        // Arrange
+        _viewModel.SelectedBackup = new BackupFileInfo { FileName = "test.db", FilePath = "/test.db", CreatedAt = DateTime.Now };
+        _viewModel.HasSelectedBackup.Should().BeTrue();
+
+        // Act
+        _viewModel.SelectedBackup = null;
+
+        // Assert
+        _viewModel.HasSelectedBackup.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region OnSelectedBackupChanged テスト
+
+    [Fact]
+    public void OnSelectedBackupChanged_HasSelectedBackupのPropertyChangedが発火すること()
+    {
+        // Arrange
+        var changedProperties = new List<string>();
+        _viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+        // Act
+        _viewModel.SelectedBackup = new BackupFileInfo
+        {
+            FileName = "backup.db",
+            FilePath = "/backups/backup.db",
+            CreatedAt = DateTime.Now
+        };
+
+        // Assert
+        changedProperties.Should().Contain("HasSelectedBackup");
+        changedProperties.Should().Contain("SelectedBackup");
+    }
+
+    #endregion
+
+    #region IsBusy 遷移テスト
+
+    [Fact]
+    public async Task LoadBackupsAsync_処理中にIsBusyがtrueになり完了後にfalseに戻ること()
+    {
+        // Arrange
+        var busyStates = new List<bool>();
+        _viewModel.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(_viewModel.IsBusy))
+            {
+                busyStates.Add(_viewModel.IsBusy);
+            }
+        };
+
+        _backupServiceMock.Setup(s => s.GetBackupFilesAsync())
+            .ReturnsAsync(Enumerable.Empty<BackupFileInfo>());
+
+        // Act
+        await _viewModel.LoadBackupsAsync();
+
+        // Assert - true（開始）→ false（終了）の順にIsBusyが遷移
+        busyStates.Should().HaveCountGreaterOrEqualTo(2);
+        busyStates.First().Should().BeTrue();
+        busyStates.Last().Should().BeFalse();
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ViewModelBaseTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ViewModelBaseTests.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using FluentAssertions;
+using ICCardManager.ViewModels;
+using Xunit;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// ViewModelBaseの単体テスト
+/// </summary>
+public class ViewModelBaseTests
+{
+    /// <summary>
+    /// テスト用のViewModelBase具象クラス
+    /// protectedメソッドを公開してテスト可能にする
+    /// BusyScopeはprotectedクラスのため、ラッパーメソッドで間接的に操作する
+    /// </summary>
+    private class TestViewModel : ViewModelBase
+    {
+        private BusyScope _currentScope;
+
+        public new void SetBusy(bool isBusy, string message = null)
+            => base.SetBusy(isBusy, message);
+
+        public new void ResetProgress()
+            => base.ResetProgress();
+
+        public new void SetProgress(double value, double max, string message = null)
+            => base.SetProgress(value, max, message);
+
+        public new IDisposable BeginBusy(string message = null)
+            => base.BeginBusy(message);
+
+        /// <summary>
+        /// BeginCancellableBusyのラッパー（BusyScopeをフィールドに保持）
+        /// </summary>
+        public IDisposable StartCancellableBusy(string message = null)
+        {
+            _currentScope = base.BeginCancellableBusy(message);
+            return _currentScope;
+        }
+
+        /// <summary>
+        /// 現在のスコープのCancellationTokenを取得
+        /// </summary>
+        public CancellationToken GetScopeCancellationToken()
+            => _currentScope?.CancellationToken ?? CancellationToken.None;
+
+        /// <summary>
+        /// 現在のスコープでThrowIfCancellationRequestedを呼び出す
+        /// </summary>
+        public void ScopeThrowIfCancellationRequested()
+            => _currentScope?.ThrowIfCancellationRequested();
+
+        /// <summary>
+        /// 現在のスコープでReportProgressを呼び出す
+        /// </summary>
+        public void ScopeReportProgress(double value, double max, string message = null)
+            => _currentScope?.ReportProgress(value, max, message);
+    }
+
+    private readonly TestViewModel _viewModel;
+
+    public ViewModelBaseTests()
+    {
+        _viewModel = new TestViewModel();
+    }
+
+    #region 初期状態テスト
+
+    [Fact]
+    public void 初期状態でIsBusyがfalseであること()
+    {
+        _viewModel.IsBusy.Should().BeFalse();
+    }
+
+    [Fact]
+    public void 初期状態でBusyMessageがnullであること()
+    {
+        _viewModel.BusyMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void 初期状態でIsIndeterminateがtrueであること()
+    {
+        _viewModel.IsIndeterminate.Should().BeTrue();
+    }
+
+    [Fact]
+    public void 初期状態でProgressValueが0であること()
+    {
+        _viewModel.ProgressValue.Should().Be(0);
+    }
+
+    [Fact]
+    public void 初期状態でProgressMaxが100であること()
+    {
+        _viewModel.ProgressMax.Should().Be(100);
+    }
+
+    [Fact]
+    public void 初期状態でCanCancelがfalseであること()
+    {
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    [Fact]
+    public void 初期状態でIsCancellationRequestedがfalseであること()
+    {
+        _viewModel.IsCancellationRequested.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region SetBusy テスト
+
+    [Fact]
+    public void SetBusy_trueを設定するとIsBusyがtrueになること()
+    {
+        // Act
+        _viewModel.SetBusy(true, "処理中...");
+
+        // Assert
+        _viewModel.IsBusy.Should().BeTrue();
+        _viewModel.BusyMessage.Should().Be("処理中...");
+    }
+
+    [Fact]
+    public void SetBusy_falseを設定するとIsBusyがfalseになりプログレスがリセットされること()
+    {
+        // Arrange - まずプログレスを設定
+        _viewModel.SetBusy(true, "処理中...");
+        _viewModel.SetProgress(50, 200, "半分完了");
+
+        // Act
+        _viewModel.SetBusy(false);
+
+        // Assert
+        _viewModel.IsBusy.Should().BeFalse();
+        _viewModel.BusyMessage.Should().BeNull();
+        _viewModel.ProgressValue.Should().Be(0);
+        _viewModel.ProgressMax.Should().Be(100);
+        _viewModel.IsIndeterminate.Should().BeTrue();
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetBusy_メッセージなしの場合BusyMessageがnullになること()
+    {
+        // Act
+        _viewModel.SetBusy(true);
+
+        // Assert
+        _viewModel.IsBusy.Should().BeTrue();
+        _viewModel.BusyMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void SetBusy_PropertyChangedが発火すること()
+    {
+        // Arrange
+        var changedProperties = new List<string>();
+        _viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+        // Act
+        _viewModel.SetBusy(true, "テスト");
+
+        // Assert
+        changedProperties.Should().Contain("IsBusy");
+        changedProperties.Should().Contain("BusyMessage");
+    }
+
+    #endregion
+
+    #region SetProgress テスト
+
+    [Fact]
+    public void SetProgress_値を設定するとIsIndeterminateがfalseになること()
+    {
+        // Act
+        _viewModel.SetProgress(30, 100);
+
+        // Assert
+        _viewModel.IsIndeterminate.Should().BeFalse();
+        _viewModel.ProgressValue.Should().Be(30);
+        _viewModel.ProgressMax.Should().Be(100);
+    }
+
+    [Fact]
+    public void SetProgress_メッセージ付きでBusyMessageが更新されること()
+    {
+        // Act
+        _viewModel.SetProgress(5, 10, "5/10 完了");
+
+        // Assert
+        _viewModel.BusyMessage.Should().Be("5/10 完了");
+        _viewModel.ProgressValue.Should().Be(5);
+        _viewModel.ProgressMax.Should().Be(10);
+    }
+
+    [Fact]
+    public void SetProgress_メッセージなしの場合BusyMessageが変わらないこと()
+    {
+        // Arrange
+        _viewModel.SetBusy(true, "初期メッセージ");
+
+        // Act
+        _viewModel.SetProgress(50, 100);
+
+        // Assert
+        _viewModel.BusyMessage.Should().Be("初期メッセージ");
+    }
+
+    #endregion
+
+    #region ResetProgress テスト
+
+    [Fact]
+    public void ResetProgress_全てのプログレス値がデフォルトに戻ること()
+    {
+        // Arrange
+        _viewModel.SetProgress(75, 200, "進行中");
+
+        // Act
+        _viewModel.ResetProgress();
+
+        // Assert
+        _viewModel.ProgressValue.Should().Be(0);
+        _viewModel.ProgressMax.Should().Be(100);
+        _viewModel.IsIndeterminate.Should().BeTrue();
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region BeginBusy テスト
+
+    [Fact]
+    public void BeginBusy_スコープ開始でIsBusyがtrueになること()
+    {
+        // Act
+        using var scope = _viewModel.BeginBusy("読み込み中...");
+
+        // Assert
+        _viewModel.IsBusy.Should().BeTrue();
+        _viewModel.BusyMessage.Should().Be("読み込み中...");
+    }
+
+    [Fact]
+    public void BeginBusy_スコープ終了でIsBusyがfalseに戻ること()
+    {
+        // Act
+        var scope = _viewModel.BeginBusy("処理中...");
+        _viewModel.IsBusy.Should().BeTrue();
+
+        scope.Dispose();
+
+        // Assert
+        _viewModel.IsBusy.Should().BeFalse();
+        _viewModel.BusyMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void BeginBusy_メッセージなしでも動作すること()
+    {
+        // Act
+        using var scope = _viewModel.BeginBusy();
+
+        // Assert
+        _viewModel.IsBusy.Should().BeTrue();
+        _viewModel.BusyMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void BeginBusy_CanCancelがfalseであること()
+    {
+        // Act
+        using var scope = _viewModel.BeginBusy("処理中...");
+
+        // Assert
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BeginBusy_複数回Disposeしてもエラーにならないこと()
+    {
+        // Act
+        var scope = _viewModel.BeginBusy("処理中...");
+        scope.Dispose();
+        scope.Dispose(); // 二重Dispose
+
+        // Assert - 例外が発生しないこと
+        _viewModel.IsBusy.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region BeginCancellableBusy テスト
+
+    [Fact]
+    public void BeginCancellableBusy_CanCancelがtrueになること()
+    {
+        // Act
+        using var scope = _viewModel.StartCancellableBusy("キャンセル可能な処理");
+
+        // Assert
+        _viewModel.IsBusy.Should().BeTrue();
+        _viewModel.CanCancel.Should().BeTrue();
+        _viewModel.BusyMessage.Should().Be("キャンセル可能な処理");
+    }
+
+    [Fact]
+    public void BeginCancellableBusy_CancellationTokenが有効であること()
+    {
+        // Act
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+
+        // Assert
+        var token = _viewModel.GetScopeCancellationToken();
+        token.Should().NotBe(CancellationToken.None);
+        token.CanBeCanceled.Should().BeTrue();
+        token.IsCancellationRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BeginCancellableBusy_スコープ終了でキャンセル状態がリセットされること()
+    {
+        // Act
+        var scope = _viewModel.StartCancellableBusy("処理中");
+        scope.Dispose();
+
+        // Assert
+        _viewModel.IsBusy.Should().BeFalse();
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region CancelOperation テスト
+
+    [Fact]
+    public void CancelOperation_キャンセル可能なスコープ内でIsCancellationRequestedがtrueになること()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+
+        // Act
+        _viewModel.CancelOperation();
+
+        // Assert
+        _viewModel.IsCancellationRequested.Should().BeTrue();
+        _viewModel.BusyMessage.Should().Be("キャンセル中...");
+    }
+
+    [Fact]
+    public void CancelOperation_CancellationTokenにキャンセルが伝播すること()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+
+        // Act
+        _viewModel.CancelOperation();
+
+        // Assert
+        var token = _viewModel.GetScopeCancellationToken();
+        token.IsCancellationRequested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CancelOperation_キャンセル不可スコープでは何も起きないこと()
+    {
+        // Arrange - BeginBusy（キャンセル不可）
+        using var scope = _viewModel.BeginBusy("処理中...");
+
+        // Act - エラーにならないこと
+        _viewModel.CancelOperation();
+
+        // Assert
+        _viewModel.IsCancellationRequested.Should().BeFalse();
+        _viewModel.BusyMessage.Should().Be("処理中...");
+    }
+
+    [Fact]
+    public void CancelOperation_スコープ外では何も起きないこと()
+    {
+        // Act - CancellationTokenSourceがnullの状態
+        _viewModel.CancelOperation();
+
+        // Assert
+        _viewModel.IsCancellationRequested.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region BusyScope.ReportProgress テスト
+
+    [Fact]
+    public void BusyScope_ReportProgress_プログレスが更新されること()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+
+        // Act
+        _viewModel.ScopeReportProgress(50, 100, "50%完了");
+
+        // Assert
+        _viewModel.ProgressValue.Should().Be(50);
+        _viewModel.ProgressMax.Should().Be(100);
+        _viewModel.IsIndeterminate.Should().BeFalse();
+        _viewModel.BusyMessage.Should().Be("50%完了");
+    }
+
+    [Fact]
+    public void BusyScope_ReportProgress_メッセージなしで値のみ更新されること()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("初期メッセージ");
+
+        // Act
+        _viewModel.ScopeReportProgress(3, 10);
+
+        // Assert
+        _viewModel.ProgressValue.Should().Be(3);
+        _viewModel.ProgressMax.Should().Be(10);
+        _viewModel.BusyMessage.Should().Be("初期メッセージ");
+    }
+
+    #endregion
+
+    #region BusyScope.ThrowIfCancellationRequested テスト
+
+    [Fact]
+    public void BusyScope_ThrowIfCancellationRequested_キャンセル未要求時は例外が発生しないこと()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+
+        // Act & Assert - 例外が発生しないこと
+        var action = () => _viewModel.ScopeThrowIfCancellationRequested();
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void BusyScope_ThrowIfCancellationRequested_キャンセル要求後にOperationCanceledExceptionが発生すること()
+    {
+        // Arrange
+        using var scope = _viewModel.StartCancellableBusy("処理中");
+        _viewModel.CancelOperation();
+
+        // Act & Assert
+        var action = () => _viewModel.ScopeThrowIfCancellationRequested();
+        action.Should().Throw<OperationCanceledException>();
+    }
+
+    #endregion
+
+    #region BeginBusy CancellationToken テスト
+
+    [Fact]
+    public void BeginBusy_キャンセル不可スコープではCancelOperationが無視されること()
+    {
+        // Arrange - キャンセル不可のBeginBusy
+        using var scope = _viewModel.BeginBusy("処理中");
+
+        // Act
+        _viewModel.CancelOperation();
+
+        // Assert - CancellationTokenSourceがnullなので何も起きない
+        _viewModel.IsCancellationRequested.Should().BeFalse();
+        _viewModel.CanCancel.Should().BeFalse();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- テストカバレッジ分析で判明した高優先度3件・中優先度2件のギャップに対し、単体テスト計215件（既存124件+新規91件）を追加
- テスト可能にするための本番コード最小変更（`BackupService`メソッドvirtual化、`ErrorDialogHelper.GetErrorInfo` internal化）を含む
- 全1613件のテストがパス、リグレッションなし

## 追加テスト内訳

### 高優先度（既存コミット: 124件）
| テストクラス | テスト数 | 内容 |
|---|---|---|
| BusinessExceptionTests | - | 各ファクトリメソッドの網羅テスト |
| BusStopInputViewModelTests | - | バス停入力VMの操作テスト |
| OperationLogSearchViewModelTests | - | 操作ログ検索VMのフィルタ・ページング等 |
| PrintPreviewViewModelTests | - | 印刷プレビューVMの初期化・操作テスト |
| FileLoggerTests | - | ログ出力・ローテーション・フィルタリング |

### 高優先度（本PR新規: 60件）
| テストクラス | テスト数 | 内容 |
|---|---|---|
| AppExceptionTests (FileOperationException) | 22件 | 7ファクトリメソッド×基本+InnerException+FilePath保持+エラーコード一意性 |
| AppExceptionTests (CardReaderException残り) | 11件 | ServiceNotAvailable/MonitorError/ReconnectFailed/CardRemoved |
| ViewModelBaseTests | 27件 | BeginBusy/BusyScope/SetProgress/CancelOperation/PropertyChanged |

### 中優先度（本PR新規: 31件）
| テストクラス | テスト数 | 内容 |
|---|---|---|
| SystemManageViewModelTests | 15件 | LoadBackupsAsync成功/空/例外/再呼び出し、HasSelectedBackup、IsBusy遷移 |
| ErrorDialogHelperTests | 16件 | GetErrorInfo例外→エラーコードマッピング全分岐（AppException系5件+一般例外8件+一貫性3件）|

## 本番コード変更（テスト可能化のための最小変更）
- `BackupService`: 4メソッドに`virtual`追加（Moqモック対応）
- `ErrorDialogHelper.GetErrorInfo`: `private` → `internal`（InternalsVisibleToテスト対応）

## Test plan
- [x] `dotnet test` 全1613件パス
- [x] 既存テストのリグレッションなし
- [x] 新規テスト91件が全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)