### PR TITLE
fix: データインポート時のファイルロックエラーを回避

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -2084,10 +2084,12 @@ namespace ICCardManager.Services
         /// <summary>
         /// CSVファイルを読み込み（UTF-8 BOM対応）
         /// </summary>
-        private static async Task<List<string>> ReadCsvFileAsync(string filePath)
+        internal static async Task<List<string>> ReadCsvFileAsync(string filePath)
         {
             // UTF-8 with BOMに対応
-            using var reader = new StreamReader(filePath, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            // FileShare.ReadWrite で開くことで、他プロセス（Excel等）がファイルを使用中でも読み込み可能にする
+            var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fileStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
             var lines = new List<string>();
 
             while (!reader.EndOfStream)

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -1360,4 +1360,57 @@ FEDCBA9876543210,鈴木花子,002,テスト2";
     }
 
     #endregion
+
+    #region ReadCsvFileAsync - ファイル共有読み取りテスト
+
+    [Fact]
+    public async Task ReadCsvFileAsync_他プロセスが書き込みロック中でも読み取りできること()
+    {
+        // Arrange: CSVファイルを作成し、書き込みロックを保持したまま読み取りを試みる
+        var filePath = Path.Combine(_testDirectory, "locked_file.csv");
+        File.WriteAllText(filePath, "ヘッダー1,ヘッダー2\nデータ1,データ2\n", Encoding.UTF8);
+
+        // 他プロセスが書き込みモードで開いている状態をシミュレート
+        using var lockStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+        // Act: ロック中のファイルを読み取り
+        var lines = await CsvImportService.ReadCsvFileAsync(filePath);
+
+        // Assert
+        lines.Should().HaveCount(2);
+        lines[0].Should().Be("ヘッダー1,ヘッダー2");
+        lines[1].Should().Be("データ1,データ2");
+    }
+
+    [Fact]
+    public async Task ReadCsvFileAsync_UTF8_BOM付きファイルを正しく読み取れること()
+    {
+        // Arrange
+        var filePath = Path.Combine(_testDirectory, "bom_file.csv");
+        var utf8Bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        File.WriteAllText(filePath, "名前,値\nテスト,123\n", utf8Bom);
+
+        // Act
+        var lines = await CsvImportService.ReadCsvFileAsync(filePath);
+
+        // Assert
+        lines.Should().HaveCount(2);
+        lines[0].Should().Be("名前,値");
+    }
+
+    [Fact]
+    public async Task ReadCsvFileAsync_空ファイルの場合は空リストを返すこと()
+    {
+        // Arrange
+        var filePath = Path.Combine(_testDirectory, "empty_file.csv");
+        File.WriteAllText(filePath, "", Encoding.UTF8);
+
+        // Act
+        var lines = await CsvImportService.ReadCsvFileAsync(filePath);
+
+        // Assert
+        lines.Should().BeEmpty();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- CSVインポート時に他プロセス（Excel等）がファイルを使用中の場合、アクセスエラーになっていた問題を修正
- `StreamReader(filePath, ...)` が内部で `FileShare.Read` を使うため、書き込みロック中のファイルにアクセスできなかった
- `FileStream` を `FileShare.ReadWrite` で明示的に開くことで、他プロセスが使用中でも読み取り可能にした
- `ReadCsvFileAsync` を `internal static` に変更してテスト可能にし、3件の単体テストを追加

Closes #902

## Test plan
- [x] 単体テスト: 書き込みロック中のファイルを読み取れること
- [x] 単体テスト: UTF-8 BOM付きファイルを正しく読み取れること
- [x] 単体テスト: 空ファイルの場合は空リストを返すこと
- [x] 手動テスト: ExcelでCSVファイルを開いた状態で、そのファイルをデータインポートで読み込めること

🤖 Generated with [Claude Code](https://claude.com/claude-code)