### PR TITLE
feat: 備考欄のフォントサイズを文字列長に応じて自動調整 (#980)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -894,6 +894,10 @@ namespace ICCardManager.Services
             var summaryCell = worksheet.Cell(row, 2);
             summaryCell.Style.Font.FontSize = GetSummaryFontSize(ledger.Summary);
 
+            // Issue #980: 備考欄のフォントサイズを文字列長に応じて調整
+            var noteCell = worksheet.Cell(row, 9);
+            noteCell.Style.Font.FontSize = GetNoteFontSize(ledger.Note);
+
             return row + 1;
         }
 
@@ -914,6 +918,28 @@ namespace ICCardManager.Services
             if (length < 38)  return 10;
             if (length < 93)  return 8;
             if (length < 108) return 7;
+            return 6;
+        }
+
+        /// <summary>
+        /// 備考欄のフォントサイズを文字列の長さに応じて決定
+        /// </summary>
+        /// <remarks>
+        /// Issue #980: I-L列結合セル（4列、摘要のB-D列3列より約1.33倍広い）の幅に収まるよう、
+        /// 文字数が多いほどフォントサイズを小さくする。
+        /// しきい値は摘要欄（GetSummaryFontSize）の約1.33倍。
+        /// </remarks>
+        /// <param name="note">備考文字列</param>
+        /// <returns>適切なフォントサイズ（ポイント）</returns>
+        internal static double GetNoteFontSize(string note)
+        {
+            var length = note?.Length ?? 0;
+
+            if (length < 20)  return 14;
+            if (length < 43)  return 12;
+            if (length < 51)  return 10;
+            if (length < 124) return 8;
+            if (length < 144) return 7;
             return 6;
         }
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceTests.cs
@@ -3364,4 +3364,40 @@ public class ReportServiceTests : IDisposable
     }
 
     #endregion
+
+    #region GetNoteFontSize - Issue #980
+
+    [Theory]
+    [InlineData(null, 14)]       // null → 14pt
+    [InlineData("", 14)]         // 空文字 → 14pt
+    [InlineData("支払額210円のうち不足額10円は現金で支払（旅費支給）", 12)]  // 27文字 → 12pt（< 43）
+    [InlineData("支払額210円のうち不足額140円は現金で支払（旅費支給）", 12)] // 28文字 → 12pt（< 43）
+    public void GetNoteFontSize_文字数に応じたフォントサイズを返す(string note, double expectedFontSize)
+    {
+        var result = ReportService.GetNoteFontSize(note);
+        result.Should().Be(expectedFontSize);
+    }
+
+    [Theory]
+    [InlineData(0, 14)]    // 0文字 → 14pt（境界: 20未満）
+    [InlineData(19, 14)]   // 19文字 → 14pt（境界: 20未満）
+    [InlineData(20, 12)]   // 20文字 → 12pt（境界: 20以上）
+    [InlineData(42, 12)]   // 42文字 → 12pt（境界: 43未満）
+    [InlineData(43, 10)]   // 43文字 → 10pt（境界: 43以上）
+    [InlineData(50, 10)]   // 50文字 → 10pt（境界: 51未満）
+    [InlineData(51, 8)]    // 51文字 → 8pt（境界: 51以上）
+    [InlineData(123, 8)]   // 123文字 → 8pt（境界: 124未満）
+    [InlineData(124, 7)]   // 124文字 → 7pt（境界: 124以上）
+    [InlineData(143, 7)]   // 143文字 → 7pt（境界: 144未満）
+    [InlineData(144, 6)]   // 144文字 → 6pt（境界: 144以上）
+    [InlineData(200, 6)]   // 200文字 → 6pt（最小サイズ）
+    public void GetNoteFontSize_境界値で正しいフォントサイズを返す(int length, double expectedFontSize)
+    {
+        var note = new string('あ', length);
+        var result = ReportService.GetNoteFontSize(note);
+        result.Should().Be(expectedFontSize,
+            $"{length}文字の備考に対して{expectedFontSize}ptが期待される");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- 物品出納簿の備考欄（I-L列結合）のフォントサイズを、文字列の長さに応じて自動調整するようにした
- 摘要欄（B-D列結合、Issue #946）と同じアプローチで、備考欄の列幅（4列=摘要の約1.33倍）に合わせたしきい値を設定
- `GetNoteFontSize()` メソッドを追加し、境界値テスト含む16件のテストを追加

## フォントサイズしきい値

| 文字数 | フォントサイズ |
|--------|---------------|
| 0-19 | 14pt |
| 20-42 | 12pt |
| 43-50 | 10pt |
| 51-123 | 8pt |
| 124-143 | 7pt |
| 144以上 | 6pt |

※典型的な備考テキスト「支払額210円のうち不足額140円は現金で支払（旅費支給）」は28文字 → 12pt

## Test plan
- [x] `GetNoteFontSize` の境界値テスト（12件）
- [x] `GetNoteFontSize` の実テキストテスト（4件）
- [x] 全1723テスト合格確認
- [ ] 実際に帳票を出力して備考欄のフォントサイズが適切に調整されていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)