### PR TITLE
fix: release.ymlにcontents: write権限を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ env:
 jobs:
   build-release:
     runs-on: windows-latest
+    permissions:
+      contents: write
 
     defaults:
       run:


### PR DESCRIPTION
## Summary
- ルートの `release.yml` に `permissions: contents: write` を追加
- GitHub Release作成 (`softprops/action-gh-release`) に必要な権限

## 背景
PR #933 マージ後、Build/Tests/Publish/Create ZIP まで全て成功したが、
Create Release ステップで 403 Forbidden エラーが発生。
`GITHUB_TOKEN` にリリース作成権限が付与されていなかったため。

## Test plan
- [ ] PRマージ後、v1.18.1タグを再作成してリリースワークフロー全体が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)