### PR TITLE
fix: CIワークフローでUIテストプロジェクトを明示的に除外

### DIFF
--- a/ICCardManager/.github/workflows/ci.yml
+++ b/ICCardManager/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Run tests
-      run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=UI" --collect:"XPlat Code Coverage" --results-directory ./coverage
+      run: dotnet test tests/ICCardManager.Tests/ICCardManager.Tests.csproj --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
 
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4

--- a/ICCardManager/.github/workflows/release.yml
+++ b/ICCardManager/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet restore ${{ env.PROJECT_PATH }}
 
       - name: Run tests
-        run: dotnet test ICCardManager/ICCardManager.sln --configuration Release --verbosity normal --filter "Category!=UI"
+        run: dotnet test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --configuration Release --verbosity normal
 
       - name: Publish self-contained executable
         run: |


### PR DESCRIPTION
## Summary
- `dotnet test`の対象をソリューション全体(`ICCardManager.sln`)からユニットテストプロジェクト(`ICCardManager.Tests.csproj`)のみに変更
- ci.yml と release.yml の両方を修正

## 背景
`--filter "Category!=UI"` フィルタでは、UIテストプロジェクト内のテスト**実行**は防げるものの、プロジェクトの**ビルドと起動**は行われるため、CI環境（GitHub Actions）でWPFアプリのメインウィンドウ表示タイムアウト（30秒）が発生してテストが失敗していた。

テストプロジェクトを明示的に指定することで、UIテストプロジェクトが一切ロードされなくなる。

## Test plan
- [x] release.yml: `dotnet test` 対象を `ICCardManager.Tests.csproj` に変更
- [x] ci.yml: 同上
- [ ] PRマージ後のCIで全ユニットテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)