### PR TITLE
docs: 設計書4件を実装に合わせて更新

### DIFF
--- a/ICCardManager/docs/design/04_機能設計書.md
+++ b/ICCardManager/docs/design/04_機能設計書.md
@@ -334,3 +334,320 @@ DELETE FROM ledger WHERE date < date('now', '-6 years');
 ### 7.4 最適化
 
 削除後に`VACUUM`コマンドでデータベースファイルを最適化可能（手動実行）。
+
+---
+
+## 8. 履歴統合（マージ）機能
+
+### 8.1 概要
+
+複数の利用履歴（Ledger）レコードを1つに統合する機能。日付の近い履歴が複数行に分かれている場合に、手動で1行にまとめることができる。統合後は「元に戻す」操作も可能。
+
+### 8.2 統合条件
+
+| # | 条件 | エラー時の動作 |
+|---|------|----------------|
+| 1 | 2件以上のLedgerが選択されていること | エラーメッセージ表示 |
+| 2 | 全てのLedgerが同一カード（CardIdm）であること | エラーメッセージ表示 |
+| 3 | 貸出中レコード（IsLentRecord = true）を含まないこと | エラーメッセージ表示 |
+| 4 | 受入（チャージ）と払出（利用）が混在しないこと | エラーメッセージ表示 |
+
+### 8.3 統合処理フロー
+
+```mermaid
+flowchart TD
+    SELECT[2件以上の履歴を選択] --> VALIDATE{統合条件<br>チェック}
+    VALIDATE -->|NG| ERROR[エラーメッセージ表示]
+    VALIDATE -->|OK| AUTH[職員認証]
+    AUTH -->|失敗| CANCEL[キャンセル]
+    AUTH -->|成功| MERGE[統合処理実行]
+
+    MERGE --> TARGET[最古のLedgerを統合先に決定]
+    TARGET --> MOVE_DETAILS[全Detailを統合先に移動]
+    MOVE_DETAILS --> CALC[金額再計算]
+    CALC --> REGEN_SUMMARY[摘要再生成]
+    REGEN_SUMMARY --> SAVE_UNDO[元に戻すデータをJSON保存]
+    SAVE_UNDO --> DELETE_SOURCE[統合元Ledgerを削除]
+    DELETE_SOURCE --> LOG[操作ログ記録]
+    LOG --> DONE[完了]
+```
+
+### 8.4 統合時のデータ計算ルール
+
+| 項目 | 計算方法 |
+|------|----------|
+| 受入金額（Income） | 全統合元の合計 |
+| 払出金額（Expense） | 全統合元の合計 |
+| 残額（Balance） | 最新DetailのBalance（SequenceNumber/UseDate順） |
+| 摘要（Summary） | SummaryGeneratorで全Detailから再生成 |
+| 備考（Note） | 非null備考を「、」区切りで結合（重複排除） |
+
+### 8.5 元に戻す機能
+
+- `ledger_merge_history`テーブルにUndoDataをJSON形式で保存
+- UndoDataには統合前の各LedgerスナップショットとDetail→Ledgerのマッピングを含む
+- 元に戻す操作時にスナップショットから元のLedgerを復元し、Detailを元の所属に戻す
+- 元に戻した履歴は`is_undone = true`にマーク
+
+---
+
+## 9. 履歴分割機能
+
+### 9.1 概要
+
+1つの利用履歴（Ledger）レコードに含まれる複数の明細（LedgerDetail）を、グループ分けして別々のLedgerレコードに分割する機能。
+
+### 9.2 分割条件
+
+- 2つ以上のグループに分けられていること（各DetailにGroupIdが設定済み）
+- 分割対象のLedgerが存在すること
+
+### 9.3 分割処理フロー
+
+```mermaid
+flowchart TD
+    SELECT[履歴の明細をグループ分け] --> VALIDATE{2グループ<br>以上?}
+    VALIDATE -->|NO| ERROR[エラー: 分割不可]
+    VALIDATE -->|YES| AUTH[職員認証]
+    AUTH -->|失敗| CANCEL[キャンセル]
+    AUTH -->|成功| SPLIT[分割処理実行]
+
+    SPLIT --> GROUP1[グループ1: 元のLedgerを更新]
+    SPLIT --> GROUP2[グループ2〜N: 新規Ledger作成]
+    GROUP1 --> CALC1[金額再計算]
+    GROUP2 --> CALC2[金額再計算]
+    CALC1 --> SUMMARY1[摘要再生成]
+    CALC2 --> SUMMARY2[摘要再生成]
+    SUMMARY1 --> CLEAR[GroupIdクリア]
+    SUMMARY2 --> CLEAR
+    CLEAR --> LOG[操作ログ記録]
+    LOG --> DONE[完了]
+```
+
+### 9.4 金額計算ロジック（CalculateGroupFinancials）
+
+```
+グループ内の各Detailについて:
+  受入金額 = IsCharge=true かつ Amount有値 のDetail.Amountの合計
+  払出金額 = IsCharge=false かつ IsPointRedemption=false かつ Amount有値 のDetail.Amountの合計
+  残額 = グループ内の最後のDetail（SequenceNumber→UseDate昇順）のBalance
+        （Balance未設定の場合は0）
+```
+
+### 9.5 分割後のLedger属性
+
+| 項目 | 値 |
+|------|-----|
+| CardIdm | 元のLedgerと同一 |
+| Date | グループ内最古DetailのUseDate（なければ元の日付） |
+| Summary | SummaryGeneratorで再生成（空の場合「（分割）」） |
+| IsLentRecord | 常にfalse |
+| LenderIdm, StaffName等 | 元のLedgerからコピー |
+
+---
+
+## 10. 残高整合性チェック
+
+### 10.1 概要
+
+カードの利用履歴における残高チェーン（前回残高 + 受入 - 払出 = 今回残高）の整合性を検証する機能。履歴の追加・削除・変更後に呼び出され、不整合を検出する。
+
+### 10.2 検証ロジック
+
+```
+Ledgerを日付順（Date昇順→Id昇順）にソート
+
+FOR each Ledger (2件目以降):
+    期待残高 = 前回のLedger.Balance + 今回のIncome - 今回のExpense
+    IF 今回のLedger.Balance ≠ 期待残高:
+        → 不整合として記録（LedgerId, 期待残高, 実際残高）
+```
+
+### 10.3 検証バリエーション
+
+| メソッド | 用途 |
+|----------|------|
+| CheckBalanceConsistencyAsync | DB取得→2件目以降を検証 |
+| CheckConsistency | 渡されたリストを直接検証 |
+| CheckConsistencyWithPreviousAsync | 期間直前のLedgerも取得して1件目から検証 |
+
+### 10.4 結果
+
+```
+ConsistencyResult:
+  IsConsistent: true/false
+  Inconsistencies: List<(LedgerId, ExpectedBalance, ActualBalance)>
+```
+
+---
+
+## 11. 職員認証機能
+
+### 11.1 概要
+
+重要な操作（履歴統合・分割・削除等）の実行前に、操作者を職員証タッチで確認する機能。
+
+### 11.2 認証フロー
+
+```mermaid
+flowchart TD
+    TRIGGER[重要操作のリクエスト] --> SHOW_DIALOG[認証ダイアログ表示]
+    SHOW_DIALOG --> SET_FLAG["App.IsAuthenticationActive = true<br>（メイン画面のカード処理を抑制）"]
+    SET_FLAG --> WAIT[職員証タッチ待ち<br>60秒タイムアウト]
+
+    WAIT --> TOUCH{職員証タッチ}
+    TOUCH --> LOOKUP{職員DB<br>に登録済み?}
+    LOOKUP -->|YES| SUCCESS[認証成功<br>StaffAuthResult返却]
+    LOOKUP -->|NO| RETRY[エラー音<br>再度タッチ待ち]
+    RETRY --> WAIT
+
+    WAIT --> TIMEOUT{60秒経過?}
+    TIMEOUT -->|YES| WARN[警告音<br>ダイアログ閉じる]
+    WARN --> FAIL[認証失敗<br>null返却]
+
+    SUCCESS --> RESET["App.IsAuthenticationActive = false"]
+    FAIL --> RESET
+```
+
+### 11.3 タイムアウト仕様
+
+| 経過時間 | 動作 |
+|----------|------|
+| 0〜50秒 | 通常のカウントダウン表示 |
+| 50〜55秒 | 残り時間を赤色表示（5秒カウントダウン） |
+| 60秒 | 警告音再生 → ダイアログ自動クローズ |
+
+### 11.4 認証対象操作
+
+- 履歴統合（マージ）
+- 履歴分割
+- 履歴行の編集・削除
+- その他、ViewModelからRequestAuthenticationAsyncを呼び出す操作
+
+---
+
+## 12. 印刷プレビュー機能
+
+### 12.1 概要
+
+月次帳票（物品出納簿）の印刷前にプレビュー表示する機能。ズーム・ページナビゲーション・印刷方向切替をサポートする。
+
+### 12.2 ズーム機能
+
+| 操作 | 動作 |
+|------|------|
+| ズームイン | 定義済みレベル（50→75→100→125→150→200%）で段階的に拡大 |
+| ズームアウト | 定義済みレベルで段階的に縮小 |
+| リセット | 100%に戻す |
+| カスタム値 | 定義済みレベル以外の値も指定可能 |
+
+### 12.3 ページナビゲーション
+
+| コマンド | 条件 |
+|----------|------|
+| 次のページ | IsLastPage でなければ実行可能 |
+| 前のページ | IsFirstPage でなければ実行可能 |
+| 最初のページ | IsFirstPage でなければ実行可能 |
+| 最後のページ | IsLastPage でなければ実行可能 |
+
+### 12.4 印刷方向切替
+
+- **縦方向（Portrait）/ 横方向（Landscape）** の切替が可能
+- 方向変更時に帳票データからFlowDocumentを再生成する
+- 方向変更後は1ページ目にリセット
+- 単一カード・複数カードの両方に対応
+
+---
+
+## 13. 操作ログExcel出力
+
+### 13.1 概要
+
+操作ログの検索結果をExcelファイル（.xlsx）にエクスポートする機能。
+
+### 13.2 出力カラム
+
+| 列 | ヘッダー | 幅 | 内容 |
+|----|----------|-----|------|
+| A | 日時 | 20 | yyyy/MM/dd HH:mm:ss形式 |
+| B | 操作種別 | 10 | INSERT/UPDATE/DELETE等（色分け・太字） |
+| C | 対象 | 18 | テーブル名の日本語表示 |
+| D | 対象ID | 20 | TargetId |
+| E | 操作者 | 12 | OperatorName |
+| F | 変更内容 | 40 | UPDATE時のみ差分サマリ |
+| G | 変更前 | 50 | JSONを日本語ラベル付きで整形 |
+| H | 変更後 | 50 | JSONを日本語ラベル付きで整形 |
+
+### 13.3 書式ルール
+
+| 要素 | 書式 |
+|------|------|
+| ヘッダー行 | 白太字 + 青背景(#4472C4) |
+| 操作種別:INSERT/RESTORE | 緑(#2E7D32) |
+| 操作種別:UPDATE | オレンジ(#E65100) |
+| 操作種別:DELETE | 赤(#C62828) |
+| 操作種別:MERGE/SPLIT | 青(#1565C0) |
+| データ行 | テキスト折り返し、上寄せ |
+| フィルター | 1行目で自動フィルター有効 |
+| 固定表示 | 1行目を固定 |
+
+### 13.4 JSON整形ルール
+
+- 単一オブジェクト: `フィールド名: 値` の一覧に変換
+- 配列: `[1] フィールド名: 値` のようにインデックス付きで変換
+- フィールド名はテーブルごとの日本語マッピングを使用（例: `card_idm` → `カードIDm`）
+- 真偽値: `true` → `はい`、`false` → `いいえ`
+- null: `（なし）`
+
+### 13.5 変更サマリ（UPDATE時）
+
+変更前後のJSONを比較し、差分のあるフィールドのみ抽出:
+
+```
+フィールド名: 変更前の値 → 変更後の値
+```
+
+---
+
+## 14. カード排他制御
+
+### 14.1 概要
+
+同一カードに対する同時操作を防止するため、カードIDm単位のロック機構を提供する。
+
+### 14.2 ロック戦略
+
+| 項目 | 仕様 |
+|------|------|
+| ロック単位 | カードIDm（1カード = 1ロック） |
+| ロック方式 | SemaphoreSlim(1, 1)による排他ロック |
+| データ構造 | ConcurrentDictionary<string, LockEntry> |
+| 参照カウント | GetLock()で+1、ReleaseLockReference()で-1 |
+
+### 14.3 ロック取得・解放
+
+```
+GetLock(cardIdm):
+    LockEntry = Dictionary.GetOrAdd(cardIdm, new LockEntry)
+    LastUsed = UtcNow
+    ReferenceCount++
+    RETURN SemaphoreSlim
+
+ReleaseLockReference(cardIdm):
+    ReferenceCount-- (最小0)
+    LastUsed = UtcNow
+```
+
+### 14.4 自動クリーンアップ
+
+| 項目 | 値 |
+|------|-----|
+| クリーンアップ間隔 | 15分 |
+| ロック有効期限 | 1時間 |
+| 削除条件 | ReferenceCount = 0 AND LastUsed < (現在 - 1時間) AND SemaphoreSlim未ロック |
+
+### 14.5 シャットダウン
+
+- `Dispose()`時に全ロックを強制解放（SemaphoreSlim.Dispose()）
+- クリーンアップタイマーを停止
+- ConcurrentDictionaryをクリア

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -103,6 +103,12 @@ graph TB
         SVC_TOAST[ToastNotificationService]
         SVC_DEBUG[DebugDataService]
         SVC_MERGE[LedgerMergeService]
+        SVC_SPLIT[LedgerSplitService]
+        SVC_CONSIST[LedgerConsistencyChecker]
+        SVC_ORDER[LedgerOrderHelper]
+        SVC_REPORT_BUILD[ReportDataBuilder]
+        SVC_OPLOGEXCEL[OperationLogExcelExportService]
+        SVC_VALID[ValidationService]
         SVC_CARDLOCK[CardLockManager]
         SVC_STAFFAUTH[IStaffAuthService]
         SVC_DIALOG[IDialogService]
@@ -120,6 +126,8 @@ graph TB
     subgraph "Infrastructure Layer"
         READER[ICardReader]
         SOUND[ISoundPlayer]
+        CACHE[ICacheService]
+        FILELOG[FileLoggerProvider]
     end
 
     subgraph "External"
@@ -177,6 +185,15 @@ graph TB
 | SettingsViewModel | 設定ダイアログのロジック |
 | ReportViewModel | 帳票作成ダイアログのロジック |
 | HistoryViewModel | 履歴表示ダイアログのロジック |
+| SystemManageViewModel | システム管理（バックアップ・リストア）のロジック |
+| PrintPreviewViewModel | 印刷プレビュー画面のズーム・ナビゲーション制御 |
+| LedgerDetailViewModel | 利用履歴詳細表示・グループ操作のロジック |
+| LedgerRowEditViewModel | 履歴行の追加・編集ダイアログのロジック |
+| BusStopInputViewModel | バス停名入力画面のロジック |
+| IncompleteBusStopViewModel | バス停未入力一覧ダイアログのロジック |
+| VirtualCardViewModel | 仮想ICカードタッチシミュレーター（DEBUG専用） |
+| DataExportImportViewModel | データCSVエクスポート・インポートのロジック |
+| OperationLogSearchViewModel | 操作ログ検索・表示のロジック |
 
 ### 3.3 Services
 
@@ -200,6 +217,12 @@ graph TB
 | CardLockManager | カードアクセスの排他制御（シングルトン） |
 | IStaffAuthService / StaffAuthService | 職員証による操作者認証 |
 | IDialogService / DialogService | ダイアログ表示の抽象化（テスタビリティ向上） |
+| ReportDataBuilder | 月次帳票の共通データ準備（Excel/印刷で共有） |
+| LedgerSplitService | 複数明細を含むLedgerレコードの分割（Issue #634） |
+| LedgerConsistencyChecker | 残高チェーンの整合性検証（Issue #635） |
+| LedgerOrderHelper | 残高チェーンに基づくLedger順序の復元（Issue #784） |
+| OperationLogExcelExportService | 操作ログのExcel出力 |
+| ValidationService | 入力値のバリデーション（IDm, カード番号, 氏名等） |
 
 ### 3.4 Repositories
 
@@ -752,6 +775,140 @@ classDiagram
     DialogService ..|> IDialogService
 ```
 
+### 5.18 ReportDataBuilder
+
+```mermaid
+classDiagram
+    class IReportDataBuilder {
+        <<interface>>
+        +BuildAsync(cardIdm, year, month) Task~MonthlyReportData~
+    }
+
+    class ReportDataBuilder {
+        -ICardRepository _cardRepository
+        -ILedgerRepository _ledgerRepository
+        +BuildAsync(cardIdm, year, month) Task~MonthlyReportData~
+        -GetPreviousMonthBalanceAsync(cardIdm, year, month) Task~int?~
+    }
+
+    ReportDataBuilder ..|> IReportDataBuilder
+```
+
+### 5.19 LedgerSplitService
+
+```mermaid
+classDiagram
+    class LedgerSplitService {
+        -ILedgerRepository _ledgerRepository
+        -SummaryGenerator _summaryGenerator
+        -OperationLogger _operationLogger
+        -ILogger~LedgerSplitService~ _logger
+        +SplitAsync(ledgerId, groupedDetails, operatorIdm?) Task~LedgerSplitResult~
+        +CalculateGroupFinancials(groupDetails)$ tuple~int, int, int~
+        -GetGroupDate(groupDetails, originalDate)$ DateTime
+        -ClearGroupIds(details)$ void
+        -CloneLedger(source)$ Ledger
+    }
+
+    class LedgerSplitResult {
+        +bool Success
+        +string ErrorMessage
+        +List~int~ CreatedLedgerIds
+    }
+
+    LedgerSplitService --> LedgerSplitResult
+```
+
+### 5.20 LedgerConsistencyChecker
+
+```mermaid
+classDiagram
+    class LedgerConsistencyChecker {
+        <<internal>>
+        -ILedgerRepository _ledgerRepository
+        +CheckBalanceConsistencyAsync(cardIdm, fromDate, toDate) Task~ConsistencyResult~
+        +CheckConsistency(ledgers, cardIdm, fromDate) ConsistencyResult
+        +CheckConsistencyWithPreviousAsync(ledgers, cardIdm, fromDate) Task~ConsistencyResult~
+    }
+
+    class ConsistencyResult {
+        <<internal>>
+        +bool IsConsistent
+        +List~tuple~ Inconsistencies
+    }
+
+    LedgerConsistencyChecker --> ConsistencyResult
+```
+
+### 5.21 LedgerOrderHelper
+
+```mermaid
+classDiagram
+    class LedgerOrderHelper {
+        <<internal, static>>
+        +ReorderByBalanceChain(ledgers, precedingBalance?)$ List~Ledger~
+        -ReconstructChain(records, startBalance)$ List~Ledger~
+        -IsSpecialRecord(ledger)$ bool
+    }
+```
+
+### 5.22 OperationLogExcelExportService
+
+```mermaid
+classDiagram
+    class OperationLogExcelExportService {
+        -XLColor HeaderBackground$
+        -XLColor ColorGreen$
+        -XLColor ColorOrange$
+        -XLColor ColorRed$
+        -XLColor ColorBlue$
+        +ExportAsync(logs, filePath) Task
+        +GetActionDisplayName(action?)$ string
+        +GetTargetTableDisplayName(targetTable?)$ string
+        +FormatJsonToReadable(targetTable?, json?)$ string
+        +GetChangeSummary(targetTable?, beforeJson?, afterJson?)$ string
+        +GetFieldNameMap(targetTable?)$ IReadOnlyDictionary~string, string~
+        -WriteHeader(worksheet)$ void
+        -WriteDataRow(worksheet, row, log)$ void
+        -ApplyFormatting(worksheet, lastDataRow)$ void
+        -GetActionColor(action?)$ XLColor?
+    }
+```
+
+### 5.23 ValidationService
+
+```mermaid
+classDiagram
+    class IValidationService {
+        <<interface>>
+        +ValidateCardIdm(idm) ValidationResult
+        +ValidateCardNumber(cardNumber) ValidationResult
+        +ValidateCardType(cardType) ValidationResult
+        +ValidateStaffIdm(idm) ValidationResult
+        +ValidateStaffName(name) ValidationResult
+        +ValidateWarningBalance(balance) ValidationResult
+        +ValidateBusStops(busStops) ValidationResult
+    }
+
+    class ValidationService {
+        -int IdmLength$
+        -int CardNumberMaxLength$
+        -int StaffNameMaxLength$
+        -int BusStopsMaxLength$
+        -Regex HexPatternRegex$
+        -Regex AlphanumericPatternRegex$
+        +ValidateCardIdm(idm) ValidationResult
+        +ValidateCardNumber(cardNumber) ValidationResult
+        +ValidateCardType(cardType) ValidationResult
+        +ValidateStaffIdm(idm) ValidationResult
+        +ValidateStaffName(name) ValidationResult
+        +ValidateWarningBalance(balance) ValidationResult
+        +ValidateBusStops(busStops) ValidationResult
+    }
+
+    ValidationService ..|> IValidationService
+```
+
 ---
 
 ## 6. DIコンテナ設定
@@ -897,4 +1054,306 @@ public interface ICardRepository
     Task<bool> UpdateLentStatusAsync(string cardIdm, bool isLent, DateTime? lentAt, string? staffIdm);
     Task<bool> DeleteAsync(string cardIdm); // 論理削除
 }
+```
+
+---
+
+## 9. インフラストラクチャ詳細
+
+### 9.1 CacheService
+
+```mermaid
+classDiagram
+    class ICacheService {
+        <<interface>>
+        +GetOrCreateAsync~T~(key, factory, absoluteExpiration) Task~T~
+        +Get~T~(key) T?
+        +Set~T~(key, value, absoluteExpiration) void
+        +Invalidate(key) void
+        +InvalidateByPrefix(prefix) void
+        +Clear() void
+    }
+
+    class CacheService {
+        <<IDisposable>>
+        -IMemoryCache _cache
+        -ConcurrentDictionary~string, byte~ _keys
+        -ILogger~CacheService~ _logger
+        -object _lock
+        -bool _disposed
+        +GetOrCreateAsync~T~(key, factory, absoluteExpiration) Task~T~
+        +Get~T~(key) T?
+        +Set~T~(key, value, absoluteExpiration) void
+        +Invalidate(key) void
+        +InvalidateByPrefix(prefix) void
+        +Clear() void
+        +Dispose() void
+        #Dispose(disposing) void
+    }
+
+    CacheService ..|> ICacheService
+```
+
+### 9.2 FelicaCardReader
+
+```mermaid
+classDiagram
+    class FelicaCardReader {
+        <<ICardReader, IDisposable>>
+        -ILogger~FelicaCardReader~ _logger
+        -object _felicaLock
+        -Timer _pollingTimer
+        -Timer _healthCheckTimer
+        -bool _isReading
+        -bool _disposed
+        -CardReaderConnectionState _connectionState
+        -string _lastReadIdm
+        -DateTime _lastReadTime
+        +event CardRead EventHandler~CardReadEventArgs~
+        +event Error EventHandler~Exception~
+        +event ConnectionStateChanged EventHandler~ConnectionStateChangedEventArgs~
+        +bool IsReading
+        +CardReaderConnectionState ConnectionState
+        +StartReadingAsync() Task
+        +StopReadingAsync() Task
+        +ReadHistoryAsync(idm) Task~IEnumerable~LedgerDetail~~
+        +ReadBalanceAsync(idm) Task~int?~
+        +CheckConnectionAsync() Task~bool~
+        +ReconnectAsync() Task
+        +Dispose() void
+        -CheckFelicaLibAvailable() bool
+        -StartPollingTimer() void
+        -OnPollingTimerElapsed(sender, e) void
+        -ParseHistoryData(currentData, previousData, cardType) LedgerDetail
+    }
+
+    FelicaCardReader ..|> ICardReader
+```
+
+### 9.3 FileLoggerProvider / FileLogger
+
+```mermaid
+classDiagram
+    class FileLoggerProvider {
+        <<ILoggerProvider>>
+        -ConcurrentDictionary~string, FileLogger~ _loggers
+        -BlockingCollection~string~ _logQueue
+        -Task _outputTask
+        -CancellationTokenSource _cancellationTokenSource
+        -string _logDirectory
+        -string _currentLogFilePath
+        -DateTime _currentLogDate
+        +FileLoggerOptions Options
+        +CreateLogger(categoryName) ILogger
+        +WriteLog(message) void
+        +Dispose() void
+        -ProcessLogQueue() void
+        -WriteToFile(message) void
+        -EnsureLogFile() void
+        -CheckFileSize() void
+        -CleanupOldLogs() void
+    }
+
+    class FileLogger {
+        <<ILogger>>
+        -string _categoryName
+        -FileLoggerProvider _provider
+        +BeginScope~TState~(state) IDisposable?
+        +IsEnabled(logLevel) bool
+        +Log~TState~(logLevel, eventId, state, exception, formatter) void
+        -FormatLogEntry(logLevel, message, exception) string
+        -GetLogLevelString(logLevel)$ string
+        -GetShortCategoryName(categoryName)$ string
+    }
+
+    FileLoggerProvider ..|> ILoggerProvider
+    FileLogger ..|> ILogger
+    FileLoggerProvider "1" --> "*" FileLogger : creates
+```
+
+---
+
+## 10. 共通ユーティリティ詳細
+
+### 10.1 ErrorDialogHelper
+
+```mermaid
+classDiagram
+    class ErrorDialogHelper {
+        <<static>>
+        -string LogDirectory$
+        +ShowError(exception, title?)$ void
+        +ShowWarning(message, title?)$ void
+        +ShowFatalError(exception)$ void
+        +CleanupOldLogs()$ void
+        ~GetErrorInfo(exception)$ tuple~string, string~
+        -ShowErrorDialog(message, title, errorCode, exception)$ void
+        -ShowErrorDialogWithClipboard(message, title, exception)$ void
+        -LogError(exception, errorCode, isFatal?)$ void
+    }
+```
+
+### 10.2 PathValidator
+
+```mermaid
+classDiagram
+    class PathValidator {
+        <<static>>
+        -int MaxPathLength$
+        +ValidateBackupPath(path)$ ValidationResult
+        +NormalizePath(path)$ string
+        +GetDefaultBackupPath()$ string
+        -IsUncPath(path)$ bool
+        -ContainsPathTraversal(path)$ bool
+        -CheckWritePermission(path)$ ValidationResult
+    }
+
+    class PathValidationResult {
+        +bool IsValid
+        +string ErrorMessage
+        +Success()$ PathValidationResult
+        +Failure(errorMessage)$ PathValidationResult
+    }
+
+    PathValidator --> PathValidationResult
+```
+
+---
+
+## 11. データベース基盤
+
+### 11.1 MigrationRunner
+
+```mermaid
+classDiagram
+    class MigrationRunner {
+        -SQLiteConnection _connection
+        -List~IMigration~ _migrations
+        +GetCurrentVersion() int
+        +MigrateToLatest() int
+        +MigrateTo(targetVersion) int
+        +GetAppliedMigrations() IReadOnlyList~MigrationInfo~
+        +HasPendingMigrations() bool
+        +GetPendingMigrations() IReadOnlyList~IMigration~
+        +ValidateMigrationSequence() void
+        -ApplyMigration(migration) void
+        -RollbackMigration(migration) void
+        -EnsureMigrationTable() void
+        -RecordMigration(migration, transaction) void
+        -DiscoverMigrations()$ List~IMigration~
+    }
+
+    class IMigration {
+        <<interface>>
+        +int Version
+        +string Description
+        +Up(connection, transaction) void
+        +Down(connection, transaction) void
+    }
+
+    class MigrationInfo {
+        +int Version
+        +string Description
+        +DateTime AppliedAt
+    }
+
+    class MigrationException {
+        +MigrationException(message)
+        +MigrationException(message, innerException)
+    }
+
+    MigrationRunner --> IMigration
+    MigrationRunner --> MigrationInfo
+    MigrationRunner ..> MigrationException : throws
+```
+
+---
+
+## 12. DTO詳細
+
+### 12.1 MonthlyReportData
+
+```mermaid
+classDiagram
+    class MonthlyReportData {
+        +IcCard Card
+        +int Year
+        +int Month
+        +int? PrecedingBalance
+        +CarryoverRowData Carryover
+        +List~Ledger~ Ledgers
+        +ReportTotalData MonthlyTotal
+        +ReportTotalData CumulativeTotal
+        +int? CarryoverToNextYear
+    }
+
+    class CarryoverRowData {
+        +DateTime Date
+        +string Summary
+        +int? Income
+        +int Balance
+    }
+
+    class ReportTotalData {
+        +string Label
+        +int Income
+        +int Expense
+        +int? Balance
+    }
+
+    MonthlyReportData --> CarryoverRowData
+    MonthlyReportData --> ReportTotalData
+```
+
+### 12.2 IncompleteBusStopItem / WarningItem / CardBalanceDashboardItem
+
+```mermaid
+classDiagram
+    class IncompleteBusStopItem {
+        +int LedgerId
+        +string CardIdm
+        +string CardDisplayName
+        +DateTime Date
+        +string DateDisplay
+        +string Summary
+        +int Expense
+        +string ExpenseDisplay
+        +string StaffName
+    }
+
+    class WarningItem {
+        +string DisplayText
+        +WarningType Type
+        +string CardIdm
+    }
+
+    class WarningType {
+        <<enumeration>>
+        LowBalance
+        IncompleteBusStop
+        CardReaderError
+        CardReaderConnection
+        BalanceInconsistency
+    }
+
+    class CardBalanceDashboardItem {
+        +string CardIdm
+        +string CardType
+        +string CardNumber
+        +int CurrentBalance
+        +bool IsBalanceWarning
+        +DateTime? LastUsageDate
+        +bool IsLent
+        +string LentStaffName
+        +string DisplayName
+        +string BalanceDisplay
+        +string WarningIcon
+        +string LentStatusIcon
+        +string LentStatusDisplay
+        +string LentInfoDisplay
+        +string LastUsageDateDisplay
+        +string RowBackgroundColor
+    }
+
+    WarningItem --> WarningType
 ```

--- a/ICCardManager/docs/design/06_シーケンス図.md
+++ b/ICCardManager/docs/design/06_シーケンス図.md
@@ -415,3 +415,337 @@ sequenceDiagram
     VM->>VM: 状態を WaitingForStaffCard に戻す
     VM->>VM: 画面表示更新
 ```
+
+---
+
+## 9. 履歴統合シーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as ユーザー
+    participant VM as LedgerDetailViewModel
+    participant Auth as StaffAuthService
+    participant MS as LedgerMergeService
+    participant LR as ILedgerRepository
+    participant SG as SummaryGenerator
+    participant OL as OperationLogger
+    participant DB as DbContext
+
+    User->>VM: 2件以上の履歴を選択して統合ボタンクリック
+
+    VM->>VM: 統合条件チェック
+    Note right of VM: ・同一カードか<br/>・貸出中レコードなし<br/>・受入/払出混在なし
+
+    alt 条件不適合
+        VM-->>User: エラーメッセージ表示
+    end
+
+    VM->>Auth: RequestAuthenticationAsync("履歴統合")
+    Auth-->>VM: StaffAuthResult
+
+    alt 認証失敗
+        VM-->>User: キャンセル
+    end
+
+    VM->>MS: MergeAsync(ledgerIds, operatorIdm)
+
+    MS->>LR: GetByIdAsync(各ledgerId)
+    LR->>DB: SELECT FROM ledger
+    DB-->>LR: Ledger一覧
+    LR-->>MS: List~Ledger~
+
+    MS->>MS: 最古のLedgerを統合先に決定
+    MS->>MS: 全Detailを統合先に移動
+    MS->>MS: Income/Expense合算
+    MS->>SG: Generate(allDetails)
+    SG-->>MS: 再生成された摘要
+
+    MS->>DB: BeginTransaction()
+    MS->>LR: UpdateAsync(統合先Ledger)
+    MS->>LR: DeleteAsync(統合元Ledger群)
+    MS->>LR: InsertMergeHistoryAsync(undoData)
+    MS->>OL: LogAsync("MERGE", ...)
+    MS->>DB: Commit()
+
+    MS-->>VM: LedgerMergeResult(Success)
+    VM-->>User: 統合完了メッセージ
+```
+
+---
+
+## 10. 履歴分割シーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as ユーザー
+    participant VM as LedgerDetailViewModel
+    participant Auth as StaffAuthService
+    participant SS as LedgerSplitService
+    participant LR as ILedgerRepository
+    participant SG as SummaryGenerator
+    participant OL as OperationLogger
+    participant DB as DbContext
+
+    User->>VM: 明細をグループ分けして分割ボタンクリック
+
+    VM->>VM: 2グループ以上か確認
+
+    VM->>Auth: RequestAuthenticationAsync("履歴分割")
+    Auth-->>VM: StaffAuthResult
+
+    VM->>SS: SplitAsync(ledgerId, groupedDetails, operatorIdm)
+
+    SS->>LR: GetByIdAsync(ledgerId)
+    LR->>DB: SELECT FROM ledger
+    DB-->>LR: Ledger
+    LR-->>SS: Ledger（元の履歴）
+
+    SS->>DB: BeginTransaction()
+
+    Note over SS: グループ1: 元のLedgerを更新
+    SS->>SS: CalculateGroupFinancials(group1)
+    SS->>SG: Generate(group1Details)
+    SG-->>SS: 摘要
+    SS->>LR: UpdateAsync(元のLedger)
+
+    loop グループ2〜N
+        SS->>SS: CloneLedger(元のLedger)
+        SS->>SS: CalculateGroupFinancials(groupN)
+        SS->>SG: Generate(groupNDetails)
+        SG-->>SS: 摘要
+        SS->>LR: InsertAsync(新規Ledger)
+        SS->>LR: InsertDetailsAsync(details)
+    end
+
+    SS->>OL: LogAsync("SPLIT", ...)
+    SS->>DB: Commit()
+
+    SS-->>VM: LedgerSplitResult(Success)
+    VM-->>User: 分割完了メッセージ
+```
+
+---
+
+## 11. 職員認証シーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant VM as 各ViewModel
+    participant Auth as StaffAuthService
+    participant Dialog as StaffAuthDialog
+    participant Reader as ICardReader
+    participant SR as IStaffRepository
+    participant Sound as ISoundPlayer
+
+    VM->>Auth: RequestAuthenticationAsync("操作の説明")
+
+    Auth->>Auth: App.IsAuthenticationActive = true
+    Auth->>Dialog: Show(operationDescription)
+
+    Note over Dialog: 60秒タイムアウト開始
+
+    loop カード待ち受け
+        Reader->>Dialog: CardRead イベント(IDm)
+        Dialog->>SR: GetByIdmAsync(idm)
+        SR-->>Dialog: Staff?
+
+        alt 未登録の職員証
+            Dialog->>Sound: PlayError()
+            Dialog->>Dialog: エラーメッセージ表示、再度待ち受け
+        else 登録済み職員証
+            Dialog->>Dialog: 認証成功 → ダイアログ閉じる
+        end
+    end
+
+    alt タイムアウト（60秒経過）
+        Dialog->>Sound: PlayWarning()
+        Dialog->>Dialog: ダイアログ閉じる
+        Auth->>Auth: App.IsAuthenticationActive = false
+        Auth-->>VM: null（認証失敗）
+    else 認証成功
+        Auth->>Auth: App.IsAuthenticationActive = false
+        Auth-->>VM: StaffAuthResult(Idm, StaffName)
+    end
+```
+
+---
+
+## 12. バックアップ/リストアシーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as ユーザー
+    participant VM as SystemManageViewModel
+    participant BS as BackupService
+    participant SR as ISettingsRepository
+    participant DB as DbContext
+
+    Note over User,DB: バックアップ実行
+
+    User->>VM: バックアップボタンクリック
+    VM->>BS: ExecuteAutoBackupAsync()
+
+    BS->>SR: GetAppSettingsAsync()
+    SR-->>BS: AppSettings(BackupPath)
+
+    alt BackupPath未設定
+        BS->>BS: デフォルトパスを使用
+    else パス検証
+        BS->>BS: PathValidator.ValidateBackupPath()
+        alt 無効なパス
+            BS->>BS: デフォルトパスにフォールバック
+        end
+    end
+
+    BS->>BS: Directory.CreateDirectory(backupPath)
+    BS->>BS: ファイル名生成（backup_yyyyMMdd_HHmmss.db）
+    BS->>BS: File.Copy(DBファイル → バックアップ先)
+    BS->>BS: 古いバックアップ削除（30世代超過分）
+
+    BS-->>VM: バックアップファイルパス
+    VM-->>User: 完了メッセージ
+
+    Note over User,DB: リストア実行
+
+    User->>VM: リストアボタンクリック（バックアップファイル選択済み）
+    VM->>BS: RestoreFromBackup(backupFilePath)
+
+    BS->>BS: バックアップファイル存在確認
+    BS->>DB: CloseConnection()
+    Note right of DB: SQLite接続を閉じて<br/>ファイルロックを解除
+
+    BS->>BS: 現在のDBを.tempに退避
+    BS->>BS: File.Copy(バックアップ → DBパス)
+
+    alt コピー成功
+        BS->>BS: .tempファイル削除
+        BS-->>VM: true
+    else コピー失敗
+        BS->>BS: .tempから元のDBを復元
+        BS-->>VM: false
+    end
+
+    VM-->>User: 結果メッセージ
+```
+
+---
+
+## 13. CSV入出力シーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as ユーザー
+    participant VM as DataExportImportViewModel
+    participant Exp as CsvExportService
+    participant Imp as CsvImportService
+    participant SR as IStaffRepository
+    participant CR as ICardRepository
+    participant LR as ILedgerRepository
+
+    Note over User,LR: CSVエクスポート
+
+    User->>VM: エクスポートボタンクリック（種別・ファイルパス選択済み）
+
+    alt 職員データ
+        VM->>Exp: ExportStaffAsync(filePath, includeDeleted)
+        Exp->>SR: GetAllAsync(includeDeleted)
+        SR-->>Exp: List~Staff~
+        Exp->>Exp: CSV書き出し
+        Exp-->>VM: 出力件数
+    else カードデータ
+        VM->>Exp: ExportCardsAsync(filePath, includeDeleted)
+        Exp->>CR: GetAllAsync(includeDeleted)
+        CR-->>Exp: List~IcCard~
+        Exp->>Exp: CSV書き出し
+        Exp-->>VM: 出力件数
+    else 履歴データ
+        VM->>Exp: ExportLedgersAsync(filePath, startDate, endDate)
+        Exp->>LR: GetByDateRangeAsync(startDate, endDate)
+        LR-->>Exp: List~Ledger~
+        Exp->>Exp: CSV書き出し
+        Exp-->>VM: 出力件数
+    end
+
+    VM-->>User: 完了メッセージ（X件出力）
+
+    Note over User,LR: CSVインポート
+
+    User->>VM: インポートボタンクリック（ファイル選択済み）
+
+    VM->>Imp: PreviewStaffImportAsync(filePath)
+    Imp->>Imp: CSVパース → バリデーション
+    Imp-->>VM: List~ImportPreviewItem~
+
+    VM-->>User: プレビュー表示
+
+    User->>VM: インポート実行
+
+    VM->>Imp: ImportStaffAsync(filePath, skipExisting)
+    Imp->>SR: InsertAsync / UpdateAsync
+    Imp-->>VM: ImportResult(inserted, updated, skipped, errors)
+
+    VM-->>User: 結果メッセージ
+```
+
+---
+
+## 14. 印刷プレビューシーケンス
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as ユーザー
+    participant RVM as ReportViewModel
+    participant PVM as PrintPreviewViewModel
+    participant RDB as ReportDataBuilder
+    participant PS as PrintService
+    participant CR as ICardRepository
+    participant LR as ILedgerRepository
+
+    User->>RVM: プレビューボタンクリック
+
+    RVM->>RDB: BuildAsync(cardIdm, year, month)
+    RDB->>CR: GetByIdmAsync(cardIdm)
+    CR-->>RDB: IcCard
+    RDB->>LR: GetByMonthAsync(cardIdm, year, month)
+    LR-->>RDB: List~Ledger~
+    RDB->>RDB: 繰越・月計・累計を計算
+    RDB-->>RVM: MonthlyReportData
+
+    RVM->>PS: CreateFlowDocument(data, orientation)
+    PS-->>RVM: FlowDocument
+
+    RVM->>PVM: SetDocument(data, title)
+    PVM->>PVM: Document = flowDocument
+    PVM->>PVM: ページ数計算
+
+    PVM-->>User: プレビュー画面表示
+
+    alt ズーム操作
+        User->>PVM: ZoomIn / ZoomOut / ResetZoom
+        PVM->>PVM: ZoomLevel変更 → ContentScale更新
+    end
+
+    alt ページナビゲーション
+        User->>PVM: 次ページ / 前ページ / 最初 / 最後
+        PVM->>PVM: CurrentPage更新
+    end
+
+    alt 印刷方向変更
+        User->>PVM: 縦横切替
+        PVM->>PS: CreateFlowDocument(data, newOrientation)
+        PS-->>PVM: 新FlowDocument
+        PVM->>PVM: Document差替え → 1ページ目にリセット
+    end
+
+    alt 印刷実行
+        User->>PVM: 印刷ボタン
+        PVM->>PS: PrintWithSettings(document, title, orientation)
+        PS-->>PVM: true/false
+    end
+```

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -5,6 +5,14 @@
 ### 1.1 テスト目的
 本テスト設計書は、交通系ICカード貸出管理システムの品質を保証するためのテスト計画・テストケースを定義する。
 
+### 1.1a テスト規模（現状）
+
+| 種別 | テスト数 | 備考 |
+|------|---------|------|
+| 単体テスト（ICCardManager.Tests） | 1,613件 | xUnit + FluentAssertions + Moq |
+| UIテスト（ICCardManager.UITests） | 9件 | |
+| **合計** | **1,622件** | 全件パス |
+
 ### 1.2 テスト範囲
 
 | テストレベル | 対象 | 担当 |
@@ -103,6 +111,192 @@
 | 3 | チャージと利用 | 1000 | 3000 | 500 | 3500 |
 | 4 | 残額ゼロ | 500 | 0 | 500 | 0 |
 | 5 | 繰越計算 | 5000 | 0 | 0 | 5000 |
+
+---
+
+### 2.6 履歴分割サービス（LedgerSplitService）
+
+#### UT-006: 履歴分割処理
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | 2グループに分割 | 元Ledger更新 + 新Ledger1件作成 |
+| 2 | 3グループ以上に分割 | 元Ledger更新 + 新Ledger(N-1)件作成 |
+| 3 | 金額再計算（CalculateGroupFinancials） | グループ内の受入/払出/残額が正しく算出される |
+| 4 | 分割後にGroupIdがクリアされる | 全DetailのGroupId = null |
+| 5 | 分割後に摘要が再生成される | SummaryGeneratorで再生成された値 |
+| 6 | 空摘要の場合「（分割）」がフォールバック | summary = "（分割）" |
+| 7 | IsLentRecordが常にfalse | 新規Ledger.IsLentRecord = false |
+| 8 | 操作ログが記録される | OperationLogger.LogAsync("SPLIT") |
+
+**テストクラス:** `LedgerSplitServiceTests`
+
+---
+
+### 2.7 残高整合性チェック（LedgerConsistencyChecker）
+
+#### UT-007: 残高チェーン整合性検証
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | 整合性のある履歴チェーン | IsConsistent = true |
+| 2 | 残高不整合がある場合 | IsConsistent = false、Inconsistenciesに不整合レコード |
+| 3 | 前回残高+受入-払出≠今回残高 | 期待残高と実際残高の差分を検出 |
+| 4 | 1件のみの場合 | IsConsistent = true（比較対象なし） |
+| 5 | 直前Ledgerを含む検証 | CheckConsistencyWithPreviousAsync正常動作 |
+
+**テストクラス:** `LedgerConsistencyCheckerTests`
+
+---
+
+### 2.8 残高チェーン順序復元（LedgerOrderHelper）
+
+#### UT-008: Ledger順序の復元
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | 正常なチェーンの順序維持 | 入力順序が維持される |
+| 2 | 順序が乱れたチェーンの復元 | 残高チェーンに基づく正しい順序 |
+| 3 | 前回残高指定ありの場合 | precedingBalanceから開始して正しい順序 |
+| 4 | 特殊レコード（チャージ等）の処理 | 特殊レコードが正しく位置付けられる |
+| 5 | 空リストの場合 | 空リストが返される |
+
+**テストクラス:** `LedgerOrderHelperTests`
+
+---
+
+### 2.9 入力バリデーション（ValidationService）
+
+#### UT-009: 入力値の検証
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 正しいIDm（16桁16進数） | "0123456789ABCDEF" | IsValid = true |
+| 2 | IDm長さ不正 | "01234567" | IsValid = false |
+| 3 | IDm非16進数文字 | "GHIJKLMNOPQRSTUV" | IsValid = false |
+| 4 | カード番号最大長超過 | 21文字以上 | IsValid = false |
+| 5 | 職員名必須チェック | "" | IsValid = false |
+| 6 | 職員名最大長超過 | 51文字以上 | IsValid = false |
+| 7 | 警告残高範囲チェック（正常） | 5000 | IsValid = true |
+| 8 | 警告残高範囲チェック（超過） | 25000 | IsValid = false |
+| 9 | バス停名最大長チェック | 101文字以上 | IsValid = false |
+
+**テストクラス:** `ValidationServiceTests`
+
+---
+
+### 2.10 バックアップサービス（BackupService）
+
+#### UT-010: バックアップ・リストア処理
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | 自動バックアップ成功 | バックアップファイルが作成される |
+| 2 | バックアップパス未設定時のフォールバック | デフォルトパスが使用される |
+| 3 | 無効なパスのフォールバック | デフォルトパスにフォールバック |
+| 4 | バックアップファイル一覧取得 | 日時降順でファイル一覧 |
+| 5 | 30世代超過時の古いファイル削除 | 最新30件のみ保持 |
+| 6 | リストア成功 | DB接続クローズ→ファイル差替え→成功 |
+| 7 | リストア失敗時のロールバック | .tempから元DBを復元 |
+
+**テストクラス:** `BackupServiceTests`
+
+---
+
+### 2.11 キャッシュサービス（CacheService）
+
+#### UT-011: メモリキャッシュ操作
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | キャッシュの取得・設定 | Set→Get で同じ値が返る |
+| 2 | GetOrCreateAsync初回呼び出し | factory関数が実行される |
+| 3 | GetOrCreateAsync2回目（キャッシュヒット） | factory関数が実行されない |
+| 4 | キャッシュの無効化（Invalidate） | 指定キーが削除される |
+| 5 | プレフィックスによる一括無効化 | 該当キーが全て削除される |
+| 6 | 全クリア（Clear） | 全キーが削除される |
+| 7 | 有効期限切れ | 期限後はnull/factory再実行 |
+
+**テストクラス:** `CacheServiceTests`
+
+---
+
+### 2.12 ViewModelBase基底クラス
+
+#### UT-012: ビジー状態・プログレス管理
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | 初期状態 | IsBusy=false, IsIndeterminate=true |
+| 2 | SetBusy(true) | IsBusy=true, BusyMessage設定 |
+| 3 | SetBusy(false) | プログレスがリセットされる |
+| 4 | SetProgress | IsIndeterminate=false, 値更新 |
+| 5 | BeginBusy スコープ開始/終了 | IsBusy遷移 true→false |
+| 6 | BeginCancellableBusy | CanCancel=true |
+| 7 | CancelOperation | IsCancellationRequested=true |
+| 8 | BusyScope.ReportProgress | プログレス値更新 |
+| 9 | BusyScope.ThrowIfCancellationRequested | キャンセル後にOperationCanceledException |
+
+**テストクラス:** `ViewModelBaseTests`
+
+---
+
+### 2.13 ErrorDialogHelperエラー情報マッピング
+
+#### UT-013: 例外→エラーコード変換
+
+| No | テストケース | 入力例外 | 期待エラーコード |
+|----|-------------|---------|----------------|
+| 1 | CardReaderException | NotConnected() | CR001 |
+| 2 | DatabaseException | ConnectionFailed() | DB001 |
+| 3 | BusinessException | CardAlreadyLent() | BIZ001 |
+| 4 | ValidationException | Required() | VAL001 |
+| 5 | FileOperationException | FileNotFound() | FILE001 |
+| 6 | UnauthorizedAccessException | - | SYS001 |
+| 7 | IOException | - | SYS002 |
+| 8 | TimeoutException | - | SYS003 |
+| 9 | InvalidOperationException | - | SYS004 |
+| 10 | ArgumentException | - | SYS005 |
+| 11 | NotSupportedException | - | SYS006 |
+| 12 | 未知の例外 | Exception | SYS999 |
+
+**テストクラス:** `ErrorDialogHelperTests`
+
+---
+
+### 2.14 FileOperationException例外
+
+#### UT-014: ファイル操作例外のファクトリメソッド
+
+| No | テストケース | ファクトリメソッド | 期待エラーコード |
+|----|-------------|-------------------|----------------|
+| 1 | ファイル未検出 | FileNotFound(path) | FILE001 |
+| 2 | 読み込み失敗 | ReadFailed(path) | FILE002 |
+| 3 | 書き込み失敗 | WriteFailed(path) | FILE003 |
+| 4 | アクセス拒否 | AccessDenied(path) | FILE004 |
+| 5 | ファイル使用中 | FileInUse(path) | FILE005 |
+| 6 | 無効な形式 | InvalidFormat(path) | FILE006 |
+| 7 | ディレクトリ作成失敗 | DirectoryCreationFailed(path) | FILE007 |
+| 8 | FilePathプロパティ保持 | 各メソッド | 指定パスが保持される |
+| 9 | エラーコード一意性 | 全メソッド | FILE001〜FILE007が重複しない |
+
+**テストクラス:** `AppExceptionTests`（FileOperationExceptionリージョン）
+
+---
+
+### 2.15 DtoMapperマッピング
+
+#### UT-015: DTO変換
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | Staff → StaffDto変換 | 全プロパティが正しくマッピング |
+| 2 | IcCard → CardDto変換 | 全プロパティが正しくマッピング |
+| 3 | Ledger → LedgerDto変換 | Detail含む全プロパティがマッピング |
+| 4 | null入力 | 例外またはnull返却 |
+| 5 | コレクション変換 | リスト全要素が正しく変換 |
+
+**テストクラス:** `DtoMapperTests`
 
 ---
 
@@ -230,6 +424,65 @@
 - staffテーブルでis_deleted=1, deleted_atが設定
 - 物理削除はされない
 - 履歴表示時に「佐藤三郎」の氏名が表示される
+
+---
+
+#### IT-007: 履歴統合→元に戻すフロー
+
+**事前条件:**
+- カード「001」に同一日の履歴が3件存在
+
+**手順:**
+1. 履歴詳細画面で3件を選択
+2. 統合ボタンをクリック
+3. 職員認証を実施
+4. 統合完了を確認
+5. 元に戻すボタンをクリック
+6. 元の3件に復元されることを確認
+
+**期待結果:**
+- 統合後: 1件のLedgerに3件分のDetailが統合
+- 摘要が再生成される
+- 元に戻す後: 元の3件が復元される
+- 操作ログにMERGE/UNMERGEが記録される
+
+---
+
+#### IT-008: 履歴分割→残高整合性チェックフロー
+
+**事前条件:**
+- カード「001」に複数Detailを含むLedgerが1件存在
+
+**手順:**
+1. 履歴詳細画面でDetailを2グループに分ける
+2. 分割ボタンをクリック
+3. 職員認証を実施
+4. 分割後に残高整合性チェックを実行
+
+**期待結果:**
+- 分割後: 元Ledger更新 + 新Ledger1件作成
+- 各Ledgerの金額がCalculateGroupFinancialsで正しく計算
+- 残高整合性チェックがIsConsistent = trueを返す
+- 操作ログにSPLITが記録される
+
+---
+
+#### IT-009: CSVエクスポート→インポート往復フロー
+
+**事前条件:**
+- 職員データが5件登録済み
+
+**手順:**
+1. データエクスポート画面で職員データをCSVエクスポート
+2. エクスポートしたCSVファイルを確認
+3. データインポート画面で同じCSVをプレビュー
+4. インポートを実行（skipExisting = true）
+
+**期待結果:**
+- エクスポート: 5件がCSV出力される
+- インポートプレビュー: 5件が「スキップ」として表示
+- インポート実行: SkippedCount = 5、InsertedCount = 0
+- データの整合性が保たれる
 
 ---
 
@@ -401,8 +654,9 @@
 
 | 項目 | 基準 |
 |------|------|
-| 単体テスト | 全件パス |
+| 単体テスト | 全件パス（現在1,613件） |
 | 結合テスト | 全件パス |
+| UIテスト | 全件パス（現在9件） |
 | システムテスト | 重大バグ0件、軽微バグ5件以下 |
 | 受入テスト | 全シナリオパス |
 
@@ -412,6 +666,7 @@
 |------|------|
 | コードカバレッジ | 80%以上 |
 | 性能テスト | 全項目が目標値以内 |
+| 自動テスト合計 | 1,600件以上を維持 |
 
 ---
 


### PR DESCRIPTION
## Summary
- ソースコードとの乖離が大きかった設計書4件を最新の実装に合わせて更新
- 後から追加された機能のクラス・ロジック・フローが設計書に反映されていなかったものを網羅的に追記
- 合計1,366行の追加（コード変更なし、ドキュメントのみ）

## 更新内容

### 05_クラス設計書.md（+459行）
- Section 3.2 ViewModelテーブルに9件追加（SystemManage, PrintPreview, LedgerDetail等）
- Section 5にサービス6クラス追加（5.18 ReportDataBuilder〜5.23 ValidationService）
- Section 2 レイヤー構成図にサービス・インフラを追加
- Section 3.3 サービステーブルに6行追加
- 新セクション9（インフラ詳細: CacheService, FelicaCardReader, FileLogger）
- 新セクション10（共通ユーティリティ: ErrorDialogHelper, PathValidator）
- 新セクション11（DB基盤: MigrationRunner）
- 新セクション12（DTO詳細: MonthlyReportData, WarningItem等）

### 04_機能設計書.md（+317行）
- セクション8: 履歴統合（マージ）機能 — 統合条件・フロー・計算ルール・元に戻す機能
- セクション9: 履歴分割機能 — 分割条件・フロー・金額計算ロジック
- セクション10: 残高整合性チェック — 検証ロジック・バリエーション
- セクション11: 職員認証機能 — 認証フロー・タイムアウト仕様
- セクション12: 印刷プレビュー機能 — ズーム・ナビゲーション・方向切替
- セクション13: 操作ログExcel出力 — カラム定義・書式・JSON整形ルール
- セクション14: カード排他制御 — ロック戦略・自動クリーンアップ

### 06_シーケンス図.md（+334行）
- セクション9: 履歴統合シーケンス
- セクション10: 履歴分割シーケンス
- セクション11: 職員認証シーケンス
- セクション12: バックアップ/リストアシーケンス
- セクション13: CSV入出力シーケンス
- セクション14: 印刷プレビューシーケンス

### 07_テスト設計書.md（+256行）
- テスト規模の現状（1,622件）を追記
- UT-006〜UT-015（単体テスト10項目）追加: LedgerSplitService, ConsistencyChecker, OrderHelper, ValidationService, BackupService, CacheService, ViewModelBase, ErrorDialogHelper, FileOperationException, DtoMapper
- IT-007〜IT-009（結合テスト3項目）追加: 統合→元に戻す, 分割→整合性チェック, CSVエクスポート→インポート往復
- テスト完了基準の数値を更新

## Test plan
- [ ] 各Mermaid図がGitHub上で正しくレンダリングされることを確認
- [ ] 追加セクションの番号が既存と連続していることを確認
- [ ] クラス名・メソッド名がソースコードと一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)