### PR TITLE
feat: インストーラーに「はじめに」マニュアルを追加 (#967)

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -79,14 +79,17 @@ Source: "..\publish\Resources\Templates\*"; DestDir: "{app}\Resources\Templates"
 
 ; ドキュメント（ユーザー向け・管理者向け）
 ; markdown形式
+Source: "..\docs\manual\はじめに.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\ユーザーマニュアル.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\ユーザーマニュアル概要版.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\管理者マニュアル.md"; DestDir: "{app}\Docs"; Flags: ignoreversion
 ; docx形式
+Source: "..\docs\manual\はじめに.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\ユーザーマニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\ユーザーマニュアル概要版（修正版）.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\管理者マニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 ; PDF形式（Issue #642）
+Source: "..\docs\manual\はじめに.pdf"; DestDir: "{app}\Docs"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "..\docs\manual\ユーザーマニュアル.pdf"; DestDir: "{app}\Docs"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "..\docs\manual\ユーザーマニュアル概要版.pdf"; DestDir: "{app}\Docs"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "..\docs\manual\管理者マニュアル.pdf"; DestDir: "{app}\Docs"; Flags: ignoreversion skipifsourcedoesntexist


### PR DESCRIPTION
## Summary
- インストーラー（ICCardManager.iss）に「はじめに」マニュアルをmd/docx/pdf形式で追加
- インストール先の `Docs` フォルダに他のマニュアルと同様に配置される

## Test plan
- [x] 手動テスト: インストーラーをビルドし、インストール後の `Docs` フォルダに「はじめに.md」「はじめに.docx」「はじめに.pdf」が含まれていることを確認

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)