### PR TITLE
fix: 愛称追加に伴いウィンドウのデフォルト幅・最小幅を拡大

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml
+++ b/ICCardManager/src/ICCardManager/App.xaml
@@ -29,8 +29,8 @@
 
             <!-- Issue #542: サイドバー幅（フォントサイズに応じて動的に変更） -->
             <sys:Double x:Key="SidebarWidth">350</sys:Double>
-            <!-- Issue #542: ウィンドウ最小幅（固定値） Issue #663: ヘルプボタン追加に伴い拡大 -->
-            <sys:Double x:Key="WindowMinWidth">1300</sys:Double>
+            <!-- Issue #542: ウィンドウ最小幅（固定値） Issue #663: ヘルプボタン追加に伴い拡大 愛称追加に伴い再拡大 -->
+            <sys:Double x:Key="WindowMinWidth">1400</sys:Double>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -459,8 +459,8 @@ namespace ICCardManager
             // 基準: Medium (14) で 350px、差分 × 5 で調整
             // Small(12)→340, Medium(14)→350, Large(16)→360, ExtraLarge(20)→380
             var sidebarWidth = Math.Round(350 + (baseFontSize - 14) * 5);
-            // Issue #663: ウィンドウ最小幅はフォントサイズに関係なく固定（1300px）
-            const double windowMinWidth = 1300;
+            // Issue #663: ウィンドウ最小幅はフォントサイズに関係なく固定 愛称追加に伴い拡大（1400px）
+            const double windowMinWidth = 1400;
 
             // アプリケーションリソースを更新
             var resources = Application.Current.Resources;

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -11,7 +11,7 @@
         d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
         Title="{x:Static conv:AppConstants.SystemName}"
         Height="700"
-        Width="1350"
+        Width="1450"
         MinWidth="{DynamicResource WindowMinWidth}"
         MinHeight="600"
         WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
## Summary

- PR #864 でシステム愛称「ピッすい」を追加した結果、ヘッダーのタイトル文字列が長くなり、ツールバーボタンが2行に折り返す問題が発生
- ウィンドウのデフォルト幅と最小幅を100px拡大して解消

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `MainWindow.xaml` Width | 1350 | 1450 |
| `App.xaml` WindowMinWidth | 1300 | 1400 |
| `App.xaml.cs` windowMinWidth | 1300 | 1400 |

## Test plan

- [x] `dotnet build` — ビルド成功
- [x] `dotnet test` — 全1666テスト合格
- [x] アプリ起動してヘッダーのボタンが1行に収まること
- [ ] 「特大」フォントサイズでもボタンが折り返さないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)