### PR TITLE
feat: デバッグ用データビューアにSQLiteのrowidを表示 (#924)

### DIFF
--- a/ICCardManager/tools/DebugDataViewer/MainViewModel.cs
+++ b/ICCardManager/tools/DebugDataViewer/MainViewModel.cs
@@ -428,7 +428,8 @@ namespace DebugDataViewer
                     }
 
                     using var command = connection.CreateCommand();
-                    command.CommandText = $"SELECT * FROM {SelectedTableName} ORDER BY 1";
+                    // rowidは SELECT * に含まれないため明示的に取得
+                    command.CommandText = $"SELECT rowid, * FROM {SelectedTableName} ORDER BY 1";
 
                     using var adapter = new System.Data.SQLite.SQLiteDataAdapter(command);
                     var dataTable = new DataTable();


### PR DESCRIPTION
## Summary
- DBデータタブのクエリを `SELECT *` → `SELECT rowid, *` に変更し、各テーブルのrowidを表示
- 特に`ledger_detail`テーブルでは`rowid`が`SequenceNumber`として摘要生成の時系列順序に使われており、デバッグ時に確認できることが重要

## 変更内容
- `MainViewModel.cs`: `LoadTableDataAsync`のSQLクエリに`rowid`を追加

## Test plan
- [x] ビルド成功
- [x] デバッグ用データビューアを起動し、DBデータタブで各テーブル（特に`ledger_detail`）を表示し、先頭列に`rowid`が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)