### PR TITLE
fix: ルートのrelease.ymlでプラットフォーム不一致とUIテスト除外を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,17 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+
     - name: Run tests
-      run: dotnet test --configuration Release --verbosity normal
+      run: dotnet test tests/ICCardManager.Tests/ICCardManager.Tests.csproj --no-build --configuration Release --verbosity normal
 
     - name: Publish
       run: |
         dotnet publish src/ICCardManager/ICCardManager.csproj `
           --configuration Release `
-          --runtime win-x64 `
+          --runtime win-x86 `
           --self-contained true `
           -p:PublishSingleFile=true `
           -p:IncludeNativeLibrariesForSelfExtract=true `


### PR DESCRIPTION
## Summary
- リポジトリルートの `.github/workflows/release.yml`（GitHub Actionsが実際に使用するファイル）を修正
- `--runtime win-x64` → `win-x86` に変更（csprojの `PlatformTarget=x86` と整合）
- Build/Test分離 (`--no-build`) でUIテストを除外

## 背景
これまでPR#930, #931で `ICCardManager/.github/workflows/release.yml` を修正していたが、
GitHub Actionsが参照するのは**リポジトリルートの** `.github/workflows/` であり、修正が反映されていなかった。

ルートの `release.yml` には以下の2つの問題があった:
1. `--runtime win-x64` が csprojの `PlatformTarget=x86` と矛盾
2. `dotnet test` がソリューション全体を実行し、UIテストがCI環境でタイムアウト

## Test plan
- [ ] PRマージ後、v1.18.1タグを再作成してリリースワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)