### PR TITLE
refactor: 利用履歴詳細の表示順をrowid非依存にし構造的問題を解消

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/LedgerDetailChronologicalSorter.cs
+++ b/ICCardManager/src/ICCardManager/Common/LedgerDetailChronologicalSorter.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICCardManager.Models;
+
+namespace ICCardManager.Common
+{
+    /// <summary>
+    /// LedgerDetailを残高チェーンに基づいて時系列順（古い→新しい）にソートするユーティリティ。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ICカード利用履歴の表示順は、SQLiteのrowidではなく残高チェーンで決定する。
+    /// これにより、挿入順序に依存しない安定した時系列表示が可能になる。
+    /// </para>
+    /// <para>
+    /// アルゴリズム:
+    /// 各明細の「処理前残高 (balance_before)」を逆算し、
+    /// 前の明細のBalance == 次の明細のbalance_before となるチェーンを辿る。
+    /// </para>
+    /// <list type="bullet">
+    /// <item>利用: balance_before = Balance + Amount（利用前は残高が多い）</item>
+    /// <item>チャージ: balance_before = Balance - Amount（チャージ前は残高が少ない）</item>
+    /// </list>
+    /// </remarks>
+    internal static class LedgerDetailChronologicalSorter
+    {
+        /// <summary>
+        /// LedgerDetailを時系列順（古い→新しい）にソートする。
+        /// </summary>
+        /// <param name="details">ソート対象の明細リスト</param>
+        /// <param name="preserveOrderOnFailure">
+        /// チェーン構築失敗時の動作。
+        /// true: 入力順序を維持（DB読み取り時向け）。
+        /// false: リストを逆順にする（FeliCa入力向け、入力が新しい→古いの場合）。
+        /// </param>
+        /// <returns>時系列順にソートされた新しいリスト</returns>
+        internal static List<LedgerDetail> Sort(
+            IEnumerable<LedgerDetail> details, bool preserveOrderOnFailure = true)
+        {
+            var detailList = details.ToList();
+
+            if (detailList.Count <= 1)
+                return new List<LedgerDetail>(detailList);
+
+            // balance_before を計算:
+            // 利用（expense）: balance_before = Balance + Amount
+            // チャージ（income）: balance_before = Balance - Amount
+            var items = detailList
+                .Where(d => d.Balance.HasValue && d.Amount.HasValue)
+                .Select(d =>
+                {
+                    var balanceBefore = d.IsCharge
+                        ? d.Balance!.Value - d.Amount!.Value
+                        : d.Balance!.Value + d.Amount!.Value;
+                    return (Detail: d, BalanceBefore: balanceBefore);
+                })
+                .ToList();
+
+            // Balance/Amount情報が不十分な場合はフォールバック
+            if (items.Count < detailList.Count)
+            {
+                return Fallback(detailList, preserveOrderOnFailure);
+            }
+
+            // チェーン構築: balance_before が他のどのdetailの Balance にも一致しないものが先頭
+            var balanceSet = new HashSet<int>(items.Select(i => i.Detail.Balance!.Value));
+            var remaining = new List<(LedgerDetail Detail, int BalanceBefore)>(items);
+
+            var start = remaining.FirstOrDefault(r => !balanceSet.Contains(r.BalanceBefore));
+            if (start.Detail == null)
+            {
+                // チェーン構築失敗: フォールバック
+                return Fallback(detailList, preserveOrderOnFailure);
+            }
+
+            var ordered = new List<LedgerDetail> { start.Detail };
+            remaining.Remove(start);
+            var currentBalance = start.Detail.Balance!.Value;
+
+            while (remaining.Count > 0)
+            {
+                var next = remaining.FirstOrDefault(r => r.BalanceBefore == currentBalance);
+                if (next.Detail == null)
+                {
+                    // チェーン途切れ: 残りをBalance降順で追加
+                    ordered.AddRange(remaining.OrderByDescending(r => r.BalanceBefore).Select(r => r.Detail));
+                    break;
+                }
+
+                ordered.Add(next.Detail);
+                currentBalance = next.Detail.Balance!.Value;
+                remaining.Remove(next);
+            }
+
+            return ordered;
+        }
+
+        /// <summary>
+        /// チェーン構築失敗時のフォールバック処理。
+        /// </summary>
+        private static List<LedgerDetail> Fallback(
+            List<LedgerDetail> detailList, bool preserveOrderOnFailure)
+        {
+            if (preserveOrderOnFailure)
+            {
+                // DB読み取り時: 既存のSQL ORDER BY結果を維持
+                return new List<LedgerDetail>(detailList);
+            }
+
+            // FeliCa入力時: 新しい→古い順を逆転して古い→新しい順に
+            var fallback = new List<LedgerDetail>(detailList);
+            fallback.Reverse();
+            return fallback;
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -468,6 +468,12 @@ LIMIT @pageSize OFFSET @offset";
         /// <summary>
         /// 利用履歴詳細を取得
         /// </summary>
+        /// <remarks>
+        /// 残高チェーンで時系列順（古い→新しい）にソートして返す。
+        /// SQLのORDER BYはフォールバック用の初期順序として使用し、
+        /// 読み取り後に残高チェーンで正しい時系列順を決定する。
+        /// これにより、挿入順序（rowid）に依存しない安定した表示順が保証される。
+        /// </remarks>
         private async Task<IEnumerable<LedgerDetail>> GetDetailsAsync(int ledgerId)
         {
             var connection = _dbContext.GetConnection();
@@ -476,8 +482,7 @@ LIMIT @pageSize OFFSET @offset";
             using var command = connection.CreateCommand();
             // Issue #393: 履歴詳細を古い順（時系列順）で表示
             // Issue #478: 同一日ではチャージ（is_charge=1）を利用より先に表示
-            // Issue #876: rowid DESCで古い順に
-            // （FeliCaカードリーダーは新しい順に履歴を返すため、小さいrowidほど新しい＝後に利用）
+            // SQL ORDER BYはフォールバック用（残高チェーン構築失敗時に使用される）
             command.CommandText = @"SELECT ledger_id, use_date, entry_station, exit_station,
        bus_stops, amount, balance, is_charge, is_point_redemption, is_bus, group_id, rowid
 FROM ledger_detail
@@ -492,7 +497,9 @@ ORDER BY use_date ASC, is_charge DESC, is_point_redemption DESC, rowid DESC";
                 details.Add(MapToLedgerDetail(reader));
             }
 
-            return details;
+            // 残高チェーンで時系列順にソート（挿入順序に依存しない）
+            // フォールバック時はSQL ORDER BY結果（上記）を維持する
+            return Common.LedgerDetailChronologicalSorter.Sort(details, preserveOrderOnFailure: true);
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -1083,70 +1083,12 @@ namespace ICCardManager.Services
         /// 残高チェーンに基づいて詳細を時系列順（古い順）に並べ替える。
         /// </summary>
         /// <remarks>
-        /// LedgerOrderHelper.ReconstructChainと同じアルゴリズムで、
-        /// balance_before（処理前残高）を逆算してチェーンを辿る。
-        /// チェーン構築に失敗した場合はリスト逆順（ICカード履歴は新しい順→逆順で古い順）にフォールバック。
+        /// LedgerDetailChronologicalSorterに委譲。
+        /// FeliCa入力（新しい→古い）を想定し、チェーン構築失敗時はリスト逆順にフォールバック。
         /// </remarks>
         internal static List<LedgerDetail> SortChronologically(List<LedgerDetail> details)
         {
-            if (details.Count <= 1)
-                return new List<LedgerDetail>(details);
-
-            // balance_before を計算:
-            // 利用（expense）: balance_before = Balance + Amount
-            // チャージ（income）: balance_before = Balance - Amount
-            var items = details
-                .Where(d => d.Balance.HasValue && d.Amount.HasValue)
-                .Select(d =>
-                {
-                    var balanceBefore = d.IsCharge
-                        ? d.Balance!.Value - d.Amount!.Value
-                        : d.Balance!.Value + d.Amount!.Value;
-                    return (Detail: d, BalanceBefore: balanceBefore);
-                })
-                .ToList();
-
-            // Balance/Amount情報が不十分な場合はリスト逆順にフォールバック
-            if (items.Count < details.Count)
-            {
-                var fallback = new List<LedgerDetail>(details);
-                fallback.Reverse();
-                return fallback;
-            }
-
-            // チェーン構築: balance_before が他のどのdetailの Balance にも一致しないものが先頭
-            var balanceSet = new HashSet<int>(items.Select(i => i.Detail.Balance!.Value));
-            var remaining = new List<(LedgerDetail Detail, int BalanceBefore)>(items);
-
-            var start = remaining.FirstOrDefault(r => !balanceSet.Contains(r.BalanceBefore));
-            if (start.Detail == null)
-            {
-                // チェーン構築失敗: フォールバック（逆順）
-                var fallback = new List<LedgerDetail>(details);
-                fallback.Reverse();
-                return fallback;
-            }
-
-            var ordered = new List<LedgerDetail> { start.Detail };
-            remaining.Remove(start);
-            var currentBalance = start.Detail.Balance!.Value;
-
-            while (remaining.Count > 0)
-            {
-                var next = remaining.FirstOrDefault(r => r.BalanceBefore == currentBalance);
-                if (next.Detail == null)
-                {
-                    // チェーン途切れ: 残りをBalance降順で追加
-                    ordered.AddRange(remaining.OrderByDescending(r => r.BalanceBefore).Select(r => r.Detail));
-                    break;
-                }
-
-                ordered.Add(next.Detail);
-                currentBalance = next.Detail.Balance!.Value;
-                remaining.Remove(next);
-            }
-
-            return ordered;
+            return Common.LedgerDetailChronologicalSorter.Sort(details, preserveOrderOnFailure: false);
         }
 
         /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Common/LedgerDetailChronologicalSorterTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/LedgerDetailChronologicalSorterTests.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using ICCardManager.Common;
+using ICCardManager.Models;
+using Xunit;
+
+namespace ICCardManager.Tests.Common;
+
+public class LedgerDetailChronologicalSorterTests
+{
+    #region 基本ケース
+
+    [Fact]
+    public void Sort_EmptyList_ReturnsEmptyList()
+    {
+        var result = LedgerDetailChronologicalSorter.Sort(new List<LedgerDetail>());
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Sort_SingleItem_ReturnsSameItem()
+    {
+        var detail = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = 790
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(new[] { detail });
+
+        result.Should().HaveCount(1);
+        result[0].Should().BeSameAs(detail);
+    }
+
+    [Fact]
+    public void Sort_TwoTrips_ReturnsChronologicalOrder()
+    {
+        // 時系列: 天神→博多(1000→790), 博多→天神(790→580)
+        // 入力: 新しい順（FeliCa順）
+        var newer = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 210,
+            Balance = 580
+        };
+        var older = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = 790
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(new[] { newer, older });
+
+        result.Should().HaveCount(2);
+        result[0].Balance.Should().Be(790);  // 古い方（天神→博多）が先
+        result[1].Balance.Should().Be(580);  // 新しい方（博多→天神）が後
+    }
+
+    [Fact]
+    public void Sort_TwoTrips_AlreadyChronological_ReturnsSameOrder()
+    {
+        // 入力が既に古い順の場合でも正しく動作する
+        var older = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = 790
+        };
+        var newer = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 210,
+            Balance = 580
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(new[] { older, newer });
+
+        result.Should().HaveCount(2);
+        result[0].Balance.Should().Be(790);  // 古い方が先
+        result[1].Balance.Should().Be(580);  // 新しい方が後
+    }
+
+    #endregion
+
+    #region チャージが利用の間に挟まるケース
+
+    [Fact]
+    public void Sort_ChargeBetweenTrips_ReturnsCorrectOrder()
+    {
+        // 時系列: 天神→博多(1000→790), チャージ(790→1790), 博多→天神(1790→1580)
+        // 入力: 新しい順（FeliCa順）
+        var trip2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 210,
+            Balance = 1580
+        };
+        var charge = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            Amount = 1000,
+            Balance = 1790,
+            IsCharge = true
+        };
+        var trip1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = 790
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(new[] { trip2, charge, trip1 });
+
+        result.Should().HaveCount(3);
+        result[0].Balance.Should().Be(790);   // trip1: 天神→博多（最古）
+        result[1].Balance.Should().Be(1790);  // charge
+        result[2].Balance.Should().Be(1580);  // trip2: 博多→天神（最新）
+    }
+
+    [Fact]
+    public void Sort_ChargeAtStart_ReturnsChargeFirst()
+    {
+        // 時系列: チャージ(500→1500), 天神→博多(1500→1290)
+        var trip = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = 1290
+        };
+        var charge = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            Amount = 1000,
+            Balance = 1500,
+            IsCharge = true
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(new[] { trip, charge });
+
+        result.Should().HaveCount(2);
+        result[0].Balance.Should().Be(1500);  // チャージが先
+        result[1].Balance.Should().Be(1290);  // 利用が後
+    }
+
+    #endregion
+
+    #region フォールバック
+
+    [Fact]
+    public void Sort_MissingBalance_PreservesOrder_WhenPreserveOrderOnFailureIsTrue()
+    {
+        var detail1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = null  // 残高情報なし
+        };
+        var detail2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 210,
+            Balance = 580
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(
+            new[] { detail1, detail2 }, preserveOrderOnFailure: true);
+
+        // 入力順序が維持される
+        result.Should().HaveCount(2);
+        result[0].Should().BeSameAs(detail1);
+        result[1].Should().BeSameAs(detail2);
+    }
+
+    [Fact]
+    public void Sort_MissingBalance_ReversesOrder_WhenPreserveOrderOnFailureIsFalse()
+    {
+        var detail1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神",
+            ExitStation = "博多",
+            Amount = 210,
+            Balance = null  // 残高情報なし
+        };
+        var detail2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 210,
+            Balance = 580
+        };
+
+        var result = LedgerDetailChronologicalSorter.Sort(
+            new[] { detail1, detail2 }, preserveOrderOnFailure: false);
+
+        // FeliCa入力を想定して逆順
+        result.Should().HaveCount(2);
+        result[0].EntryStation.Should().Be("博多");
+        result[1].EntryStation.Should().Be("天神");
+    }
+
+    [Fact]
+    public void Sort_CircularChain_PreservesOrder()
+    {
+        // 残高が循環するケース（異常データ）
+        // detail1: balance_before = 500 + 210 = 710, balance = 500
+        // detail2: balance_before = 710 + 210 = 920, balance = 710
+        // detail1のbalance_before(710) == detail2のbalance(710) → 循環
+        // ただしチェーン先頭の検出で解決される可能性もある
+        var detail1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "A",
+            ExitStation = "B",
+            Amount = 210,
+            Balance = 500
+        };
+        var detail2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "B",
+            ExitStation = "A",
+            Amount = 210,
+            Balance = 710
+        };
+
+        // エラーが発生しないこと
+        var result = LedgerDetailChronologicalSorter.Sort(
+            new[] { detail1, detail2 }, preserveOrderOnFailure: true);
+
+        result.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region 挿入順序に依存しないことの検証
+
+    [Fact]
+    public void Sort_SameResult_RegardlessOfInputOrder()
+    {
+        // 3件の利用を異なる順序で入力しても、同じ時系列順になること
+        // 時系列: A→B(1000→790), B→C(790→580), C→D(580→370)
+        var trip1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "A",
+            ExitStation = "B",
+            Amount = 210,
+            Balance = 790
+        };
+        var trip2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "B",
+            ExitStation = "C",
+            Amount = 210,
+            Balance = 580
+        };
+        var trip3 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "C",
+            ExitStation = "D",
+            Amount = 210,
+            Balance = 370
+        };
+
+        // パターン1: FeliCa順（新しい→古い）
+        var result1 = LedgerDetailChronologicalSorter.Sort(new[] { trip3, trip2, trip1 });
+        // パターン2: 古い順
+        var result2 = LedgerDetailChronologicalSorter.Sort(new[] { trip1, trip2, trip3 });
+        // パターン3: ランダム順
+        var result3 = LedgerDetailChronologicalSorter.Sort(new[] { trip2, trip3, trip1 });
+
+        // すべて同じ時系列順になる
+        foreach (var result in new[] { result1, result2, result3 })
+        {
+            result.Should().HaveCount(3);
+            result[0].Balance.Should().Be(790);  // A→B（最古）
+            result[1].Balance.Should().Be(580);  // B→C
+            result[2].Balance.Should().Be(370);  // C→D（最新）
+        }
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerDetailOrderingIntegrationTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Repositories/LedgerDetailOrderingIntegrationTests.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
+using ICCardManager.Models;
+using ICCardManager.Tests.Data;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Repositories;
+
+/// <summary>
+/// 利用履歴詳細の表示順が挿入順序に依存しないことを検証する統合テスト。
+/// 実SQLiteデータベースを使用し、挿入→読み取りのエンドツーエンドを検証する。
+/// </summary>
+/// <remarks>
+/// このテストクラスの目的:
+/// 過去に表示順の問題が繰り返し発生した根本原因は、SQLiteのrowidに暗黙的に依存していたこと。
+/// 残高チェーンソートの導入により、挿入順序に関係なく常に正しい時系列順で表示されることを保証する。
+/// </remarks>
+public class LedgerDetailOrderingIntegrationTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly LedgerRepository _repository;
+    private readonly CardRepository _cardRepository;
+    private readonly StaffRepository _staffRepository;
+
+    private const string TestCardIdm = "0102030405060708";
+    private const string TestStaffIdm = "STAFF00000000001";
+
+    public LedgerDetailOrderingIntegrationTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+
+        var cacheServiceMock = new Mock<ICacheService>();
+        cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<IcCard>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<IcCard>>> factory, TimeSpan expiration) => factory());
+        cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<Staff>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<Staff>>> factory, TimeSpan expiration) => factory());
+
+        _repository = new LedgerRepository(_dbContext);
+        _cardRepository = new CardRepository(_dbContext, cacheServiceMock.Object, Options.Create(new CacheOptions()));
+        _staffRepository = new StaffRepository(_dbContext, cacheServiceMock.Object, Options.Create(new CacheOptions()));
+
+        SetupTestData().Wait();
+    }
+
+    private async Task SetupTestData()
+    {
+        await _staffRepository.InsertAsync(new Staff
+        {
+            StaffIdm = TestStaffIdm,
+            Name = "テスト職員",
+            IsDeleted = false
+        });
+        await _cardRepository.InsertAsync(new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "H001"
+        });
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    private async Task<int> CreateTestLedger(string summary, int expense = 0, int income = 0)
+    {
+        var ledger = new Ledger
+        {
+            CardIdm = TestCardIdm,
+            Date = DateTime.Today,
+            Summary = summary,
+            Income = income,
+            Expense = expense,
+            Balance = 10000 - expense + income,
+            IsLentRecord = false
+        };
+        return await _repository.InsertAsync(ledger);
+    }
+
+    #region 挿入順序に依存しない表示順の検証
+
+    /// <summary>
+    /// FeliCa順（新しい→古い）で挿入しても、古い順で取得される（従来パターン）
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_InsertedInFeliCaOrder_ReturnsChronologicalOrder()
+    {
+        // Arrange: FeliCa順（新しい→古い）で挿入
+        // 時系列: 天神→博多(1000→790), 博多→天神(790→580)
+        var ledgerId = await CreateTestLedger("往復", expense: 420);
+
+        var newerDetail = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多", ExitStation = "天神",
+            Amount = 210, Balance = 580
+        };
+        var olderDetail = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神", ExitStation = "博多",
+            Amount = 210, Balance = 790
+        };
+
+        // 新しい方を先に挿入（FeliCa順）
+        await _repository.InsertDetailsAsync(ledgerId, new[] { newerDetail, olderDetail });
+
+        // Act
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: 古い順（時系列順）で返されること
+        result!.Details.Should().HaveCount(2);
+        result.Details[0].EntryStation.Should().Be("天神");    // 古い方が先
+        result.Details[0].Balance.Should().Be(790);
+        result.Details[1].EntryStation.Should().Be("博多");    // 新しい方が後
+        result.Details[1].Balance.Should().Be(580);
+    }
+
+    /// <summary>
+    /// 時系列順（古い→新しい）で挿入しても、古い順で取得される
+    /// （c2c4f6aで発生したパターン）
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_InsertedInChronologicalOrder_ReturnsChronologicalOrder()
+    {
+        // Arrange: 時系列順（古い→新しい）で挿入
+        var ledgerId = await CreateTestLedger("往復", expense: 420);
+
+        var olderDetail = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神", ExitStation = "博多",
+            Amount = 210, Balance = 790
+        };
+        var newerDetail = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多", ExitStation = "天神",
+            Amount = 210, Balance = 580
+        };
+
+        // 古い方を先に挿入（時系列順＝FeliCaの逆）
+        await _repository.InsertDetailsAsync(ledgerId, new[] { olderDetail, newerDetail });
+
+        // Act
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: 挿入順序に関係なく、古い順で返されること
+        result!.Details.Should().HaveCount(2);
+        result.Details[0].EntryStation.Should().Be("天神");    // 古い方が先
+        result.Details[0].Balance.Should().Be(790);
+        result.Details[1].EntryStation.Should().Be("博多");    // 新しい方が後
+        result.Details[1].Balance.Should().Be(580);
+    }
+
+    /// <summary>
+    /// ランダム順で挿入しても、古い順で取得される
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_InsertedInRandomOrder_ReturnsChronologicalOrder()
+    {
+        // Arrange: 3件をランダム順で挿入
+        // 時系列: A→B(1000→790), B→C(790→580), C→D(580→370)
+        var ledgerId = await CreateTestLedger("3区間", expense: 630);
+
+        var trip2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "B", ExitStation = "C",
+            Amount = 210, Balance = 580
+        };
+        var trip3 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "C", ExitStation = "D",
+            Amount = 210, Balance = 370
+        };
+        var trip1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "A", ExitStation = "B",
+            Amount = 210, Balance = 790
+        };
+
+        // ランダム順で挿入: trip2, trip3, trip1
+        await _repository.InsertDetailsAsync(ledgerId, new[] { trip2, trip3, trip1 });
+
+        // Act
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: 挿入順序に関係なく、古い順で返されること
+        result!.Details.Should().HaveCount(3);
+        result.Details[0].EntryStation.Should().Be("A");
+        result.Details[0].Balance.Should().Be(790);
+        result.Details[1].EntryStation.Should().Be("B");
+        result.Details[1].Balance.Should().Be(580);
+        result.Details[2].EntryStation.Should().Be("C");
+        result.Details[2].Balance.Should().Be(370);
+    }
+
+    #endregion
+
+    #region チャージが利用の間に挟まるケース
+
+    /// <summary>
+    /// チャージが利用の間に挟まる場合、正しい時系列順で取得される
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_ChargeBetweenTrips_ReturnsCorrectOrder()
+    {
+        // Arrange: チャージが利用の間に挟まるケース
+        // 時系列: 天神→博多(1000→790), チャージ(790→1790), 博多→天神(1790→1580)
+        var ledgerId = await CreateTestLedger("利用+チャージ", expense: 420, income: 1000);
+
+        // 意図的にランダムな順序で挿入
+        var charge = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            Amount = 1000, Balance = 1790,
+            IsCharge = true
+        };
+        var trip1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神", ExitStation = "博多",
+            Amount = 210, Balance = 790
+        };
+        var trip2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多", ExitStation = "天神",
+            Amount = 210, Balance = 1580
+        };
+
+        await _repository.InsertDetailsAsync(ledgerId, new[] { charge, trip2, trip1 });
+
+        // Act
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: 時系列順（古い→新しい）
+        result!.Details.Should().HaveCount(3);
+        result.Details[0].Balance.Should().Be(790);   // trip1: 天神→博多
+        result.Details[1].Balance.Should().Be(1790);  // チャージ
+        result.Details[2].Balance.Should().Be(1580);  // trip2: 博多→天神
+    }
+
+    #endregion
+
+    #region ReplaceDetailsAsyncでの順序
+
+    /// <summary>
+    /// ReplaceDetailsAsync（DELETE+INSERT）後も正しい時系列順で取得される
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_AfterReplaceDetails_ReturnsChronologicalOrder()
+    {
+        // Arrange: まずFeliCa順で挿入
+        var ledgerId = await CreateTestLedger("往復", expense: 420);
+
+        var detail1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "博多", ExitStation = "天神",
+            Amount = 210, Balance = 580
+        };
+        var detail2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            EntryStation = "天神", ExitStation = "博多",
+            Amount = 210, Balance = 790
+        };
+        await _repository.InsertDetailsAsync(ledgerId, new[] { detail1, detail2 });
+
+        // Act: ReplaceDetailsAsync で逆順に再挿入（rowidが再採番される）
+        var newDetails = new List<LedgerDetail>
+        {
+            new() { UseDate = DateTime.Today, EntryStation = "天神", ExitStation = "博多", Amount = 210, Balance = 790 },
+            new() { UseDate = DateTime.Today, EntryStation = "博多", ExitStation = "天神", Amount = 210, Balance = 580 },
+        };
+        await _repository.ReplaceDetailsAsync(ledgerId, newDetails);
+
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: ReplaceDetailsAsync後も正しい時系列順
+        result!.Details.Should().HaveCount(2);
+        result.Details[0].Balance.Should().Be(790);  // 古い方が先
+        result.Details[1].Balance.Should().Be(580);  // 新しい方が後
+    }
+
+    #endregion
+
+    #region フォールバック
+
+    /// <summary>
+    /// 残高情報がない場合、SQLのORDER BY結果が維持される
+    /// </summary>
+    [Fact]
+    public async Task GetDetails_WithoutBalanceInfo_FallsBackToSqlOrder()
+    {
+        // Arrange: 残高情報なしの明細を挿入
+        var ledgerId = await CreateTestLedger("バス利用", expense: 400);
+
+        var detail1 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            BusStops = "バス停A",
+            Amount = 200,
+            Balance = null,  // 残高なし
+            IsBus = true
+        };
+        var detail2 = new LedgerDetail
+        {
+            UseDate = DateTime.Today,
+            BusStops = "バス停B",
+            Amount = 200,
+            Balance = null,  // 残高なし
+            IsBus = true
+        };
+        await _repository.InsertDetailsAsync(ledgerId, new[] { detail1, detail2 });
+
+        // Act
+        var result = await _repository.GetByIdAsync(ledgerId);
+
+        // Assert: エラーなく取得でき、2件返されること（順序は不定だが例外が出ないこと）
+        result!.Details.Should().HaveCount(2);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- 利用履歴詳細の表示順が繰り返し壊れる根本原因は **SQLiteのrowidに暗黙的に依存**していたこと（過去11回の修正歴）
- `LedgerDetailChronologicalSorter`: 残高チェーンで時系列順を決定する共通ユーティリティを新設
- `GetDetailsAsync`: 読み取り後に残高チェーンソートを適用し、**挿入順序に依存しない安定した表示順**を保証
- `LendingService.SortChronologically`: 共通ユーティリティに委譲して重複ロジックを解消
- 既存の `.Reverse()` は防御的にそのまま残す

## Test plan

- [x] 単体テスト: `LedgerDetailChronologicalSorterTests`（10件）— ソートユーティリティの各ケース
- [x] 統合テスト: `LedgerDetailOrderingIntegrationTests`（6件）— 実SQLiteで挿入順序に依存しないことを検証
  - FeliCa順 / 時系列順 / ランダム順での挿入 → すべて古い順で取得
  - チャージ挟み込み、ReplaceDetailsAsync後の順序
- [x] 既存テスト全1697件パス
- [ ] 実機テスト: 利用履歴詳細画面で古い方が上、新しい方が下に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)