### PR TITLE
fix: 利用履歴インポート時にCSV最初の行もDB直前残高と整合性チェック (#907)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -1147,9 +1147,17 @@ namespace ICCardManager.Services
                     allRecordsForValidation.Add((lineNumber, ledger, isUpdate));
                 }
 
+                // Issue #907: カードごとにDB上の直前残高を取得（最初の行の整合性チェック用）
+                var previousBalanceByCard = await GetPreviousBalanceByCardAsync(allRecordsForValidation
+                    .GroupBy(r => r.Ledger.CardIdm, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.Min(r => r.Ledger.Date)));
+
                 // Issue #754: 残高整合性チェックはスキップ分を含む全レコードで実施
                 // （スキップされたレコードを除外すると前後関係が崩れ、誤った前回残高でエラーになる）
-                ValidateBalanceConsistencyForLedgers(allRecordsForValidation, errors);
+                // Issue #907: 最初の行もDB上の直前残高と照合
+                ValidateBalanceConsistencyForLedgers(allRecordsForValidation, errors, previousBalanceByCard);
 
                 // バリデーションエラーがあれば中断
                 if (errors.Count > 0)
@@ -1488,8 +1496,16 @@ namespace ICCardManager.Services
                     validatedRecords.Add((lineNumber, ledgerId, cardIdm, date, summary, income, expense, balance, staffName, note));
                 }
 
+                // Issue #907: カードごとにDB上の直前残高を取得（最初の行の整合性チェック用）
+                var previousBalanceByCard = await GetPreviousBalanceByCardAsync(validatedRecords
+                    .GroupBy(r => r.CardIdm, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.Min(r => r.Date)));
+
                 // Issue #428: 金額の整合性チェック（カードごとに残高の連続性を検証）
-                ValidateBalanceConsistency(validatedRecords, errors);
+                // Issue #907: 最初の行もDB上の直前残高と照合
+                ValidateBalanceConsistency(validatedRecords, errors, previousBalanceByCard);
 
                 // Issue #334: 既存履歴の重複チェック用キーを取得（新規追加分のみ）
                 // Issue #903: skipExisting=falseの場合は重複チェックを行わない
@@ -2829,12 +2845,15 @@ namespace ICCardManager.Services
         /// 残高整合性チェック（プレビュー用）
         /// カードごとに日時順で残高の連続性を検証します。
         /// 計算式: 前の残高 + 受入金額 - 払出金額 = 今回の残高
+        /// Issue #907: 最初の行もDB上の直前残高と照合します。
         /// </summary>
         /// <param name="records">検証対象レコード（LineNumber, LedgerId, CardIdm, Date, Summary, Income, Expense, Balance, StaffName, Note）</param>
         /// <param name="errors">エラーリスト</param>
-        private static void ValidateBalanceConsistency(
+        /// <param name="previousBalanceByCard">カードIDmごとのDB上の直前残高（存在しない場合はキーなし）</param>
+        internal static void ValidateBalanceConsistency(
             List<(int LineNumber, int? LedgerId, string CardIdm, DateTime Date, string Summary, int Income, int Expense, int Balance, string StaffName, string Note)> records,
-            List<CsvImportError> errors)
+            List<CsvImportError> errors,
+            Dictionary<string, int> previousBalanceByCard = null)
         {
             if (records.Count == 0) return;
 
@@ -2847,6 +2866,24 @@ namespace ICCardManager.Services
             {
                 var cardIdm = kvp.Key;
                 var cardRecords = kvp.Value;
+
+                // Issue #907: 最初の行をDB上の直前残高と照合
+                if (cardRecords.Count > 0 && previousBalanceByCard != null &&
+                    previousBalanceByCard.TryGetValue(cardIdm.ToUpperInvariant(), out var prevDbBalance))
+                {
+                    var firstRecord = cardRecords[0];
+                    var expectedBalance = prevDbBalance + firstRecord.Income - firstRecord.Expense;
+                    if (expectedBalance != firstRecord.Balance)
+                    {
+                        errors.Add(new CsvImportError
+                        {
+                            LineNumber = firstRecord.LineNumber,
+                            Message = $"残高が一致しません（期待値: {expectedBalance}円、実際: {firstRecord.Balance}円）。" +
+                                      $"前回残高（DB）: {prevDbBalance}円 + 受入: {firstRecord.Income}円 - 払出: {firstRecord.Expense}円",
+                            Data = cardIdm
+                        });
+                    }
+                }
 
                 for (var i = 1; i < cardRecords.Count; i++)
                 {
@@ -2874,12 +2911,15 @@ namespace ICCardManager.Services
         /// 残高整合性チェック（インポート用）
         /// カードごとに日時順で残高の連続性を検証します。
         /// 計算式: 前の残高 + 受入金額 - 払出金額 = 今回の残高
+        /// Issue #907: 最初の行もDB上の直前残高と照合します。
         /// </summary>
         /// <param name="records">検証対象レコード（LineNumber, Ledger, IsUpdate）</param>
         /// <param name="errors">エラーリスト</param>
-        private static void ValidateBalanceConsistencyForLedgers(
+        /// <param name="previousBalanceByCard">カードIDmごとのDB上の直前残高（存在しない場合はキーなし）</param>
+        internal static void ValidateBalanceConsistencyForLedgers(
             List<(int LineNumber, Ledger Ledger, bool IsUpdate)> records,
-            List<CsvImportError> errors)
+            List<CsvImportError> errors,
+            Dictionary<string, int> previousBalanceByCard = null)
         {
             if (records.Count == 0) return;
 
@@ -2892,6 +2932,24 @@ namespace ICCardManager.Services
             {
                 var cardIdm = kvp.Key;
                 var cardRecords = kvp.Value;
+
+                // Issue #907: 最初の行をDB上の直前残高と照合
+                if (cardRecords.Count > 0 && previousBalanceByCard != null &&
+                    previousBalanceByCard.TryGetValue(cardIdm.ToUpperInvariant(), out var prevDbBalance))
+                {
+                    var firstRecord = cardRecords[0];
+                    var expectedBalance = prevDbBalance + firstRecord.Ledger.Income - firstRecord.Ledger.Expense;
+                    if (expectedBalance != firstRecord.Ledger.Balance)
+                    {
+                        errors.Add(new CsvImportError
+                        {
+                            LineNumber = firstRecord.LineNumber,
+                            Message = $"残高が一致しません（期待値: {expectedBalance}円、実際: {firstRecord.Ledger.Balance}円）。" +
+                                      $"前回残高（DB）: {prevDbBalance}円 + 受入: {firstRecord.Ledger.Income}円 - 払出: {firstRecord.Ledger.Expense}円",
+                            Data = cardIdm
+                        });
+                    }
+                }
 
                 for (var i = 1; i < cardRecords.Count; i++)
                 {
@@ -2913,6 +2971,33 @@ namespace ICCardManager.Services
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Issue #907: カードごとにDB上の直前残高を取得する
+        /// CSVの各カードの最も古い日付より前のledgerレコードの残高を返します。
+        /// DB上に該当レコードがない場合はキーに含まれません。
+        /// </summary>
+        /// <param name="earliestDateByCard">カードIDmごとのCSV内の最小日付</param>
+        /// <returns>カードIDm（大文字）→直前残高のディクショナリ</returns>
+        private async Task<Dictionary<string, int>> GetPreviousBalanceByCardAsync(
+            Dictionary<string, DateTime> earliestDateByCard)
+        {
+            var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kvp in earliestDateByCard)
+            {
+                var cardIdm = kvp.Key;
+                var earliestDate = kvp.Value;
+
+                var previousLedger = await _ledgerRepository.GetLatestBeforeDateAsync(cardIdm, earliestDate);
+                if (previousLedger != null)
+                {
+                    result[cardIdm.ToUpperInvariant()] = previousLedger.Balance;
+                }
+            }
+
+            return result;
         }
 
         #endregion

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -672,6 +672,177 @@ FEDCBA9876543210,鈴木花子,002,テスト2";
 
     #endregion
 
+    #region Issue #907: 最初の行のDB直前残高との整合性チェック
+
+    /// <summary>
+    /// DB上に直前残高がある場合、最初の行の残高がDB直前残高と整合すればOK
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgersAsync_最初の行がDB直前残高と整合_正常()
+    {
+        // Arrange: DB上の直前残高は1200円
+        // CSV1行目: 受入=0, 払出=200, 残額=1000 → 期待: 1200 + 0 - 200 = 1000 ✓
+        var csvContent = @"日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
+2024-01-15 10:00:00,0123456789ABCDEF,001,鉄道（A駅～B駅）,,200,1000,山田太郎,";
+
+        var filePath = Path.Combine(_testDirectory, "ledgers_first_row_db_valid.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "001" }
+        };
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+        _ledgerRepositoryMock.Setup(x => x.GetExistingLedgerKeysAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new HashSet<(string, DateTime, string, int, int, int)>());
+
+        // DB上の直前残高: 1200円
+        _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync("0123456789ABCDEF", It.IsAny<DateTime>()))
+            .ReturnsAsync(new Ledger { CardIdm = "0123456789ABCDEF", Balance = 1200, Date = new DateTime(2024, 1, 14) });
+
+        // Act
+        var result = await _service.PreviewLedgersAsync(filePath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ErrorCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// DB上に直前残高がある場合、最初の行の残高がDB直前残高と不整合ならエラー
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgersAsync_最初の行がDB直前残高と不整合_エラー()
+    {
+        // Arrange: DB上の直前残高は1200円
+        // CSV1行目: 受入=0, 払出=200, 残額=900 → 期待: 1200 + 0 - 200 = 1000 ≠ 900 ✗
+        var csvContent = @"日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
+2024-01-15 10:00:00,0123456789ABCDEF,001,鉄道（A駅～B駅）,,200,900,山田太郎,";
+
+        var filePath = Path.Combine(_testDirectory, "ledgers_first_row_db_invalid.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "001" }
+        };
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+        _ledgerRepositoryMock.Setup(x => x.GetExistingLedgerKeysAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new HashSet<(string, DateTime, string, int, int, int)>());
+
+        // DB上の直前残高: 1200円
+        _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync("0123456789ABCDEF", It.IsAny<DateTime>()))
+            .ReturnsAsync(new Ledger { CardIdm = "0123456789ABCDEF", Balance = 1200, Date = new DateTime(2024, 1, 14) });
+
+        // Act
+        var result = await _service.PreviewLedgersAsync(filePath);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorCount.Should().Be(1);
+        result.Errors.Should().Contain(e => e.Message.Contains("残高が一致しません"));
+        result.Errors.Should().Contain(e => e.Message.Contains("期待値: 1000円"));
+        result.Errors.Should().Contain(e => e.Message.Contains("前回残高（DB）: 1200円"));
+    }
+
+    /// <summary>
+    /// DB上に直前レコードがない場合（新規カード）、最初の行はチェックしない
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgersAsync_DB直前レコードなし_最初の行スキップ()
+    {
+        // Arrange: DBに直前残高なし → 最初の行は検証不可
+        var csvContent = @"日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
+2024-01-15 10:00:00,0123456789ABCDEF,001,鉄道（A駅～B駅）,,200,999,山田太郎,
+2024-01-16 10:00:00,0123456789ABCDEF,001,鉄道（B駅～C駅）,,100,899,山田太郎,";
+
+        var filePath = Path.Combine(_testDirectory, "ledgers_first_row_no_db.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "001" }
+        };
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+        _ledgerRepositoryMock.Setup(x => x.GetExistingLedgerKeysAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new HashSet<(string, DateTime, string, int, int, int)>());
+
+        // DB上に直前レコードなし（デフォルトでnullを返す）
+
+        // Act
+        var result = await _service.PreviewLedgersAsync(filePath);
+
+        // Assert: 2行目のチェーンは正しいのでOK（999 - 100 = 899）
+        result.IsValid.Should().BeTrue();
+        result.ErrorCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// チャージ（受入金額あり）の最初の行がDB直前残高と整合すること
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgersAsync_チャージの最初の行がDB直前残高と整合()
+    {
+        // Arrange: DB上の直前残高は200円
+        // CSV1行目: 受入=1000(チャージ), 払出=0, 残額=1200 → 期待: 200 + 1000 - 0 = 1200 ✓
+        var csvContent = @"日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
+2024-01-15 10:00:00,0123456789ABCDEF,001,役務費によりチャージ,1000,,1200,山田太郎,";
+
+        var filePath = Path.Combine(_testDirectory, "ledgers_first_row_charge.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "0123456789ABCDEF", CardType = "Suica", CardNumber = "001" }
+        };
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+        _ledgerRepositoryMock.Setup(x => x.GetExistingLedgerKeysAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new HashSet<(string, DateTime, string, int, int, int)>());
+
+        _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync("0123456789ABCDEF", It.IsAny<DateTime>()))
+            .ReturnsAsync(new Ledger { CardIdm = "0123456789ABCDEF", Balance = 200, Date = new DateTime(2024, 1, 14) });
+
+        // Act
+        var result = await _service.PreviewLedgersAsync(filePath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// インポート時にも最初の行のDB直前残高チェックが動作すること
+    /// </summary>
+    [Fact]
+    public async Task ImportLedgersAsync_最初の行がDB直前残高と不整合_エラー()
+    {
+        // Arrange: DB上の直前残高は5000円
+        // CSV1行目: 受入=0, 払出=260, 残額=4000 → 期待: 5000 + 0 - 260 = 4740 ≠ 4000 ✗
+        var csvContent = @"日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
+2024-01-15 10:00:00,0123456789ABCDEF,001,鉄道（博多～天神）,,260,4000,山田太郎,";
+
+        var filePath = Path.Combine(_testDirectory, "import_first_row_db_invalid.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "0123456789ABCDEF", CardType = "はやかけん", CardNumber = "001" }
+        };
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+
+        _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync("0123456789ABCDEF", It.IsAny<DateTime>()))
+            .ReturnsAsync(new Ledger { CardIdm = "0123456789ABCDEF", Balance = 5000, Date = new DateTime(2024, 1, 14) });
+
+        // Act
+        var result = await _service.ImportLedgersAsync(filePath);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Message.Contains("残高が一致しません"));
+        result.Errors.Should().Contain(e => e.Message.Contains("前回残高（DB）: 5000円"));
+    }
+
+    #endregion
+
     #region Issue #639: 繰越レコードの金額変更インポートテスト
 
     /// <summary>


### PR DESCRIPTION
## Summary
- 利用履歴インポート時の残高整合性チェックで、CSV内の最初の行が検証対象外だった問題を修正
- DB上の直前レコードの残高と照合し、最初の行の受入額・払出額の誤りも検出可能に
- プレビュー・実インポートの両方で一貫したチェックを実施

## 問題の詳細

従来の残高整合性チェックでは、CSV内の2行目以降のみ「前回残高 + 受入 - 払出 = 今回残高」を検証していました。最初の行は比較対象がなく、常にスキップされていたため：

- 1行目の受入額/払出額に誤りがあっても検出できない
- 不整合なデータがインポートされてしまう可能性があった

## 修正内容

| ファイル | 変更内容 |
|----------|----------|
| `CsvImportService.cs` | `ValidateBalanceConsistency`/`ValidateBalanceConsistencyForLedgers`に`previousBalanceByCard`パラメータ追加、`GetPreviousBalanceByCardAsync`ヘルパー追加 |
| `CsvImportServiceTests.cs` | 5件のテストケース追加 |

### 動作仕様

1. CSV内の各カードの最も古い日付より前のDB上の利用履歴を `GetLatestBeforeDateAsync` で取得
2. その残高を「前回残高」として、CSVの最初の行に対して `前回残高 + 受入 - 払出 = 残額` を検証
3. DB上に直前レコードがない場合（新規カード初回登録等）は最初の行の検証をスキップ（従来と同じ動作）

### エラーメッセージ例
```
残高が一致しません（期待値: 1000円、実際: 900円）。前回残高（DB）: 1200円 + 受入: 0円 - 払出: 200円
```

## Test plan
- [x] ユニットテスト1725件全て合格
- [x] DB直前残高と整合する場合にOKとなることを検証
- [x] DB直前残高と不整合の場合にエラーとなることを検証
- [x] DB上に直前レコードがない場合にスキップされることを検証
- [x] チャージ（受入金額あり）の最初の行の整合性を検証
- [x] インポート側でも同様の検証が動作することを検証
- [ ] 実機で以下を確認:
  - 既存データがあるカードに対して、意図的に1行目の残高を間違えたCSVをインポートし、エラーが検出されること
  - 正しいCSVは問題なくインポートできること

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)