### PR TITLE
fix: 利用履歴画面の受入・払出列から太字を除去

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/HistoryDialog.xaml
@@ -192,7 +192,6 @@
                         <Style TargetType="TextBlock">
                             <Setter Property="HorizontalAlignment" Value="Right"/>
                             <Setter Property="Foreground" Value="{DynamicResource SuccessActionBrush}"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
@@ -203,7 +202,6 @@
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
                         </Style>
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -427,7 +427,6 @@
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                                            <Setter Property="FontWeight" Value="Bold"/>
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>
@@ -438,7 +437,6 @@
                                     <DataGridTextColumn.ElementStyle>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="HorizontalAlignment" Value="Right"/>
-                                            <Setter Property="FontWeight" Value="Bold"/>
                                         </Style>
                                     </DataGridTextColumn.ElementStyle>
                                 </DataGridTextColumn>


### PR DESCRIPTION
## Summary
- 利用履歴画面で「受入」「払出」列が太字（Bold）だったが「残高」列は通常フォントだったため不統一だった
- 受入・払出列の `FontWeight="Bold"` を除去し、3列とも通常フォントに統一
- MainWindow と HistoryDialog の両方を修正

Closes #901

## Test plan
- [x] メイン画面の利用履歴DataGridで、受入・払出・残高の3列がすべて同じフォントウェイト（通常）で表示されること
- [x] 利用履歴ダイアログ（カードをダブルクリックで開く）でも同様に3列が通常フォントで表示されること
- [ ] 受入列の緑色（SuccessActionBrush）の表示は維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)