### PR TITLE
fix: 利用履歴詳細インポートプレビューの列ヘッダーを動的表示 (#905)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -1654,6 +1654,8 @@ namespace ICCardManager.Services
             var detailsByLedgerId = new Dictionary<int, List<(int LineNumber, LedgerDetail Detail)>>();
             // 既存の詳細をキャッシュ（比較用）
             var existingDetailsByLedgerId = new Dictionary<int, List<LedgerDetail>>();
+            // ledger_idからカードIDmへのマッピング（プレビュー表示用）
+            var ledgerCardIdmMap = new Dictionary<int, string>();
 
             for (var i = 1; i < lines.Count; i++)
             {
@@ -1694,6 +1696,7 @@ namespace ICCardManager.Services
                         continue;
                     }
                     existingDetailsByLedgerId[detail.LedgerId] = ledger.Details ?? new List<LedgerDetail>();
+                    ledgerCardIdmMap[detail.LedgerId] = ledger.CardIdm ?? "";
                 }
 
                 if (!detailsByLedgerId.ContainsKey(detail.LedgerId))
@@ -1727,12 +1730,14 @@ namespace ICCardManager.Services
                     skipCount++;
                 }
 
+                var cardIdm = ledgerCardIdmMap.TryGetValue(ledgerId, out var idm) ? idm : "";
+
                 items.Add(new CsvImportPreviewItem
                 {
                     LineNumber = detailRows.First().LineNumber,
                     Idm = ledgerId.ToString(),
-                    Name = $"利用履歴ID {ledgerId}",
-                    AdditionalInfo = $"{detailRows.Count}件の詳細",
+                    Name = cardIdm,
+                    AdditionalInfo = $"{detailRows.Count}件",
                     Action = action,
                     Changes = changes
                 });

--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -224,6 +224,40 @@ public partial class DataExportImportViewModel : ViewModelBase
     public bool IsLedgerImportSelected => SelectedImportType == DataType.Ledgers;
 
     /// <summary>
+    /// プレビューDataGridの列1ヘッダー（データ種別に応じて変化）
+    /// </summary>
+    public string PreviewColumn1Header => SelectedImportType switch
+    {
+        DataType.LedgerDetails => "利用履歴ID",
+        DataType.Ledgers => "カードIDm",
+        _ => "IDm"
+    };
+
+    /// <summary>
+    /// プレビューDataGridの列2ヘッダー（データ種別に応じて変化）
+    /// </summary>
+    public string PreviewColumn2Header => SelectedImportType switch
+    {
+        DataType.LedgerDetails => "カードIDm",
+        DataType.Ledgers => "摘要",
+        DataType.Cards => "カード種別",
+        DataType.Staff => "氏名",
+        _ => "名前"
+    };
+
+    /// <summary>
+    /// プレビューDataGridの列3ヘッダー（データ種別に応じて変化）
+    /// </summary>
+    public string PreviewColumn3Header => SelectedImportType switch
+    {
+        DataType.LedgerDetails => "詳細件数",
+        DataType.Ledgers => "日付",
+        DataType.Cards => "管理番号",
+        DataType.Staff => "職員番号",
+        _ => "追加情報"
+    };
+
+    /// <summary>
     /// インポート時に使用するターゲットカードIDmを取得
     /// </summary>
     /// <returns>選択またはタッチされたカードのIDm。未選択の場合はnull</returns>
@@ -290,6 +324,9 @@ public partial class DataExportImportViewModel : ViewModelBase
     partial void OnSelectedImportTypeChanged(DataType value)
     {
         OnPropertyChanged(nameof(IsLedgerImportSelected));
+        OnPropertyChanged(nameof(PreviewColumn1Header));
+        OnPropertyChanged(nameof(PreviewColumn2Header));
+        OnPropertyChanged(nameof(PreviewColumn3Header));
 
         // 利用履歴以外が選択された場合、カード指定をクリア
         if (value != DataType.Ledgers)

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -430,9 +430,27 @@
                       AutomationProperties.Name="インポートプレビュー一覧">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="行" Binding="{Binding LineNumber}" Width="50"/>
-                    <DataGridTextColumn Header="IDm" Binding="{Binding Idm}" Width="140"/>
-                    <DataGridTextColumn Header="名前" Binding="{Binding Name}" Width="120"/>
-                    <DataGridTextColumn Header="追加情報" Binding="{Binding AdditionalInfo}" Width="100"/>
+                    <DataGridTextColumn Binding="{Binding Idm}" Width="140">
+                        <DataGridTextColumn.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DataContext.PreviewColumn1Header, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                            </DataTemplate>
+                        </DataGridTextColumn.HeaderTemplate>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding Name}" Width="120">
+                        <DataGridTextColumn.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DataContext.PreviewColumn2Header, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                            </DataTemplate>
+                        </DataGridTextColumn.HeaderTemplate>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Binding="{Binding AdditionalInfo}" Width="100">
+                        <DataGridTextColumn.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DataContext.PreviewColumn3Header, RelativeSource={RelativeSource AncestorType=DataGrid}}"/>
+                            </DataTemplate>
+                        </DataGridTextColumn.HeaderTemplate>
+                    </DataGridTextColumn>
                     <DataGridTemplateColumn Header="アクション" Width="80">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -1398,6 +1398,48 @@ FEDCBA9876543210,鈴木花子,002,テスト2";
         result.Items.Should().HaveCount(1);
         result.Items[0].Action.Should().Be(ImportAction.Update);
         result.Items[0].AdditionalInfo.Should().Contain("2件");
+        // Issue #905: プレビューアイテムに利用履歴IDとカードIDmが正しく設定されること
+        result.Items[0].Idm.Should().Be("1");
+        result.Items[0].Name.Should().Be("0123456789ABCDEF");
+    }
+
+    /// <summary>
+    /// Issue #905: 複数のledger_idを含むCSVのプレビューで各アイテムに正しいカードIDmが表示されること
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgerDetailsAsync_複数LedgerId_各アイテムにカードIDmが表示される()
+    {
+        // Arrange
+        var csvContent = @"利用履歴ID,利用日時,カードIDm,管理番号,乗車駅,降車駅,バス停,金額,残額,チャージ,ポイント還元,バス利用,グループID
+1,2024-01-15 10:30:00,AAAA456789ABCDEF,001,博多,天神,,260,9740,0,0,0,
+2,2024-01-16 09:00:00,BBBB456789ABCDEF,002,天神,博多,,260,9480,0,0,0,";
+
+        var filePath = Path.Combine(_testDirectory, "details_multi_ledger.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(1)).ReturnsAsync(new Ledger
+        {
+            Id = 1, CardIdm = "AAAA456789ABCDEF", Date = new DateTime(2024, 1, 15),
+            Summary = "鉄道（博多～天神）", Income = 0, Expense = 260, Balance = 9740
+        });
+        _ledgerRepositoryMock.Setup(x => x.GetByIdAsync(2)).ReturnsAsync(new Ledger
+        {
+            Id = 2, CardIdm = "BBBB456789ABCDEF", Date = new DateTime(2024, 1, 16),
+            Summary = "鉄道（天神～博多）", Income = 0, Expense = 260, Balance = 9480
+        });
+
+        // Act
+        var result = await _service.PreviewLedgerDetailsAsync(filePath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Items.Should().HaveCount(2);
+        result.Items[0].Idm.Should().Be("1");
+        result.Items[0].Name.Should().Be("AAAA456789ABCDEF");
+        result.Items[0].AdditionalInfo.Should().Be("1件");
+        result.Items[1].Idm.Should().Be("2");
+        result.Items[1].Name.Should().Be("BBBB456789ABCDEF");
+        result.Items[1].AdditionalInfo.Should().Be("1件");
     }
 
     /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
@@ -409,6 +409,43 @@ public class DataExportImportViewModelTests : IDisposable
 
     #endregion
 
+    #region Issue #905: プレビュー列ヘッダーの動的切り替え
+
+    [Theory]
+    [InlineData(DataType.Cards, "IDm", "カード種別", "管理番号")]
+    [InlineData(DataType.Staff, "IDm", "氏名", "職員番号")]
+    [InlineData(DataType.Ledgers, "カードIDm", "摘要", "日付")]
+    [InlineData(DataType.LedgerDetails, "利用履歴ID", "カードIDm", "詳細件数")]
+    public void PreviewColumnHeaders_データ種別に応じて正しいヘッダーが返される(
+        DataType dataType, string expectedCol1, string expectedCol2, string expectedCol3)
+    {
+        // Act
+        _viewModel.SelectedImportType = dataType;
+
+        // Assert
+        _viewModel.PreviewColumn1Header.Should().Be(expectedCol1);
+        _viewModel.PreviewColumn2Header.Should().Be(expectedCol2);
+        _viewModel.PreviewColumn3Header.Should().Be(expectedCol3);
+    }
+
+    [Fact]
+    public void PreviewColumnHeaders_種別変更時にPropertyChangedが発火する()
+    {
+        // Arrange
+        var changedProperties = new List<string>();
+        _viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName);
+
+        // Act
+        _viewModel.SelectedImportType = DataType.LedgerDetails;
+
+        // Assert
+        changedProperties.Should().Contain(nameof(DataExportImportViewModel.PreviewColumn1Header));
+        changedProperties.Should().Contain(nameof(DataExportImportViewModel.PreviewColumn2Header));
+        changedProperties.Should().Contain(nameof(DataExportImportViewModel.PreviewColumn3Header));
+    }
+
+    #endregion
+
     /// <summary>
     /// テスト用にプレビュー状態をセットアップするヘルパー
     /// </summary>


### PR DESCRIPTION
## Summary
- 利用履歴詳細データのインポートプレビューで、DataGridの列ヘッダーが「IDm」「名前」と固定表示されており、利用履歴詳細の内容と乖離してユーザーが混乱する問題を修正
- インポート種別に応じてプレビューDataGridの列ヘッダーを動的に切り替えるよう変更（カード/職員/利用履歴/利用履歴詳細それぞれに適切なヘッダーを表示）
- 利用履歴詳細プレビューのNameフィールドに冗長な「利用履歴ID N」ではなくカードIDmを表示するよう改善

## Changes
| ファイル | 変更内容 |
|----------|----------|
| `DataExportImportViewModel.cs` | `PreviewColumn1/2/3Header`プロパティ追加、種別変更時のPropertyChanged通知追加 |
| `DataExportImportDialog.xaml` | DataGrid列ヘッダーを`HeaderTemplate`によるバインディングに変更 |
| `CsvImportService.cs` | 利用履歴詳細プレビューでカードIDmをledgerから取得しNameフィールドに設定 |
| `CsvImportServiceTests.cs` | プレビューのカードIDm表示検証テスト追加 |
| `DataExportImportViewModelTests.cs` | 列ヘッダー動的切り替えのTheoryテスト・PropertyChanged発火テスト追加 |

## 列ヘッダー対応表
| データ種別 | 列1 | 列2 | 列3 |
|-----------|-----|-----|-----|
| カード一覧 | IDm | カード種別 | 管理番号 |
| 職員一覧 | IDm | 氏名 | 職員番号 |
| 利用履歴 | カードIDm | 摘要 | 日付 |
| 利用履歴詳細 | 利用履歴ID | カードIDm | 詳細件数 |

## Test plan
- [x] ユニットテスト1713件全て合格
- [x] 列ヘッダーが各データ種別で正しく表示されることをTheoryテストで検証
- [x] PropertyChangedが種別変更時に正しく発火することを検証
- [x] プレビューアイテムのカードIDm表示を検証
- [x] 実機で利用履歴詳細をエクスポート→インポートし、プレビュー画面の列表示を目視確認

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)