### PR TITLE
fix: 新規カード登録時のデフォルトカード種別をnimocaに修正

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -180,7 +180,7 @@ namespace ICCardManager.ViewModels
             IsEditing = true;
             IsNewCard = true;
             EditCardIdm = string.Empty;
-            EditCardType = "はやかけん";
+            EditCardType = "nimoca";
             EditCardNumber = string.Empty;
             EditNote = string.Empty;
             StatusMessage = "カードをタッチするとIDmを読み取ります";

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -176,7 +176,7 @@ public class CardManageViewModelTests
         _viewModel.IsWaitingForCard.Should().BeTrue();
         _viewModel.SelectedCard.Should().BeNull();
         _viewModel.EditCardIdm.Should().BeEmpty();
-        _viewModel.EditCardType.Should().Be("はやかけん");
+        _viewModel.EditCardType.Should().Be("nimoca");
         _viewModel.EditCardNumber.Should().BeEmpty();
         _viewModel.EditNote.Should().BeEmpty();
         _viewModel.StatusMessage.Should().Contain("タッチ");


### PR DESCRIPTION
## Summary
- `StartNewCard()`のデフォルトカード種別を「はやかけん」から「nimoca」に変更
- カードタッチ時のデフォルト（nimoca）と初期表示を統一

## 原因
`StartNewCard()`（183行目）で`EditCardType = "はやかけん"`と初期化していたが、カードタッチ後の処理（265行目, 829行目）では`EditCardType = "nimoca"`に設定されるため、表示が不一致だった。

## Test plan
- [x] 既存テスト `StartNewCard_ShouldSetEditingModeCorrectly` のアサーションを`nimoca`に更新済み
- [x] 全1681テスト合格
- [ ] カード管理画面で「新規登録」ボタンを押した際、カード種別が最初から「nimoca」と表示されることを確認

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)