### PR TITLE
fix: リリースワークフローでUIテストが実行される問題を修正

### DIFF
--- a/ICCardManager/.github/workflows/release.yml
+++ b/ICCardManager/.github/workflows/release.yml
@@ -31,10 +31,13 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        run: dotnet restore ${{ env.PROJECT_PATH }}
+        run: dotnet restore ICCardManager/ICCardManager.sln
+
+      - name: Build
+        run: dotnet build ICCardManager/ICCardManager.sln --no-restore --configuration Release
 
       - name: Run tests
-        run: dotnet test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --configuration Release --verbosity normal
+        run: dotnet test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --no-build --configuration Release --verbosity normal
 
       - name: Publish self-contained executable
         run: |


### PR DESCRIPTION
## Summary
- `release.yml` のテストステップで `dotnet test` がビルド時にソリューション全体を発見し、UIテストも実行されていた
- 明示的にBuild → Test (`--no-build`) に分離し、ユニットテストプロジェクトのみを実行するよう修正
- CI (`ci.yml`) と同じパターンに統一

## 背景
PR #930 マージ後のv1.18.1リリース再実行で、ユニットテスト1610件は全パスしたがUIテスト (`ステータスバーにカードリーダー状態が表示される`) がCI環境でタイムアウトし失敗。

## Test plan
- [ ] PRマージ後、v1.18.1タグを再作成してリリースワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)