### PR TITLE
fix: release.ymlのPublishを.NET Framework 4.8対応に修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,7 @@ jobs:
       run: |
         dotnet publish src/ICCardManager/ICCardManager.csproj `
           --configuration Release `
-          --runtime win-x86 `
-          --self-contained true `
-          -p:PublishSingleFile=true `
-          -p:IncludeNativeLibrariesForSelfExtract=true `
-          -p:EnableCompressionInSingleFile=true `
+          --no-build `
           --output ./publish
 
     - name: Create ZIP


### PR DESCRIPTION
## Summary
- `dotnet publish` から .NET Core 専用オプションを削除
  - `--runtime win-x86` / `--self-contained true` / `-p:PublishSingleFile=true` 等
- .NET Framework 4.8 では `dotnet publish -c Release --no-build` でビルド成果物を出力するのが正しい方法

## 背景
PR #932 でプラットフォーム不一致・UIテスト問題を修正後、Publishステップで新たなエラー:
```
Publishing to a single-file is only supported for netcoreapp target.
```
このプロジェクトは `net48` (.NET Framework 4.8) をターゲットにしており、
`PublishSingleFile`、`--self-contained`、`--runtime` は .NET Core/.NET 5+ でのみ利用可能。

## Test plan
- [ ] PRマージ後、v1.18.1タグを再作成してリリースワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)