### PR TITLE
fix: データエクスポート/インポート画面の初期サイズを調整

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/DataExportImportDialog.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:DataExportImportViewModel}"
         Title="データエクスポート/インポート"
-        Height="750"
+        Height="800"
         Width="800"
         WindowStartupLocation="CenterOwner"
         ResizeMode="CanResize"
@@ -37,7 +37,7 @@
         </Grid.RowDefinitions>
 
         <!-- 設定エリア（スクロール可能） -->
-        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" MaxHeight="400">
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" MaxHeight="500">
         <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>   <!-- Row 0: エクスポート設定 -->


### PR DESCRIPTION
## Summary
- データエクスポート/インポート画面の初期状態で設定エリアが微妙にスクロールしないと見えない問題を修正 (#961)

## 変更内容
- ウィンドウ初期高さ: 750px → 800px
- 設定エリアScrollViewer MaxHeight: 400px → 500px

## Test plan
- [x] ダイアログを開いた初期状態で、エクスポート設定・インポート設定・アクションボタンがスクロールなしで全て表示されることを確認
- [x] フォントサイズを「特大」に変更した場合でも、設定エリアが適切にスクロール可能であることを確認
- [x] ウィンドウをリサイズした際にレイアウトが崩れないことを確認

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)