### PR TITLE
feat: 利用履歴詳細インポートの表示情報追加 (#938)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -104,7 +104,7 @@ namespace ICCardManager.Services
         /// <summary>アクション（新規/更新/スキップ）</summary>
         public ImportAction Action { get; set; }
 
-        /// <summary>変更点リスト（更新時のみ）</summary>
+        /// <summary>変更点リスト（更新時および新規追加時）</summary>
         public List<FieldChange> Changes { get; set; } = new();
 
         /// <summary>変更点があるか</summary>
@@ -114,6 +114,9 @@ namespace ICCardManager.Services
         public string ChangesSummary => HasChanges
             ? string.Join("、", Changes.Select(c => c.FieldName))
             : string.Empty;
+
+        /// <summary>詳細セクションのヘッダー（アクションに応じて変化）</summary>
+        public string ChangesHeader => Action == ImportAction.Insert ? "追加する内容:" : "変更内容の詳細:";
     }
 
     /// <summary>
@@ -1794,6 +1797,10 @@ namespace ICCardManager.Services
                     ? $"{newDetailCardName} ({cardIdm})"
                     : cardIdm;
 
+                // Issue #938: 追加する内容の詳細を表示
+                var insertDetails = detailRows.Select(x => x.Detail).ToList();
+                var insertChanges = CreateInsertDetailChanges(insertDetails);
+
                 items.Add(new CsvImportPreviewItem
                 {
                     LineNumber = detailRows.First().LineNumber,
@@ -1801,7 +1808,7 @@ namespace ICCardManager.Services
                     Name = cardDisplayName,
                     AdditionalInfo = $"{detailRows.Count}件{dateStr}",
                     Action = ImportAction.Insert,
-                    Changes = new List<FieldChange>()
+                    Changes = insertChanges
                 });
                 newCount++;
             }
@@ -2895,6 +2902,83 @@ namespace ICCardManager.Services
                     });
                 }
             }
+        }
+
+        /// <summary>
+        /// Issue #938: 新規追加する利用履歴詳細の内容をFieldChangeリストとして生成する。
+        /// Insert行の詳細表示用。
+        /// </summary>
+        internal static List<FieldChange> CreateInsertDetailChanges(List<LedgerDetail> details)
+        {
+            var changes = new List<FieldChange>();
+
+            for (var i = 0; i < details.Count; i++)
+            {
+                var detail = details[i];
+                var rowLabel = $"[{i + 1}行目]";
+
+                // 利用内容を組み立て
+                var description = FormatDetailDescription(detail);
+
+                changes.Add(new FieldChange
+                {
+                    FieldName = rowLabel,
+                    OldValue = "(新規追加)",
+                    NewValue = description
+                });
+            }
+
+            return changes;
+        }
+
+        /// <summary>
+        /// 利用履歴詳細1件の内容を表示用の文字列にフォーマットする。
+        /// </summary>
+        internal static string FormatDetailDescription(LedgerDetail detail)
+        {
+            var parts = new List<string>();
+
+            // 利用日時
+            if (detail.UseDate.HasValue)
+            {
+                parts.Add(detail.UseDate.Value.ToString("yyyy-MM-dd HH:mm"));
+            }
+
+            // 区間情報
+            if (detail.IsCharge)
+            {
+                parts.Add("チャージ");
+            }
+            else if (detail.IsPointRedemption)
+            {
+                parts.Add("ポイント還元");
+            }
+            else if (detail.IsBus)
+            {
+                var busStop = !string.IsNullOrEmpty(detail.BusStops) ? $"バス（{detail.BusStops}）" : "バス";
+                parts.Add(busStop);
+            }
+            else
+            {
+                var entry = !string.IsNullOrEmpty(detail.EntryStation) ? detail.EntryStation : "?";
+                var exit = !string.IsNullOrEmpty(detail.ExitStation) ? detail.ExitStation : "?";
+                if (!string.IsNullOrEmpty(detail.EntryStation) || !string.IsNullOrEmpty(detail.ExitStation))
+                {
+                    parts.Add($"{entry}→{exit}");
+                }
+            }
+
+            // 金額・残額
+            if (detail.Amount.HasValue)
+            {
+                parts.Add($"{detail.Amount.Value}円");
+            }
+            if (detail.Balance.HasValue)
+            {
+                parts.Add($"残額{detail.Balance.Value}円");
+            }
+
+            return string.Join(" ", parts);
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -508,7 +508,7 @@
                         <Border Background="{DynamicResource WarningBackgroundBrush}" Padding="10" Margin="0,2"
                                 Visibility="{Binding HasChanges, Converter={StaticResource BoolToVisibilityConverter}}">
                             <StackPanel>
-                                <TextBlock Text="変更内容の詳細:" FontWeight="Bold" Margin="0,0,0,5"/>
+                                <TextBlock Text="{Binding ChangesHeader}" FontWeight="Bold" Margin="0,0,0,5"/>
                                 <ItemsControl ItemsSource="{Binding Changes}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvImportServiceTests.cs
@@ -2432,4 +2432,136 @@ FEDCBA9876543210,鈴木花子,002,テスト2";
     }
 
     #endregion
+
+    #region Issue #938: 追加行の詳細表示
+
+    /// <summary>
+    /// 新規追加する利用履歴詳細の内容がChangesに格納されること
+    /// </summary>
+    [Fact]
+    public async Task PreviewLedgerDetailsAsync_Insert行に追加内容の詳細が表示される()
+    {
+        // Arrange
+        var csvContent = @"利用履歴ID,利用日時,カードIDm,管理番号,乗車駅,降車駅,バス停,金額,残額,チャージ,ポイント還元,バス利用,グループID
+,2024-01-15 10:30:00,0123456789ABCDEF,001,博多,天神,,260,9740,0,0,0,
+,2024-01-15 17:00:00,0123456789ABCDEF,001,天神,博多,,260,9480,0,0,0,";
+
+        var filePath = Path.Combine(_testDirectory, "details_insert_changes.csv");
+        await Task.Run(() => File.WriteAllText(filePath, csvContent, CsvEncoding));
+
+        _cardRepositoryMock.Setup(x => x.GetByIdmAsync("0123456789ABCDEF", true))
+            .ReturnsAsync(new IcCard { CardIdm = "0123456789ABCDEF", CardType = "はやかけん", CardNumber = "001" });
+
+        // Act
+        var result = await _service.PreviewLedgerDetailsAsync(filePath);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Action.Should().Be(ImportAction.Insert);
+        result.Items[0].HasChanges.Should().BeTrue("追加行にも詳細が表示されるべき");
+        result.Items[0].Changes.Should().HaveCount(2);
+        result.Items[0].Changes[0].FieldName.Should().Be("[1行目]");
+        result.Items[0].Changes[0].OldValue.Should().Be("(新規追加)");
+        result.Items[0].Changes[0].NewValue.Should().Contain("博多→天神");
+        result.Items[0].Changes[0].NewValue.Should().Contain("260円");
+        result.Items[0].Changes[1].FieldName.Should().Be("[2行目]");
+        result.Items[0].Changes[1].NewValue.Should().Contain("天神→博多");
+    }
+
+    /// <summary>
+    /// ChangesHeaderがアクションに応じて変化すること
+    /// </summary>
+    [Fact]
+    public void ChangesHeader_Insertの場合は追加する内容()
+    {
+        var insertItem = new CsvImportPreviewItem { Action = ImportAction.Insert };
+        insertItem.ChangesHeader.Should().Be("追加する内容:");
+
+        var updateItem = new CsvImportPreviewItem { Action = ImportAction.Update };
+        updateItem.ChangesHeader.Should().Be("変更内容の詳細:");
+
+        var skipItem = new CsvImportPreviewItem { Action = ImportAction.Skip };
+        skipItem.ChangesHeader.Should().Be("変更内容の詳細:");
+    }
+
+    /// <summary>
+    /// FormatDetailDescriptionで鉄道利用の説明が正しく生成されること
+    /// </summary>
+    [Fact]
+    public void FormatDetailDescription_鉄道利用()
+    {
+        var detail = new LedgerDetail
+        {
+            UseDate = new DateTime(2024, 1, 15, 10, 30, 0),
+            EntryStation = "博多",
+            ExitStation = "天神",
+            Amount = 260,
+            Balance = 9740
+        };
+
+        var result = CsvImportService.FormatDetailDescription(detail);
+
+        result.Should().Be("2024-01-15 10:30 博多→天神 260円 残額9740円");
+    }
+
+    /// <summary>
+    /// FormatDetailDescriptionでチャージの説明が正しく生成されること
+    /// </summary>
+    [Fact]
+    public void FormatDetailDescription_チャージ()
+    {
+        var detail = new LedgerDetail
+        {
+            UseDate = new DateTime(2024, 1, 15, 12, 0, 0),
+            IsCharge = true,
+            Amount = 1000,
+            Balance = 10740
+        };
+
+        var result = CsvImportService.FormatDetailDescription(detail);
+
+        result.Should().Be("2024-01-15 12:00 チャージ 1000円 残額10740円");
+    }
+
+    /// <summary>
+    /// FormatDetailDescriptionでバス利用の説明が正しく生成されること
+    /// </summary>
+    [Fact]
+    public void FormatDetailDescription_バス利用()
+    {
+        var detail = new LedgerDetail
+        {
+            UseDate = new DateTime(2024, 1, 15, 14, 0, 0),
+            IsBus = true,
+            BusStops = "天神バス停",
+            Amount = 200,
+            Balance = 9540
+        };
+
+        var result = CsvImportService.FormatDetailDescription(detail);
+
+        result.Should().Be("2024-01-15 14:00 バス（天神バス停） 200円 残額9540円");
+    }
+
+    /// <summary>
+    /// FormatDetailDescriptionでポイント還元の説明が正しく生成されること
+    /// </summary>
+    [Fact]
+    public void FormatDetailDescription_ポイント還元()
+    {
+        var detail = new LedgerDetail
+        {
+            UseDate = new DateTime(2024, 1, 15, 16, 0, 0),
+            IsPointRedemption = true,
+            Amount = 50,
+            Balance = 9590
+        };
+
+        var result = CsvImportService.FormatDetailDescription(detail);
+
+        result.Should().Be("2024-01-15 16:00 ポイント還元 50円 残額9590円");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- 利用履歴詳細インポートのプレビューで「追加」行を選択した際に、追加する内容の詳細を表示
- 各明細の利用日時・区間情報・金額・残額を一覧で確認可能に
- ヘッダーテキストをアクションに応じて動的に切替（「追加する内容:」/「変更内容の詳細:」）
- カード名表示（#937で対応済み）と合わせてIssue #938の2要件を両方カバー

### 表示例
Insert行をクリックした際の詳細表示:
```
追加する内容:
  [1行目]: (新規追加) → 2024-01-15 10:30 博多→天神 260円 残額9740円
  [2行目]: (新規追加) → 2024-01-15 17:00 天神→博多 260円 残額9480円
```

### 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `CsvImportService.cs` | `ChangesHeader`プロパティ追加、`CreateInsertDetailChanges`/`FormatDetailDescription`メソッド追加、Insert行のChanges設定 |
| `DataExportImportDialog.xaml` | ヘッダーテキストを`ChangesHeader`バインディングに変更 |
| `CsvImportServiceTests.cs` | 6件の新規テスト（Insert詳細表示、ChangesHeader、各種利用パターンのフォーマット） |

## Test plan
- [x] 全1657件のユニットテストがパス
- [ ] 利用履歴詳細CSVをインポートし、「追加」行をクリックして詳細内容が表示されることを確認
- [ ] 「更新」行をクリックして従来通り変更内容が表示されることを確認
- [ ] 鉄道・バス・チャージ・ポイント還元の各パターンで適切な表示になることを確認

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)