### PR TITLE
fix: データエクスポート/インポート画面で閉じるボタンがはみ出す問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -31,13 +31,20 @@
 
     <Grid Margin="20">
         <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>      <!-- Row 0: スクロール可能なコンテンツ -->
+            <RowDefinition Height="Auto"/>   <!-- Row 1: Close button（常に表示） -->
+        </Grid.RowDefinitions>
+
+        <!-- スクロール可能なコンテンツ領域 -->
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+        <Grid>
+        <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>   <!-- Row 0: エクスポート設定 -->
             <RowDefinition Height="Auto"/>   <!-- Row 1: インポート設定（スクロール可能） -->
             <RowDefinition Height="Auto"/>   <!-- Row 2: アクションボタン（常に表示） -->
             <RowDefinition Height="Auto"/>   <!-- Row 3: Status message -->
-            <RowDefinition Height="*" MinHeight="150"/>  <!-- Row 4: プレビュー結果（サマリー + DataGrid） -->
+            <RowDefinition Height="Auto"/>   <!-- Row 4: プレビュー結果（サマリー + DataGrid） -->
             <RowDefinition Height="Auto"/>   <!-- Row 5: エラー一覧 -->
-            <RowDefinition Height="Auto"/>   <!-- Row 6: Close button -->
         </Grid.RowDefinitions>
 
         <!-- エクスポート設定 -->
@@ -396,7 +403,7 @@
               Visibility="{Binding HasPreview, Converter={StaticResource BoolToVisibilityConverter}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>  <!-- サマリーバナー -->
-                <RowDefinition Height="*"/>     <!-- DataGrid -->
+                <RowDefinition Height="Auto"/>  <!-- DataGrid -->
             </Grid.RowDefinitions>
 
             <!-- プレビューサマリー -->
@@ -427,6 +434,7 @@
                       BorderThickness="1"
                       BorderBrush="{DynamicResource SubtleBorderBrush}"
                       MinHeight="120"
+                      MaxHeight="300"
                       AutomationProperties.Name="インポートプレビュー一覧">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="行" Binding="{Binding LineNumber}" Width="50"/>
@@ -546,8 +554,11 @@
             </StackPanel>
         </Border>
 
-        <!-- 閉じるボタン -->
-        <StackPanel Grid.Row="6"
+        </Grid>
+        </ScrollViewer>
+
+        <!-- 閉じるボタン（常に画面下部に表示） -->
+        <StackPanel Grid.Row="1"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Margin="0,15,0,0">
@@ -561,7 +572,7 @@
         </StackPanel>
 
         <!-- 処理中オーバーレイ -->
-        <Border Grid.RowSpan="7"
+        <Border Grid.RowSpan="2"
                 Background="{DynamicResource OverlayBrush}"
                 Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary
- エクスポート/インポート実行後に「閉じる」ボタンが画面外にはみ出して操作不能になる問題を修正 (#948)
- コンテンツ領域をScrollViewerで囲み、閉じるボタンを常に画面下部に固定表示するよう構造を変更
- プレビューDataGridにMaxHeight制約を追加し、無制限に伸張しないよう制御

## 変更内容
- `DataExportImportDialog.xaml`: 外側Gridを2行構成（スクロール可能コンテンツ + 閉じるボタン）に再構成

## Test plan
- [x] データエクスポート/インポート画面を開き、「閉じる」ボタンが表示されていることを確認
- [x] CSVエクスポートを実行し、ステータスメッセージ表示後も「閉じる」ボタンが見えることを確認
- [x] インポートプレビューを実行し、プレビュー結果表示後も「閉じる」ボタンが見えることを確認
- [x] インポートを実行し、エラー一覧が表示されても「閉じる」ボタンが見えることを確認
- [x] ウィンドウを最小サイズ（600x700）にリサイズしても「閉じる」ボタンが見えることを確認
- [x] Escapeキーでダイアログを閉じられることを確認

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)