### PR TITLE
fix: チャージが利用の間に挟まる場合の残高チェーン不整合を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -721,186 +721,197 @@ namespace ICCardManager.Services
                     lastBalance = 0;
                 }
 
-                // チャージとそれ以外を分ける（残高不足パターンで処理済みのものは除外されている）
-                var chargeDetails = dailyDetails.Where(d => d.IsCharge).ToList();
-                var usageDetails = dailyDetails.Where(d => !d.IsCharge).ToList();
+                // チャージ境界で利用グループを分割（残高不足パターンで処理済みのものは除外されている）
+                var segments = SplitAtChargeBoundaries(dailyDetails);
 
-                // チャージがある場合、別レコードとして作成
-                foreach (var charge in chargeDetails)
+                // Issue #837: 同一カード・同一日の既存利用レコードを取得（統合用）
+                // 最初の利用セグメント処理時に既存レコードとの統合を試みる
+                List<Ledger> existingUsageLedgers = null;
+                var hasUsageSegment = segments.Any(s => !s.IsCharge);
+                if (hasUsageSegment)
                 {
-                    int balance;
-                    int income;
-
-                    if (useCardBalance && charge.Balance.HasValue)
-                    {
-                        // カードから読み取った残高を使用
-                        balance = charge.Balance.Value;
-                        income = charge.Amount ?? (balance - lastBalance);
-                        lastBalance = balance;
-                    }
-                    else
-                    {
-                        // フォールバック: Amountから計算
-                        income = charge.Amount ?? 0;
-                        lastBalance += income;
-                        balance = lastBalance;
-                    }
-
-                    var chargeLedger = new Ledger
-                    {
-                        CardIdm = cardIdm,
-                        Date = charge.UseDate ?? date,
-                        Summary = SummaryGenerator.GetChargeSummary(_settingsRepository.GetAppSettings().DepartmentType),
-                        Income = income,
-                        Expense = 0,
-                        Balance = balance,
-                        StaffName = null  // チャージは機械操作のため氏名不要
-                    };
-
-                    var ledgerId = await _ledgerRepository.InsertAsync(chargeLedger);
-                    chargeLedger.Id = ledgerId;
-
-                    // 詳細を登録
-                    charge.LedgerId = ledgerId;
-                    await _ledgerRepository.InsertDetailAsync(charge);
-
-                    createdLedgers.Add(chargeLedger);
-                }
-
-                // 利用がある場合
-                if (usageDetails.Count > 0)
-                {
-                    // Issue #837: 同一カード・同一日の既存利用レコードがあれば統合する
                     var existingLedgers = await _ledgerRepository.GetByDateRangeAsync(cardIdm, date, date);
-                    var existingUsageLedger = existingLedgers
-                        .FirstOrDefault(l => !l.IsLentRecord && l.Income == 0 && string.IsNullOrEmpty(l.Note));
+                    existingUsageLedgers = existingLedgers
+                        .Where(l => !l.IsLentRecord && l.Income == 0 && string.IsNullOrEmpty(l.Note))
+                        .OrderByDescending(l => l.Balance)  // 残高降順（高い=古い）
+                        .ToList();
+                }
+                var isFirstUsageSegment = true;
 
-                    if (existingUsageLedger != null)
+                // 各セグメントを時系列順に処理（lastBalanceを引き継いで残高チェーンを維持）
+                foreach (var segment in segments)
+                {
+                    if (segment.IsCharge)
                     {
-                        _logger.LogDebug("LendingService: 同一日の既存利用レコードを検出（LedgerId={Id}）、統合します", existingUsageLedger.Id);
-
-                        // 1. 新しい詳細を既存レコードに追加
-                        await _ledgerRepository.InsertDetailsAsync(existingUsageLedger.Id, usageDetails);
-
-                        // 2. 全詳細を再読み込み
-                        var fullLedger = await _ledgerRepository.GetByIdAsync(existingUsageLedger.Id);
-                        var allUsageDetails = fullLedger.Details.Where(d => !d.IsCharge).ToList();
-
-                        // 3. 摘要を再生成（往復検出・乗継統合が全詳細に対して実行される）
-                        var summary = _summaryGenerator.Generate(allUsageDetails);
-
-                        // 4. 残高・支出を再計算
+                        // チャージLedger作成
+                        var charge = segment.Details[0];
                         int balance;
-                        int expense;
+                        int income;
 
-                        if (useCardBalance)
+                        if (useCardBalance && charge.Balance.HasValue)
                         {
-                            var latestDetail = allUsageDetails
-                                .Where(d => d.Balance.HasValue)
-                                .OrderBy(d => d.Balance)
-                                .FirstOrDefault();
-
-                            if (latestDetail?.Balance != null)
-                            {
-                                balance = latestDetail.Balance.Value;
-                                expense = allUsageDetails.Sum(d => d.Amount ?? 0);
-                                if (expense == 0)
-                                {
-                                    expense = lastBalance - balance;
-                                    if (expense < 0) expense = 0;
-                                }
-                                lastBalance = balance;
-                            }
-                            else
-                            {
-                                expense = allUsageDetails.Sum(d => d.Amount ?? 0);
-                                lastBalance -= expense;
-                                balance = lastBalance;
-                            }
+                            balance = charge.Balance.Value;
+                            income = charge.Amount ?? (balance - lastBalance);
+                            lastBalance = balance;
                         }
                         else
                         {
-                            expense = allUsageDetails.Sum(d => d.Amount ?? 0);
-                            lastBalance -= (expense - existingUsageLedger.Expense);
+                            income = charge.Amount ?? 0;
+                            lastBalance += income;
                             balance = lastBalance;
                         }
 
-                        // 5. 既存レコードを更新
-                        fullLedger.Summary = summary;
-                        fullLedger.Expense = expense;
-                        fullLedger.Balance = balance;
-                        if (fullLedger.StaffName == null && staffName != null)
-                        {
-                            fullLedger.StaffName = staffName;
-                        }
-                        await _ledgerRepository.UpdateAsync(fullLedger);
-
-                        createdLedgers.Add(fullLedger);
-                    }
-                    else
-                    {
-                        // 既存の利用レコードがない場合は新規作成
-                        int balance;
-                        int expense;
-
-                        if (useCardBalance)
-                        {
-                            // カードから読み取った残高を使用（日付内の最新レコードの残高）
-                            // 利用履歴は時刻順にソートされていないので、残高が最小のものを選ぶ
-                            // （利用後なので残高は減っている）
-                            var latestDetail = usageDetails
-                                .Where(d => d.Balance.HasValue)
-                                .OrderBy(d => d.Balance)
-                                .FirstOrDefault();
-
-                            if (latestDetail?.Balance != null)
-                            {
-                                balance = latestDetail.Balance.Value;
-                                expense = usageDetails.Sum(d => d.Amount ?? 0);
-                                if (expense == 0)
-                                {
-                                    // Amountが設定されていない場合、残高差から計算
-                                    expense = lastBalance - balance;
-                                    if (expense < 0) expense = 0;
-                                }
-                                lastBalance = balance;
-                            }
-                            else
-                            {
-                                // フォールバック
-                                expense = usageDetails.Sum(d => d.Amount ?? 0);
-                                lastBalance -= expense;
-                                balance = lastBalance;
-                            }
-                        }
-                        else
-                        {
-                            // フォールバック: Amountから計算
-                            expense = usageDetails.Sum(d => d.Amount ?? 0);
-                            lastBalance -= expense;
-                            balance = lastBalance;
-                        }
-
-                        var summary = _summaryGenerator.Generate(usageDetails);
-
-                        var usageLedger = new Ledger
+                        var chargeLedger = new Ledger
                         {
                             CardIdm = cardIdm,
-                            Date = usageDetails.FirstOrDefault()?.UseDate ?? date,
-                            Summary = summary,
-                            Income = 0,
-                            Expense = expense,
+                            Date = charge.UseDate ?? date,
+                            Summary = SummaryGenerator.GetChargeSummary(_settingsRepository.GetAppSettings().DepartmentType),
+                            Income = income,
+                            Expense = 0,
                             Balance = balance,
-                            StaffName = usageDetails.All(d => d.IsPointRedemption) ? null : staffName
+                            StaffName = null  // チャージは機械操作のため氏名不要
                         };
 
-                        var ledgerId = await _ledgerRepository.InsertAsync(usageLedger);
-                        usageLedger.Id = ledgerId;
+                        var ledgerId = await _ledgerRepository.InsertAsync(chargeLedger);
+                        chargeLedger.Id = ledgerId;
 
-                        // 詳細を登録
-                        await _ledgerRepository.InsertDetailsAsync(ledgerId, usageDetails);
+                        charge.LedgerId = ledgerId;
+                        await _ledgerRepository.InsertDetailAsync(charge);
 
-                        createdLedgers.Add(usageLedger);
+                        createdLedgers.Add(chargeLedger);
+                    }
+                    else
+                    {
+                        // 利用グループLedger作成
+                        var usageDetails = segment.Details;
+                        if (usageDetails.Count == 0) continue;
+
+                        // 最初の利用セグメントのみ既存レコードとの統合を試みる
+                        var existingUsageLedger = isFirstUsageSegment
+                            ? existingUsageLedgers?.LastOrDefault()  // 残高最小（時系列最新）
+                            : null;
+                        isFirstUsageSegment = false;
+
+                        if (existingUsageLedger != null)
+                        {
+                            _logger.LogDebug("LendingService: 同一日の既存利用レコードを検出（LedgerId={Id}）、統合します", existingUsageLedger.Id);
+
+                            // 1. 新しい詳細を既存レコードに追加
+                            await _ledgerRepository.InsertDetailsAsync(existingUsageLedger.Id, usageDetails);
+
+                            // 2. 全詳細を再読み込み
+                            var fullLedger = await _ledgerRepository.GetByIdAsync(existingUsageLedger.Id);
+                            var allUsageDetails = fullLedger.Details.Where(d => !d.IsCharge).ToList();
+
+                            // 3. 摘要を再生成（往復検出・乗継統合が全詳細に対して実行される）
+                            var summary = _summaryGenerator.Generate(allUsageDetails);
+
+                            // 4. 残高・支出を再計算
+                            int balance;
+                            int expense;
+
+                            if (useCardBalance)
+                            {
+                                var latestDetail = allUsageDetails
+                                    .Where(d => d.Balance.HasValue)
+                                    .OrderBy(d => d.Balance)
+                                    .FirstOrDefault();
+
+                                if (latestDetail?.Balance != null)
+                                {
+                                    balance = latestDetail.Balance.Value;
+                                    expense = allUsageDetails.Sum(d => d.Amount ?? 0);
+                                    if (expense == 0)
+                                    {
+                                        expense = lastBalance - balance;
+                                        if (expense < 0) expense = 0;
+                                    }
+                                    lastBalance = balance;
+                                }
+                                else
+                                {
+                                    expense = allUsageDetails.Sum(d => d.Amount ?? 0);
+                                    lastBalance -= expense;
+                                    balance = lastBalance;
+                                }
+                            }
+                            else
+                            {
+                                expense = allUsageDetails.Sum(d => d.Amount ?? 0);
+                                lastBalance -= (expense - existingUsageLedger.Expense);
+                                balance = lastBalance;
+                            }
+
+                            // 5. 既存レコードを更新
+                            fullLedger.Summary = summary;
+                            fullLedger.Expense = expense;
+                            fullLedger.Balance = balance;
+                            if (fullLedger.StaffName == null && staffName != null)
+                            {
+                                fullLedger.StaffName = staffName;
+                            }
+                            await _ledgerRepository.UpdateAsync(fullLedger);
+
+                            createdLedgers.Add(fullLedger);
+                        }
+                        else
+                        {
+                            // 新規作成
+                            int balance;
+                            int expense;
+
+                            if (useCardBalance)
+                            {
+                                var latestDetail = usageDetails
+                                    .Where(d => d.Balance.HasValue)
+                                    .OrderBy(d => d.Balance)
+                                    .FirstOrDefault();
+
+                                if (latestDetail?.Balance != null)
+                                {
+                                    balance = latestDetail.Balance.Value;
+                                    expense = usageDetails.Sum(d => d.Amount ?? 0);
+                                    if (expense == 0)
+                                    {
+                                        expense = lastBalance - balance;
+                                        if (expense < 0) expense = 0;
+                                    }
+                                    lastBalance = balance;
+                                }
+                                else
+                                {
+                                    expense = usageDetails.Sum(d => d.Amount ?? 0);
+                                    lastBalance -= expense;
+                                    balance = lastBalance;
+                                }
+                            }
+                            else
+                            {
+                                expense = usageDetails.Sum(d => d.Amount ?? 0);
+                                lastBalance -= expense;
+                                balance = lastBalance;
+                            }
+
+                            var summary = _summaryGenerator.Generate(usageDetails);
+
+                            var usageLedger = new Ledger
+                            {
+                                CardIdm = cardIdm,
+                                Date = usageDetails.FirstOrDefault()?.UseDate ?? date,
+                                Summary = summary,
+                                Income = 0,
+                                Expense = expense,
+                                Balance = balance,
+                                StaffName = usageDetails.All(d => d.IsPointRedemption) ? null : staffName
+                            };
+
+                            var ledgerId = await _ledgerRepository.InsertAsync(usageLedger);
+                            usageLedger.Id = ledgerId;
+
+                            await _ledgerRepository.InsertDetailsAsync(ledgerId, usageDetails);
+
+                            createdLedgers.Add(usageLedger);
+                        }
                     }
                 }
             }
@@ -981,6 +992,158 @@ namespace ICCardManager.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// 同一日の時系列セグメント（利用グループまたは単一チャージ）。
+        /// チャージ境界で利用を分割するために使用する。
+        /// </summary>
+        internal class DailySegment
+        {
+            /// <summary>チャージセグメントかどうか</summary>
+            public bool IsCharge { get; init; }
+
+            /// <summary>セグメント内の詳細リスト（利用グループの場合は複数、チャージの場合は1件）</summary>
+            public List<LedgerDetail> Details { get; init; } = new();
+        }
+
+        /// <summary>
+        /// 同一日の履歴を時系列順に並べ、チャージの位置で利用グループを分割する。
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// ICカードの利用履歴を残高チェーンで時系列順（古い順）に並べ替え、
+        /// チャージが出現する位置で利用グループを区切る。
+        /// これにより、チャージが利用の間に挟まるケースで残高チェーンが正しく維持される。
+        /// </para>
+        /// <para>
+        /// 例: [trip1, charge, trip2] → [UsageGroup(trip1), Charge, UsageGroup(trip2)]<br/>
+        /// 例: [trip1, trip2, charge] → [UsageGroup(trip1+trip2), Charge]<br/>
+        /// 例: [trip1, trip2] → [UsageGroup(trip1+trip2)]
+        /// </para>
+        /// </remarks>
+        /// <param name="dailyDetails">同一日内の全詳細（残高不足パターン処理済み）</param>
+        /// <returns>時系列順のセグメントリスト</returns>
+        internal static List<DailySegment> SplitAtChargeBoundaries(List<LedgerDetail> dailyDetails)
+        {
+            if (dailyDetails.Count == 0)
+                return new List<DailySegment>();
+
+            // 時系列順（古い順）に並べ替え
+            var chronological = SortChronologically(dailyDetails);
+
+            var segments = new List<DailySegment>();
+            var currentUsageGroup = new List<LedgerDetail>();
+
+            foreach (var detail in chronological)
+            {
+                if (detail.IsCharge)
+                {
+                    // 溜まった利用グループを先に出力
+                    if (currentUsageGroup.Count > 0)
+                    {
+                        segments.Add(new DailySegment
+                        {
+                            IsCharge = false,
+                            Details = new List<LedgerDetail>(currentUsageGroup)
+                        });
+                        currentUsageGroup.Clear();
+                    }
+
+                    // チャージを出力
+                    segments.Add(new DailySegment
+                    {
+                        IsCharge = true,
+                        Details = new List<LedgerDetail> { detail }
+                    });
+                }
+                else
+                {
+                    currentUsageGroup.Add(detail);
+                }
+            }
+
+            // 残りの利用グループを出力
+            if (currentUsageGroup.Count > 0)
+            {
+                segments.Add(new DailySegment
+                {
+                    IsCharge = false,
+                    Details = new List<LedgerDetail>(currentUsageGroup)
+                });
+            }
+
+            return segments;
+        }
+
+        /// <summary>
+        /// 残高チェーンに基づいて詳細を時系列順（古い順）に並べ替える。
+        /// </summary>
+        /// <remarks>
+        /// LedgerOrderHelper.ReconstructChainと同じアルゴリズムで、
+        /// balance_before（処理前残高）を逆算してチェーンを辿る。
+        /// チェーン構築に失敗した場合はリスト逆順（ICカード履歴は新しい順→逆順で古い順）にフォールバック。
+        /// </remarks>
+        internal static List<LedgerDetail> SortChronologically(List<LedgerDetail> details)
+        {
+            if (details.Count <= 1)
+                return new List<LedgerDetail>(details);
+
+            // balance_before を計算:
+            // 利用（expense）: balance_before = Balance + Amount
+            // チャージ（income）: balance_before = Balance - Amount
+            var items = details
+                .Where(d => d.Balance.HasValue && d.Amount.HasValue)
+                .Select(d =>
+                {
+                    var balanceBefore = d.IsCharge
+                        ? d.Balance!.Value - d.Amount!.Value
+                        : d.Balance!.Value + d.Amount!.Value;
+                    return (Detail: d, BalanceBefore: balanceBefore);
+                })
+                .ToList();
+
+            // Balance/Amount情報が不十分な場合はリスト逆順にフォールバック
+            if (items.Count < details.Count)
+            {
+                var fallback = new List<LedgerDetail>(details);
+                fallback.Reverse();
+                return fallback;
+            }
+
+            // チェーン構築: balance_before が他のどのdetailの Balance にも一致しないものが先頭
+            var balanceSet = new HashSet<int>(items.Select(i => i.Detail.Balance!.Value));
+            var remaining = new List<(LedgerDetail Detail, int BalanceBefore)>(items);
+
+            var start = remaining.FirstOrDefault(r => !balanceSet.Contains(r.BalanceBefore));
+            if (start.Detail == null)
+            {
+                // チェーン構築失敗: フォールバック（逆順）
+                var fallback = new List<LedgerDetail>(details);
+                fallback.Reverse();
+                return fallback;
+            }
+
+            var ordered = new List<LedgerDetail> { start.Detail };
+            remaining.Remove(start);
+            var currentBalance = start.Detail.Balance!.Value;
+
+            while (remaining.Count > 0)
+            {
+                var next = remaining.FirstOrDefault(r => r.BalanceBefore == currentBalance);
+                if (next.Detail == null)
+                {
+                    // チェーン途切れ: 残りをBalance降順で追加
+                    ordered.AddRange(remaining.OrderByDescending(r => r.BalanceBefore).Select(r => r.Detail));
+                    break;
+                }
+
+                ordered.Add(next.Detail);
+                currentBalance = next.Detail.Balance!.Value;
+                remaining.Remove(next);
+            }
+
+            return ordered;
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -185,26 +185,68 @@ namespace ICCardManager.Services
                 var date = dateGroup.Key;
                 var dayItems = dateGroup.ToList();
 
-                // 利用（鉄道・バス）、チャージ、ポイント還元を分離
-                var usageItems = dayItems.Where(x => !x.Detail.IsCharge && !x.Detail.IsPointRedemption).ToList();
-                var chargeItems = dayItems.Where(x => x.Detail.IsCharge).ToList();
+                // ポイント還元を先に分離（ポイント還元は個別DailySummaryだがチャージ境界にはしない）
                 var pointRedemptionItems = dayItems.Where(x => x.Detail.IsPointRedemption).ToList();
+
+                // 残りの項目（利用+チャージ）を時系列順（古い順＝インデックス降順）にソート
+                var usageAndChargeItems = dayItems
+                    .Where(x => !x.Detail.IsPointRedemption)
+                    .OrderByDescending(x => x.Index)
+                    .ToList();
 
                 // 出力候補を作成（最古のインデックスと共に）
                 var summariesToAdd = new List<(int OldestIndex, DailySummary Summary)>();
 
-                // 利用がある場合は利用摘要を追加
-                if (usageItems.Count > 0)
+                // チャージ境界で利用グループを分割しながら摘要を生成
+                var currentUsageGroup = new List<(LedgerDetail Detail, int Index)>();
+
+                foreach (var item in usageAndChargeItems)
                 {
-                    // 古い順（インデックス降順）にソートして摘要生成
-                    var usageDetails = usageItems
-                        .OrderByDescending(x => x.Index)
-                        .Select(x => x.Detail)
-                        .ToList();
+                    if (item.Detail.IsCharge)
+                    {
+                        // 溜まった利用グループを先に出力
+                        if (currentUsageGroup.Count > 0)
+                        {
+                            var usageDetails = currentUsageGroup.Select(x => x.Detail).ToList();
+                            var usageSummary = GenerateUsageSummary(usageDetails);
+                            if (!string.IsNullOrEmpty(usageSummary))
+                            {
+                                var oldestIndex = currentUsageGroup.Max(x => x.Index);
+                                summariesToAdd.Add((oldestIndex, new DailySummary
+                                {
+                                    Date = date,
+                                    Summary = usageSummary,
+                                    IsCharge = false,
+                                    IsPointRedemption = false
+                                }));
+                            }
+                            currentUsageGroup.Clear();
+                        }
+
+                        // チャージを出力
+                        summariesToAdd.Add((item.Index, new DailySummary
+                        {
+                            Date = date,
+                            Summary = GetChargeSummary(_departmentType),
+                            IsCharge = true,
+                            IsPointRedemption = false
+                        }));
+                    }
+                    else
+                    {
+                        // 利用: グループに追加
+                        currentUsageGroup.Add(item);
+                    }
+                }
+
+                // 残りの利用グループを出力
+                if (currentUsageGroup.Count > 0)
+                {
+                    var usageDetails = currentUsageGroup.Select(x => x.Detail).ToList();
                     var usageSummary = GenerateUsageSummary(usageDetails);
                     if (!string.IsNullOrEmpty(usageSummary))
                     {
-                        var oldestIndex = usageItems.Max(x => x.Index);
+                        var oldestIndex = currentUsageGroup.Max(x => x.Index);
                         summariesToAdd.Add((oldestIndex, new DailySummary
                         {
                             Date = date,
@@ -213,19 +255,6 @@ namespace ICCardManager.Services
                             IsPointRedemption = false
                         }));
                     }
-                }
-
-                // チャージがある場合はチャージ摘要を追加
-                if (chargeItems.Count > 0)
-                {
-                    var oldestIndex = chargeItems.Max(x => x.Index);
-                    summariesToAdd.Add((oldestIndex, new DailySummary
-                    {
-                        Date = date,
-                        Summary = GetChargeSummary(_departmentType),
-                        IsCharge = true,
-                        IsPointRedemption = false
-                    }));
                 }
 
                 // ポイント還元がある場合はポイント還元摘要を追加

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
@@ -2652,4 +2652,264 @@ public class LendingServiceTests : IDisposable
     }
 
     #endregion
+
+    #region SplitAtChargeBoundaries テスト
+
+    [Fact]
+    public void SplitAtChargeBoundaries_NoCharge_ReturnsSingleUsageGroup()
+    {
+        // Arrange: 2つの利用のみ（チャージなし）
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 790, IsCharge = false },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 1000, IsCharge = false },
+        };
+
+        // Act
+        var segments = LendingService.SplitAtChargeBoundaries(details);
+
+        // Assert: 1つの利用グループ
+        segments.Should().HaveCount(1);
+        segments[0].IsCharge.Should().BeFalse();
+        segments[0].Details.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void SplitAtChargeBoundaries_ChargeBetweenTrips_ReturnsSplitGroups()
+    {
+        // Arrange: 利用→チャージ→利用（チャージが間に挟まる）
+        // 時系列順: 天神→博多(1000→790), チャージ(790→1790), 博多→天神(1790→1580)
+        // ICカード履歴は新しい順なので逆順で入力
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 1580, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 1790, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 790, IsCharge = false },
+        };
+
+        // Act
+        var segments = LendingService.SplitAtChargeBoundaries(details);
+
+        // Assert: 利用グループ1, チャージ, 利用グループ2
+        segments.Should().HaveCount(3);
+
+        segments[0].IsCharge.Should().BeFalse();
+        segments[0].Details.Should().HaveCount(1);
+        segments[0].Details[0].ExitStation.Should().Be("博多");  // 天神→博多（古い方）
+
+        segments[1].IsCharge.Should().BeTrue();
+        segments[1].Details.Should().HaveCount(1);
+
+        segments[2].IsCharge.Should().BeFalse();
+        segments[2].Details.Should().HaveCount(1);
+        segments[2].Details[0].ExitStation.Should().Be("天神");  // 博多→天神（新しい方）
+    }
+
+    [Fact]
+    public void SplitAtChargeBoundaries_ChargeAtStart_ReturnsChargeFirst()
+    {
+        // Arrange: チャージ→利用→利用
+        // 時系列順: チャージ(500→1500), 天神→博多(1500→1290), 博多→天神(1290→1080)
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 1080, IsCharge = false },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 1290, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 1500, IsCharge = true },
+        };
+
+        // Act
+        var segments = LendingService.SplitAtChargeBoundaries(details);
+
+        // Assert: チャージが先、利用グループが後（2件まとめて）
+        segments.Should().HaveCount(2);
+        segments[0].IsCharge.Should().BeTrue();
+        segments[1].IsCharge.Should().BeFalse();
+        segments[1].Details.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void SplitAtChargeBoundaries_ChargeAtEnd_ReturnsChargeAtEnd()
+    {
+        // Arrange: 利用→利用→チャージ
+        // 時系列順: 天神→博多(1500→1290), 博多→天神(1290→1080), チャージ(1080→2080)
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 2080, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 1080, IsCharge = false },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 1290, IsCharge = false },
+        };
+
+        // Act
+        var segments = LendingService.SplitAtChargeBoundaries(details);
+
+        // Assert: 利用グループが先、チャージが後
+        segments.Should().HaveCount(2);
+        segments[0].IsCharge.Should().BeFalse();
+        segments[0].Details.Should().HaveCount(2);
+        segments[1].IsCharge.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SplitAtChargeBoundaries_MultipleCharges_ReturnsMultipleGroups()
+    {
+        // Arrange: 利用→チャージ→利用→チャージ→利用
+        // 時系列順: trip1(2000→1790), charge1(1790→2790), trip2(2790→2580), charge2(2580→3580), trip3(3580→3370)
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "A", ExitStation = "B", Amount = 210, Balance = 3370, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 3580, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "C", ExitStation = "D", Amount = 210, Balance = 2580, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 2790, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "E", ExitStation = "F", Amount = 210, Balance = 1790, IsCharge = false },
+        };
+
+        // Act
+        var segments = LendingService.SplitAtChargeBoundaries(details);
+
+        // Assert: 5セグメント（利用, チャージ, 利用, チャージ, 利用）
+        segments.Should().HaveCount(5);
+        segments[0].IsCharge.Should().BeFalse();
+        segments[1].IsCharge.Should().BeTrue();
+        segments[2].IsCharge.Should().BeFalse();
+        segments[3].IsCharge.Should().BeTrue();
+        segments[4].IsCharge.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SplitAtChargeBoundaries_EmptyList_ReturnsEmpty()
+    {
+        var segments = LendingService.SplitAtChargeBoundaries(new List<LedgerDetail>());
+        segments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SortChronologically_ChargeBetweenTrips_ReturnsCorrectOrder()
+    {
+        // Arrange: ICカード履歴順（新しい順）: 博多→天神, チャージ, 天神→博多
+        // 期待する時系列順（古い順）: 天神→博多, チャージ, 博多→天神
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 1580, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 1790, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 790, IsCharge = false },
+        };
+
+        // Act
+        var sorted = LendingService.SortChronologically(details);
+
+        // Assert: 古い順（残高チェーンの開始点から辿る）
+        sorted.Should().HaveCount(3);
+        sorted[0].Balance.Should().Be(790);   // 天神→博多（最古）
+        sorted[1].Balance.Should().Be(1790);  // チャージ
+        sorted[2].Balance.Should().Be(1580);  // 博多→天神（最新）
+    }
+
+    [Fact]
+    public void SortChronologically_NoBalanceInfo_FallsBackToReverseOrder()
+    {
+        // Arrange: Balance情報なし
+        var details = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "A", ExitStation = "B", IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "C", ExitStation = "D", IsCharge = false },
+        };
+
+        // Act
+        var sorted = LendingService.SortChronologically(details);
+
+        // Assert: フォールバック（逆順=古い順）
+        sorted.Should().HaveCount(3);
+        sorted[0].EntryStation.Should().Be("C");  // 元のリストの最後=古い
+        sorted[1].IsCharge.Should().BeTrue();
+        sorted[2].EntryStation.Should().Be("A");  // 元のリストの最初=新しい
+    }
+
+    #endregion
+
+    #region チャージ境界分割 統合テスト
+
+    [Fact]
+    public async Task ReturnAsync_ChargeBetweenRoundTrip_CreatesSeparateLedgers()
+    {
+        // Arrange: 薬院→博多(-310,残高690), チャージ(+1000,残高1690), 博多→薬院(-310,残高1380)
+        var card = CreateTestCard(isLent: true);
+        var staff = CreateTestStaff();
+        var lentRecord = CreateTestLentRecord();
+
+        var usageDetails = new List<LedgerDetail>
+        {
+            // ICカード履歴は新しい順
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "薬院", Amount = 310, Balance = 1380, IsCharge = false },
+            new() { UseDate = DateTime.Today, Amount = 1000, Balance = 1690, IsCharge = true },
+            new() { UseDate = DateTime.Today, EntryStation = "薬院", ExitStation = "博多", Amount = 310, Balance = 690, IsCharge = false },
+        };
+
+        SetupReturnMocks(card, staff, lentRecord);
+
+        var createdLedgers = new List<Ledger>();
+        _ledgerRepositoryMock.Setup(x => x.InsertAsync(It.IsAny<Ledger>()))
+            .Callback<Ledger>(l => createdLedgers.Add(l))
+            .ReturnsAsync(1);
+
+        // Act
+        await _service.ReturnAsync(TestStaffIdm, TestCardIdm, usageDetails);
+
+        // Assert: 3つのLedgerが作成される（利用1 + チャージ + 利用2）
+        var nonLentLedgers = createdLedgers.Where(l => !l.IsLentRecord && l.Summary != "（貸出中）").ToList();
+        nonLentLedgers.Should().HaveCount(3);
+
+        // 時系列順: 利用(薬院→博多), チャージ, 利用(博多→薬院)
+        var usageLedger1 = nonLentLedgers.FirstOrDefault(l => l.Expense == 310 && l.Balance == 690);
+        var chargeLedger = nonLentLedgers.FirstOrDefault(l => l.Income > 0);
+        var usageLedger2 = nonLentLedgers.FirstOrDefault(l => l.Expense == 310 && l.Balance == 1380);
+
+        usageLedger1.Should().NotBeNull();
+        usageLedger1!.Summary.Should().Contain("薬院");
+        usageLedger1.Summary.Should().NotContain("往復");  // 往復にならないこと
+
+        chargeLedger.Should().NotBeNull();
+        chargeLedger!.Income.Should().Be(1000);
+        chargeLedger.Balance.Should().Be(1690);
+
+        usageLedger2.Should().NotBeNull();
+        usageLedger2!.Summary.Should().Contain("博多");
+        usageLedger2.Summary.Should().NotContain("往復");  // 往復にならないこと
+    }
+
+    [Fact]
+    public async Task ReturnAsync_NoChargeBetweenTrips_CreatesSingleUsageLedger()
+    {
+        // Arrange: チャージなしの往復（天神→博多, 博多→天神）
+        var card = CreateTestCard(isLent: true);
+        var staff = CreateTestStaff();
+        var lentRecord = CreateTestLentRecord();
+
+        var usageDetails = new List<LedgerDetail>
+        {
+            // ICカード履歴は新しい順
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 580, IsCharge = false },
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 790, IsCharge = false },
+        };
+
+        SetupReturnMocks(card, staff, lentRecord);
+
+        var createdLedgers = new List<Ledger>();
+        _ledgerRepositoryMock.Setup(x => x.InsertAsync(It.IsAny<Ledger>()))
+            .Callback<Ledger>(l => createdLedgers.Add(l))
+            .ReturnsAsync(1);
+
+        // Act
+        await _service.ReturnAsync(TestStaffIdm, TestCardIdm, usageDetails);
+
+        // Assert: 1つの利用Ledger（往復として統合）
+        var nonLentLedgers = createdLedgers.Where(l => !l.IsLentRecord && l.Summary != "（貸出中）").ToList();
+        var usageLedgers = nonLentLedgers.Where(l => l.Expense > 0).ToList();
+
+        usageLedgers.Should().HaveCount(1);
+        usageLedgers[0].Expense.Should().Be(420);  // 210 + 210
+        usageLedgers[0].Summary.Should().Contain("往復");  // 往復であること
+    }
+
+    #endregion
 }

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
@@ -1132,4 +1132,109 @@ public class SummaryGeneratorComprehensiveTests
     }
 
     #endregion
+
+    #region カテゴリ8: GenerateByDate - チャージ境界分割
+
+    /// <summary>
+    /// チャージが往復の間に挟まる場合、利用が分割されて往復にならないことを確認
+    /// </summary>
+    [Fact]
+    public void TC039_チャージが往復の間に挟まる場合_利用が分割される()
+    {
+        // Arrange: 薬院→博多, チャージ, 博多→薬院（同一日）
+        // ICカード履歴は新しい順
+        var details = new List<LedgerDetail>
+        {
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "博多", "薬院", 310, 1380),   // 帰り（新しい）
+            CreateCharge(new DateTime(2024, 12, 9), 1000, 1690),                        // チャージ
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "薬院", "博多", 310, 690),    // 行き（古い）
+        };
+
+        // Act
+        var results = _generator.GenerateByDate(details);
+
+        // Assert: 3件（利用1, チャージ, 利用2）- 往復にならない
+        results.Should().HaveCount(3);
+        OutputInputAndResult(details, results);
+
+        // 古い順: 利用（薬院→博多）→ チャージ → 利用（博多→薬院）
+        results[0].IsCharge.Should().BeFalse();
+        results[0].Summary.Should().Be("鉄道（薬院～博多）");
+
+        results[1].IsCharge.Should().BeTrue();
+
+        results[2].IsCharge.Should().BeFalse();
+        results[2].Summary.Should().Be("鉄道（博多～薬院）");
+    }
+
+    /// <summary>
+    /// チャージが利用の前にある場合（挟まっていない）、利用は従来通り統合されることを確認
+    /// </summary>
+    [Fact]
+    public void TC040_チャージが利用の前にある場合_利用は統合される()
+    {
+        // Arrange: チャージ→天神→博多→博多→天神（同一日）
+        // TC012の12/4と同じパターン
+        // ICカード履歴は新しい順
+        var details = new List<LedgerDetail>
+        {
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "博多", "天神", 210, 1580),  // 帰り（新しい）
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "天神", "博多", 210, 1790),  // 行き
+            CreateCharge(new DateTime(2024, 12, 9), 1000, 2000),                       // チャージ（古い）
+        };
+
+        // Act
+        var results = _generator.GenerateByDate(details);
+
+        // Assert: 2件（チャージ, 往復利用）
+        results.Should().HaveCount(2);
+        OutputInputAndResult(details, results);
+
+        results[0].IsCharge.Should().BeTrue();
+
+        results[1].IsCharge.Should().BeFalse();
+        results[1].Summary.Should().Be("鉄道（天神～博多 往復）");
+    }
+
+    /// <summary>
+    /// 複数日にまたがるケースでチャージ境界分割が正しく動作することを確認
+    /// </summary>
+    [Fact]
+    public void TC041_複数日_チャージ挟み込みのある日とない日の混在()
+    {
+        // Arrange: 12/8はチャージなし往復、12/9はチャージ挟み
+        var details = new List<LedgerDetail>
+        {
+            // 12/9: 博多→薬院(新), チャージ, 薬院→博多(古)
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "博多", "薬院", 310, 1380),
+            CreateCharge(new DateTime(2024, 12, 9), 1000, 1690),
+            CreateRailwayUsage(new DateTime(2024, 12, 9), "薬院", "博多", 310, 690),
+            // 12/8: 博多→天神(新), 天神→博多(古) - チャージなし
+            CreateRailwayUsage(new DateTime(2024, 12, 8), "博多", "天神", 210, 1000),
+            CreateRailwayUsage(new DateTime(2024, 12, 8), "天神", "博多", 210, 1210),
+        };
+
+        // Act
+        var results = _generator.GenerateByDate(details);
+
+        // Assert: 12/8は1件（往復）、12/9は3件（分割）
+        results.Should().HaveCount(4);
+        OutputInputAndResult(details, results);
+
+        // 12/8: 往復
+        results[0].Date.Should().Be(new DateTime(2024, 12, 8));
+        results[0].Summary.Should().Be("鉄道（天神～博多 往復）");
+
+        // 12/9: 分割
+        results[1].Date.Should().Be(new DateTime(2024, 12, 9));
+        results[1].Summary.Should().Be("鉄道（薬院～博多）");
+
+        results[2].Date.Should().Be(new DateTime(2024, 12, 9));
+        results[2].IsCharge.Should().BeTrue();
+
+        results[3].Date.Should().Be(new DateTime(2024, 12, 9));
+        results[3].Summary.Should().Be("鉄道（博多～薬院）");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- 同一日に「鉄道利用→チャージ→鉄道利用」の順で取引がある場合、全利用を1行に統合していたため残高チェーンが壊れていた問題を修正
- 残高チェーンを使って時系列順を復元し、チャージの位置で利用グループを分割するように変更
- チャージが挟まらない日は従来通り利用を統合（往復判定含む）

### 変更前の動作（不具合）

開始残高1,000円、薬院→博多(-310)、チャージ(+1,000)、博多→薬院(-310) の場合：

| 摘要 | 受入 | 払出 | 残額 |
|------|------|------|------|
| 役務費によりチャージ | 1,000 | - | 1,690 |
| 鉄道（薬院～博多 往復） | - | 620 | 1,380 |

→ 中間残高が実際のカード残高と一致しない（残高チェーン破綻）

### 変更後の動作

| 摘要 | 受入 | 払出 | 残額 |
|------|------|------|------|
| 鉄道（薬院～博多） | - | 310 | 690 |
| 役務費によりチャージ | 1,000 | - | 1,690 |
| 鉄道（博多～薬院） | - | 310 | 1,380 |

→ 残高チェーンが正しく維持される

### 主な変更内容

- `LendingService.SplitAtChargeBoundaries()`: 残高チェーンで時系列順を復元し、チャージ位置で利用を分割
- `LendingService.SortChronologically()`: 残高チェーンに基づく時系列ソート
- `LendingService.CreateUsageLedgersAsync()`: セグメント単位の処理にリファクタ
- `SummaryGenerator.GenerateByDate()`: チャージ境界での利用分割に対応
- Issue #837統合ロジック: 複数の既存利用Ledgerへの対応

## Test plan

- [x] `SplitAtChargeBoundaries` 単体テスト 6件（チャージなし/間/先頭/末尾/複数/空）
- [x] `SortChronologically` 単体テスト 2件（正常/フォールバック）
- [x] `ReturnAsync` 統合テスト 2件（チャージ挟み→3行分割/チャージなし→往復統合）
- [x] `SummaryGenerator` テスト 3件（チャージ挟み分割/チャージ前統合/複数日混在）
- [x] 既存テスト全1679件 回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)