### PR TITLE
fix: 利用履歴詳細CSVエクスポートの順序を残高チェーンベースに修正 (#964)

### DIFF
--- a/ICCardManager/src/ICCardManager/Common/LedgerDetailChronologicalSorter.cs
+++ b/ICCardManager/src/ICCardManager/Common/LedgerDetailChronologicalSorter.cs
@@ -46,28 +46,34 @@ namespace ICCardManager.Common
             // balance_before を計算:
             // 利用（expense）: balance_before = Balance + Amount
             // チャージ（income）: balance_before = Balance - Amount
+            // Issue #964: Amount が null の場合は 0 として扱う（FeliCa最古レコード等で発生）
             var items = detailList
-                .Where(d => d.Balance.HasValue && d.Amount.HasValue)
+                .Where(d => d.Balance.HasValue)
                 .Select(d =>
                 {
+                    var amount = d.Amount ?? 0;
                     var balanceBefore = d.IsCharge
-                        ? d.Balance!.Value - d.Amount!.Value
-                        : d.Balance!.Value + d.Amount!.Value;
+                        ? d.Balance!.Value - amount
+                        : d.Balance!.Value + amount;
                     return (Detail: d, BalanceBefore: balanceBefore);
                 })
                 .ToList();
 
-            // Balance/Amount情報が不十分な場合はフォールバック
+            // Balance情報が不十分な場合はフォールバック
             if (items.Count < detailList.Count)
             {
                 return Fallback(detailList, preserveOrderOnFailure);
             }
 
             // チェーン構築: balance_before が他のどのdetailの Balance にも一致しないものが先頭
-            var balanceSet = new HashSet<int>(items.Select(i => i.Detail.Balance!.Value));
+            // Issue #964: Amount=null/0の場合 balance_before == Balance となるため、
+            // 自分自身のBalanceではなく他のエントリのBalanceとのみ比較する
             var remaining = new List<(LedgerDetail Detail, int BalanceBefore)>(items);
 
-            var start = remaining.FirstOrDefault(r => !balanceSet.Contains(r.BalanceBefore));
+            var start = remaining.FirstOrDefault(r =>
+                !remaining.Any(other =>
+                    !ReferenceEquals(other.Detail, r.Detail) &&
+                    other.Detail.Balance!.Value == r.BalanceBefore));
             if (start.Detail == null)
             {
                 // チェーン構築失敗: フォールバック

--- a/ICCardManager/src/ICCardManager/Services/CsvExportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvExportService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.IO;
 using System.Text;
+using ICCardManager.Common;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
 
@@ -257,19 +258,31 @@ namespace ICCardManager.Services
                     "利用履歴ID,利用日時,カードIDm,管理番号,乗車駅,降車駅,バス停,金額,残額,チャージ,ポイント還元,バス利用,グループID"
                 };
 
-                // カード種別・管理番号 → 日付 → ledger_id → rowid 順でソート
-                foreach (var detail in details
-                    .OrderBy(d =>
+                // Issue #964: LedgerId単位で残高チェーンによる時系列ソートを適用
+                // SequenceNumber（rowid）順はFeliCa循環バッファの境界で不正確になるため、
+                // 残高チェーンで確実な時系列順を得る
+                var sortedDetails = details
+                    .GroupBy(d => d.LedgerId)
+                    .SelectMany(g => LedgerDetailChronologicalSorter.Sort(g.ToList())
+                        .Select(d => d))
+                    .ToList();
+
+                // カード種別・管理番号 → 日付 → ledger_id 順でソート（グループ内は残高チェーン順を維持）
+                var orderedDetails = sortedDetails
+                    .Select((d, idx) => new { Detail = d, ChainOrder = idx })
+                    .OrderBy(x =>
                     {
-                        if (ledgerCardMap.TryGetValue(d.LedgerId, out var idm) &&
+                        if (ledgerCardMap.TryGetValue(x.Detail.LedgerId, out var idm) &&
                             cardSortKeyMap.TryGetValue(idm, out var key))
                             return key;
                         return "";
                     })
-                    .ThenBy(d => d.UseDate)
-                    .ThenBy(d => d.LedgerId)
-                    // Issue #904: SequenceNumber降順で古い取引から順に出力（FeliCa互換: 小さいrowid=新しい取引）
-                    .ThenByDescending(d => d.SequenceNumber))
+                    .ThenBy(x => x.Detail.UseDate)
+                    .ThenBy(x => x.Detail.LedgerId)
+                    .ThenBy(x => x.ChainOrder)
+                    .Select(x => x.Detail);
+
+                foreach (var detail in orderedDetails)
                 {
                     // 参照用のカードIDmと管理番号を取得
                     var cardIdm = ledgerCardMap.TryGetValue(detail.LedgerId, out var idmVal) ? idmVal : "";

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CsvExportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CsvExportServiceTests.cs
@@ -878,6 +878,79 @@ public class CsvExportServiceTests : IDisposable
         lines[3].Should().Contain(",9220,");
     }
 
+    /// <summary>
+    /// Issue #964: SequenceNumber順と残高チェーン順が異なる場合でも
+    /// 残高チェーンに基づく正しい時系列順で出力されることを確認
+    /// （FeliCa循環バッファ境界の最古部分で発生）
+    /// </summary>
+    [Fact]
+    public async Task ExportLedgerDetailsAsync_SequenceNumber順が残高チェーンと異なる場合_残高チェーン順で出力される()
+    {
+        // Arrange: Issue #964の再現データ
+        // 正しい時系列: 薬院→博多(1526) → 博多→薬院(210円支払い, 1316)
+        // だがSequenceNumberは逆順（FeliCa循環バッファ境界で発生）
+        var details = new List<LedgerDetail>
+        {
+            new LedgerDetail
+            {
+                LedgerId = 2,
+                UseDate = new DateTime(2026, 3, 2),
+                EntryStation = "博多",
+                ExitStation = "薬院",
+                Amount = 210,
+                Balance = 1316,
+                IsCharge = false,
+                IsPointRedemption = false,
+                IsBus = false,
+                SequenceNumber = 20 // FeliCa上では大きいrowid（古いはず）だが実際は新しい
+            },
+            new LedgerDetail
+            {
+                LedgerId = 2,
+                UseDate = new DateTime(2026, 3, 2),
+                EntryStation = "薬院",
+                ExitStation = "博多",
+                Amount = 0,
+                Balance = 1526,
+                IsCharge = false,
+                IsPointRedemption = false,
+                IsBus = false,
+                SequenceNumber = 1 // FeliCa上では小さいrowid（新しいはず）だが実際は古い
+            }
+        };
+
+        var ledgers = new List<Ledger>
+        {
+            new Ledger { Id = 2, CardIdm = "01010212CC0C2A1F", Date = new DateTime(2026, 3, 2) }
+        };
+        var cards = new List<IcCard>
+        {
+            new IcCard { CardIdm = "01010212CC0C2A1F", CardType = "nimoca", CardNumber = "5042" }
+        };
+
+        _ledgerRepositoryMock.Setup(x => x.GetAllDetailsInDateRangeAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync(details);
+        _ledgerRepositoryMock.Setup(x => x.GetByDateRangeAsync(null, It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync(ledgers);
+        _cardRepositoryMock.Setup(x => x.GetAllIncludingDeletedAsync()).ReturnsAsync(cards);
+
+        var filePath = Path.Combine(_testDirectory, "ledger_details_964.csv");
+
+        // Act
+        var result = await _service.ExportLedgerDetailsAsync(filePath, new DateTime(2026, 3, 1), new DateTime(2026, 3, 31));
+
+        // Assert: 残高チェーン順（1526→1316）で出力される
+        result.Success.Should().BeTrue();
+        var lines = await Task.Run(() => File.ReadAllLines(filePath, Encoding.UTF8));
+        lines.Should().HaveCount(3); // ヘッダー + 2行
+
+        // 1行目: 薬院→博多（残額1526、時系列的に先）
+        lines[1].Should().Contain(",薬院,博多,");
+        lines[1].Should().Contain(",1526,");
+
+        // 2行目: 博多→薬院（残額1316、時系列的に後）
+        lines[2].Should().Contain(",博多,薬院,");
+        lines[2].Should().Contain(",1316,");
+    }
+
     #endregion
 
     #region エラーハンドリング テスト


### PR DESCRIPTION
## Summary
- FeliCa循環バッファの境界でSequenceNumber(rowid)順が時系列と一致しない問題を修正
- `CsvExportService.ExportLedgerDetailsAsync`のソートを`LedgerDetailChronologicalSorter`による残高チェーンベースに変更
- `LedgerDetailChronologicalSorter`をAmount=null（FeliCa最古レコード等）に対応させ、チェーン起点判定の自己参照バグを修正

## Changes
- `CsvExportService.cs`: SequenceNumber順ソートを残高チェーン順に変更（LedgerId単位でグループ化→残高チェーンソート→カード順・日付順で最終ソート）
- `LedgerDetailChronologicalSorter.cs`: `Amount ?? 0`によるnull安全化、`ReferenceEquals`による自己参照除外
- `CsvExportServiceTests.cs`: SequenceNumber順と残高チェーン順が異なるケースの回帰テスト追加

## Test plan
- [x] 全1685テスト合格（既存テスト影響なし）
- [x] 新規テスト: SequenceNumber順と残高チェーン順が異なる場合に残高チェーン順で出力されることを検証
- [ ] 手動テスト: 実データで利用履歴詳細CSVエクスポートし、時系列順が正しいことを確認

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)