### PR TITLE
fix: リリースワークフローでUIテストを除外（#873）

### DIFF
--- a/ICCardManager/.github/workflows/release.yml
+++ b/ICCardManager/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet restore ${{ env.PROJECT_PATH }}
 
       - name: Run tests
-        run: dotnet test ICCardManager/ICCardManager.sln --configuration Release --verbosity normal
+        run: dotnet test ICCardManager/ICCardManager.sln --configuration Release --verbosity normal --filter "Category!=UI"
 
       - name: Publish self-contained executable
         run: |

--- a/ICCardManager/tests/ICCardManager.UITests/Infrastructure/AppFixture.cs
+++ b/ICCardManager/tests/ICCardManager.UITests/Infrastructure/AppFixture.cs
@@ -155,21 +155,49 @@ namespace ICCardManager.UITests.Infrastructure
         }
 
         /// <summary>
-        /// Debug ビルドの既定 exe パスを解決する。
+        /// 既定の exe パスを解決する。
+        /// テスト DLL と同じビルド構成（Release/Debug）を優先し、
+        /// 見つからなければもう一方の構成にフォールバックする。
         /// </summary>
         private static string ResolveDefaultExePath()
         {
-            // テスト DLL の場所から相対パスで exe を探す
             var testAssemblyDir = AppDomain.CurrentDomain.BaseDirectory;
+            var (primaryPath, fallbackPath) = ResolveExePathCandidates(testAssemblyDir);
 
-            // tests/ICCardManager.UITests/bin/Debug/net48/
-            //   → src/ICCardManager/bin/Debug/net48/ICCardManager.exe
+            if (File.Exists(primaryPath))
+                return primaryPath;
+
+            return File.Exists(fallbackPath) ? fallbackPath : primaryPath;
+        }
+
+        /// <summary>
+        /// テスト DLL のディレクトリから exe パスの候補を算出する（純粋なパス計算、I/O なし）。
+        /// </summary>
+        /// <param name="testAssemblyDir">テスト DLL の BaseDirectory（末尾セパレータあり/なし両対応）。</param>
+        /// <returns>primaryPath（テスト構成と同じ）と fallbackPath（もう一方の構成）のタプル。</returns>
+        internal static (string primaryPath, string fallbackPath) ResolveExePathCandidates(string testAssemblyDir)
+        {
+            // tests/ICCardManager.UITests/bin/{Config}/net48/
+            //   → src/ICCardManager/bin/{Config}/net48/ICCardManager.exe
             var projectRoot = Path.GetFullPath(
                 Path.Combine(testAssemblyDir, "..", "..", "..", "..", ".."));
-            var exePath = Path.Combine(
-                projectRoot, "src", "ICCardManager", "bin", "Debug", "net48", "ICCardManager.exe");
 
-            return exePath;
+            // テスト DLL 自身のパスからビルド構成を推定する
+            // testAssemblyDir は …/bin/Debug/net48/ または …/bin/Release/net48/ の形式
+            var parentOfNet48 = Path.GetFullPath(Path.Combine(testAssemblyDir, ".."));
+            var configDir = Path.GetFileName(parentOfNet48);
+
+            var primaryConfig = configDir;
+            var fallbackConfig = string.Equals(configDir, "Release", StringComparison.OrdinalIgnoreCase)
+                ? "Debug"
+                : "Release";
+
+            var primaryPath = Path.Combine(
+                projectRoot, "src", "ICCardManager", "bin", primaryConfig, "net48", "ICCardManager.exe");
+            var fallbackPath = Path.Combine(
+                projectRoot, "src", "ICCardManager", "bin", fallbackConfig, "net48", "ICCardManager.exe");
+
+            return (primaryPath, fallbackPath);
         }
     }
 }

--- a/ICCardManager/tests/ICCardManager.UITests/Tests/AppFixturePathResolutionTests.cs
+++ b/ICCardManager/tests/ICCardManager.UITests/Tests/AppFixturePathResolutionTests.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using FluentAssertions;
+using ICCardManager.UITests.Infrastructure;
+using Xunit;
+
+namespace ICCardManager.UITests.Tests
+{
+    /// <summary>
+    /// AppFixture のパス解決ロジックのユニットテスト。
+    /// GUI 不要のため Category=UI を付けず、CI でも実行される。
+    /// </summary>
+    public class AppFixturePathResolutionTests
+    {
+        [Theory]
+        [InlineData("Debug")]
+        [InlineData("Release")]
+        public void ResolveExePathCandidates_テストDLLの構成と同じ構成が優先される(string config)
+        {
+            // Arrange: テスト DLL のパスを模擬
+            var testAssemblyDir = Path.Combine(
+                "C:", "repo", "tests", "ICCardManager.UITests", "bin", config, "net48");
+
+            // Act
+            var (primaryPath, _) = AppFixture.ResolveExePathCandidates(testAssemblyDir);
+
+            // Assert: primary パスにテスト構成と同じ構成名が含まれること
+            primaryPath.Should().Contain(
+                Path.Combine("bin", config, "net48", "ICCardManager.exe"));
+        }
+
+        [Fact]
+        public void ResolveExePathCandidates_Debug構成のフォールバックはRelease()
+        {
+            var testAssemblyDir = Path.Combine(
+                "C:", "repo", "tests", "ICCardManager.UITests", "bin", "Debug", "net48");
+
+            var (_, fallbackPath) = AppFixture.ResolveExePathCandidates(testAssemblyDir);
+
+            fallbackPath.Should().Contain(
+                Path.Combine("bin", "Release", "net48", "ICCardManager.exe"));
+        }
+
+        [Fact]
+        public void ResolveExePathCandidates_Release構成のフォールバックはDebug()
+        {
+            var testAssemblyDir = Path.Combine(
+                "C:", "repo", "tests", "ICCardManager.UITests", "bin", "Release", "net48");
+
+            var (_, fallbackPath) = AppFixture.ResolveExePathCandidates(testAssemblyDir);
+
+            fallbackPath.Should().Contain(
+                Path.Combine("bin", "Debug", "net48", "ICCardManager.exe"));
+        }
+
+        [Theory]
+        [InlineData("Debug")]
+        [InlineData("Release")]
+        public void ResolveExePathCandidates_プロジェクトルートからのsrc相対パスが正しい(string config)
+        {
+            var testAssemblyDir = Path.Combine(
+                "C:", "repo", "tests", "ICCardManager.UITests", "bin", config, "net48");
+
+            var (primaryPath, _) = AppFixture.ResolveExePathCandidates(testAssemblyDir);
+
+            // プロジェクトルート/src/ICCardManager/bin/{config}/net48/ICCardManager.exe
+            primaryPath.Should().Contain(Path.Combine("src", "ICCardManager", "bin"));
+            primaryPath.Should().EndWith("ICCardManager.exe");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- リリースワークフロー（`release.yml`）でUIテスト（GUI必須）が実行されて全テスト失敗していた問題を修正
- `AppFixture.ResolveDefaultExePath()` がDebug構成のexeパスしか検索しない問題を修正し、ビルド構成に応じたフォールバック機能を追加
- パス解決ロジックのユニットテスト6件を追加

## 変更内容

### release.yml
- `dotnet test` に `--filter "Category!=UI"` を追加（`ci.yml` と統一）

### AppFixture.cs
- テストDLLの配置パスからビルド構成（Debug/Release）を自動検出
- 同じ構成のexeを優先し、存在しなければもう一方の構成にフォールバック
- パス計算ロジックを `internal static ResolveExePathCandidates()` に切り出してテスト可能に

### AppFixturePathResolutionTests.cs（新規）
- パス解決ロジックの単体テスト6件

## Test plan
- [x] 新規テスト6件が成功することを確認
- [x] 既存テスト1621件がすべて成功することを確認
- [ ] CIが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)