### PR TITLE
fix: 会社名を「Your Organization」から正しい値に修正

### DIFF
--- a/ICCardManager/src/ICCardManager/ICCardManager.csproj
+++ b/ICCardManager/src/ICCardManager/ICCardManager.csproj
@@ -15,7 +15,7 @@
     <Version>1.15.1</Version>
     <FileVersion>1.15.1.0</FileVersion>
     <AssemblyVersion>1.15.1.0</AssemblyVersion>
-    <Company>Your Organization</Company>
+    <Company>桑山雅行</Company>
     <Product>交通系ICカード管理システム</Product>
     <Description>交通系ICカードの貸出管理システム</Description>
 

--- a/ICCardManager/tools/DebugDataViewer/DebugDataViewer.csproj
+++ b/ICCardManager/tools/DebugDataViewer/DebugDataViewer.csproj
@@ -15,7 +15,7 @@
     <Version>1.0.0</Version>
     <FileVersion>1.0.0.0</FileVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Company>Your Organization</Company>
+    <Company>桑山雅行</Company>
     <Product>ICカード管理システム デバッグツール</Product>
     <Description>ICカードの生データおよびDBデータを確認するための開発者向けツール</Description>
 


### PR DESCRIPTION
## Summary
Closes #857

- `ICCardManager.csproj`と`DebugDataViewer.csproj`の`<Company>`タグがプレースホルダー「Your Organization」のまま残っていた
- 正しい値「桑山雅行」に修正

## Test plan
- [ ] 手動テスト: リリースビルド後、exeファイルのプロパティ→詳細タブで会社名が「桑山雅行」になっていることを確認
- [ ] 手動テスト: インストール時に会社名が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)