### PR TITLE
fix: リリースワークフローのプラットフォーム不一致を修正

### DIFF
--- a/ICCardManager/.github/workflows/release.yml
+++ b/ICCardManager/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           dotnet publish ${{ env.PROJECT_PATH }} `
             --configuration Release `
-            --runtime win-x64 `
+            --runtime win-x86 `
             --self-contained true `
             -p:PublishSingleFile=true `
             -p:Version=${{ steps.get_version.outputs.VERSION }} `
@@ -67,7 +67,7 @@ jobs:
           echo "## ICCardManager v${{ steps.get_version.outputs.VERSION }}" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo "### 動作環境" >> $GITHUB_OUTPUT
-          echo "- Windows 10/11 (64-bit)" >> $GITHUB_OUTPUT
+          echo "- Windows 10/11 (32-bit/64-bit)" >> $GITHUB_OUTPUT
           echo "- Sony PaSoRi (RC-S380等)" >> $GITHUB_OUTPUT
           echo "- .NET Runtime: 不要（self-contained）" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `release.yml` の `--runtime` を `win-x64` → `win-x86` に修正
- csproj の `PlatformTarget=x86`（felicalib.dllが32ビット）と整合性を取る
- リリースノートの動作環境表記を `32-bit/64-bit` に修正

## 背景
v1.18.1のリリースビルド（[Run #22829234243](https://github.com/kuwayamamasayuki/ICCardManager/actions/runs/22829234243)）で以下のエラーが発生:
```
The RuntimeIdentifier platform 'win-x64' and the PlatformTarget 'x86' must be compatible.
```

## Test plan
- [ ] PRマージ後、新しいタグをpushしてリリースワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)