### PR TITLE
fix: アンインストーラーのレジストリキー更新バグを修正

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -190,7 +190,9 @@ begin
       RenameFile(OldDat, NewDat);
 
     // レジストリのUninstallStringを更新
-    UninstallKey := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{#SetupSetting("AppId")}_is1';
+    // 注: SetupSetting("AppId") は "{{GUID}" を返す（Inno Setup の記法で {{ は { のエスケープ）
+    // Pascal Script ではそのまま展開されるため、StringChange で {{ → { に変換が必要
+    UninstallKey := 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{#StringChange(SetupSetting("AppId"), "{{", "{")}_is1';
     if RegKeyExists(HKLM, UninstallKey) then
     begin
       RegWriteStringValue(HKLM, UninstallKey, 'UninstallString', '"' + NewExe + '"');


### PR DESCRIPTION
## Summary
- 「設定 → アプリ → インストールされているアプリ」からアンインストールしようとすると `unins000.exe が見つかりません` エラーが発生する問題を修正
- 原因: `SetupSetting("AppId")` が `{{GUID}` 形式（Inno Setup のエスケープ記法）を返すため、レジストリキーのパスに二重ブレースが含まれ、実際のキーとマッチしなかった
- `StringChange` プリプロセッサ関数で `{{` → `{` に変換することで正しいキーを参照するよう修正

## Test plan
- [ ] 修正版インストーラーでインストール後、`regedit` で `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{F6CAE9C5-...}_is1` の `UninstallString` が `Uninstall_ICCardManager.exe` を指していることを確認
- [ ] 「設定 → アプリ」からアンインストールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)