### PR TITLE
fix: バス停名を編集後に統合すると修正前の摘要に戻る問題を修正 (#983)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/LedgerMergeService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LedgerMergeService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
@@ -246,6 +247,10 @@ namespace ICCardManager.Services
                 target.Balance = latestDetail.Balance!.Value;
             }
 
+            // Issue #983: 摘要が手動編集されている場合、Detail.BusStopsが未同期の
+            // 可能性があるため、各Ledgerの摘要からバス停名を抽出してDetailに反映する
+            SyncBusStopsFromSummary(ledgers);
+
             // Issue #920: 摘要を再生成（詳細を新しい順にソートしてからGenerateに渡す）
             // Generate()はICカードの読み取り順（新しい順）を前提に.Reverse()するため、
             // DB由来の詳細はUseDate降順・Balance昇順で新しい順に並べ替える必要がある。
@@ -450,6 +455,45 @@ namespace ICCardManager.Services
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// 各Ledgerの摘要からバス停名を抽出してDetail.BusStopsに反映する（Issue #983）
+        /// </summary>
+        /// <remarks>
+        /// 摘要の直接編集（LedgerRowEditViewModel）ではDetail.BusStopsが更新されないため、
+        /// 統合時にSummaryGenerator.Generate()が古いBusStopsから摘要を再生成してしまう。
+        /// この処理で摘要とDetailの整合性を回復する。
+        /// </remarks>
+        internal static void SyncBusStopsFromSummary(List<Ledger> ledgers)
+        {
+            foreach (var ledger in ledgers)
+            {
+                var busDetails = ledger.Details.Where(d => d.IsBus).ToList();
+                if (busDetails.Count == 0) continue;
+
+                var match = Regex.Match(ledger.Summary ?? "", @"バス（(.+?)）");
+                if (!match.Success) continue;
+
+                var busStopText = match.Groups[1].Value;
+
+                if (busDetails.Count == 1)
+                {
+                    busDetails[0].BusStops = busStopText;
+                }
+                else
+                {
+                    // 複数件のバス利用: 「、」で分割してDetailに対応付け
+                    var parts = busStopText.Split('、');
+                    if (parts.Length == busDetails.Count)
+                    {
+                        for (int i = 0; i < parts.Length; i++)
+                        {
+                            busDetails[i].BusStops = parts[i];
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/ICCardManager/src/ICCardManager/ViewModels/LedgerRowEditViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/LedgerRowEditViewModel.cs
@@ -594,12 +594,63 @@ namespace ICCardManager.ViewModels
             var result = await _ledgerRepository.UpdateAsync(ledger);
             if (result)
             {
+                // Issue #983: 摘要編集時にバス停名をDetailに同期
+                // 摘要を直接編集するとLedger.Summaryは更新されるがDetail.BusStopsは更新されない。
+                // この不整合を放置すると、統合時にSummaryGenerator.Generate()が
+                // Detail.BusStopsから摘要を再生成し、修正前のバス停名に戻ってしまう。
+                if (beforeLedger.Summary != ledger.Summary)
+                {
+                    await SyncBusStopsFromSummaryAsync(ledger);
+                }
+
                 await _operationLogger.LogLedgerUpdateAsync(_operatorIdm, beforeLedger, ledger);
                 IsSaved = true;
             }
             else
             {
                 StatusMessage = "保存に失敗しました";
+            }
+        }
+
+        /// <summary>
+        /// 摘要からバス停名を抽出してDetail.BusStopsに同期する（Issue #983）
+        /// </summary>
+        /// <remarks>
+        /// 摘要の直接編集ではLedger.Summaryのみ更新されDetail.BusStopsは未更新のため、
+        /// 統合時の摘要再生成で修正前のバス停名に戻る問題を防止する。
+        /// </remarks>
+        private async Task SyncBusStopsFromSummaryAsync(Ledger ledger)
+        {
+            var busDetails = ledger.Details.Where(d => d.IsBus).ToList();
+            if (busDetails.Count == 0) return;
+
+            var match = System.Text.RegularExpressions.Regex.Match(
+                ledger.Summary ?? "", @"バス（(.+?)）");
+            if (!match.Success) return;
+
+            var busStopText = match.Groups[1].Value;
+            var busStopUpdates = new List<(int SequenceNumber, string BusStops)>();
+
+            if (busDetails.Count == 1)
+            {
+                busStopUpdates.Add((busDetails[0].SequenceNumber, busStopText));
+            }
+            else
+            {
+                // 複数件のバス利用: 「、」で分割してDetailに対応付け
+                var parts = busStopText.Split('、');
+                if (parts.Length == busDetails.Count)
+                {
+                    for (int i = 0; i < parts.Length; i++)
+                    {
+                        busStopUpdates.Add((busDetails[i].SequenceNumber, parts[i]));
+                    }
+                }
+            }
+
+            if (busStopUpdates.Count > 0)
+            {
+                await _ledgerRepository.UpdateDetailBusStopsAsync(ledger.Id, busStopUpdates);
             }
         }
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
@@ -1248,4 +1248,216 @@ public class LedgerMergeServiceTests
     }
 
     #endregion
+
+    #region SyncBusStopsFromSummary - Issue #983
+
+    /// <summary>
+    /// 摘要が手動編集された場合、BusStopsが摘要から同期されること
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_単一バス利用_摘要からBusStopsを同期()
+    {
+        // Arrange: 分割後に摘要が「バス（qq）」→「バス（薬院大通～西鉄平尾駅）」に編集されたが
+        // Detail.BusStopsは「qq」のまま
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "バス（薬院大通～西鉄平尾駅）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "qq", Amount = 210, Balance = 500 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert
+        ledgers[0].Details[0].BusStops.Should().Be("薬院大通～西鉄平尾駅");
+    }
+
+    /// <summary>
+    /// 複数Ledgerでそれぞれバス停名が同期されること（分割→編集→統合シナリオ）
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_分割後の複数Ledger_それぞれ同期()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "バス（薬院大通～西鉄平尾駅）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "qq", Amount = 210, Balance = 500 }
+                }
+            },
+            new()
+            {
+                Id = 2,
+                Summary = "バス（那の川～渡辺通一丁目）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "aa", Amount = 210, Balance = 290 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert
+        ledgers[0].Details[0].BusStops.Should().Be("薬院大通～西鉄平尾駅");
+        ledgers[1].Details[0].BusStops.Should().Be("那の川～渡辺通一丁目");
+    }
+
+    /// <summary>
+    /// 複数バス利用が1つのLedgerにある場合、「、」で分割して対応付けること
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_複数バス利用の1Ledger_分割して対応付け()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "バス（薬院大通～天神、博多～吉塚）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "★", Amount = 210, Balance = 500 },
+                    new() { IsBus = true, BusStops = "★", Amount = 210, Balance = 290 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert
+        ledgers[0].Details[0].BusStops.Should().Be("薬院大通～天神");
+        ledgers[0].Details[1].BusStops.Should().Be("博多～吉塚");
+    }
+
+    /// <summary>
+    /// バス利用がないLedgerでは何も変更されないこと
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_鉄道のみ_変更なし()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "鉄道（博多～天神）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = false, EntryStation = "博多", ExitStation = "天神", Amount = 260, Balance = 500 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert: 変更なし
+        ledgers[0].Details[0].BusStops.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 鉄道+バス混在の摘要からバス部分のみ抽出されること
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_鉄道とバス混在_バス部分のみ同期()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "鉄道（博多～天神）、バス（渡辺通～薬院）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = false, EntryStation = "博多", ExitStation = "天神", Amount = 260, Balance = 500 },
+                    new() { IsBus = true, BusStops = "★", Amount = 210, Balance = 240 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert
+        ledgers[0].Details.First(d => d.IsBus).BusStops.Should().Be("渡辺通～薬院");
+        ledgers[0].Details.First(d => !d.IsBus).EntryStation.Should().Be("博多", "鉄道Detailは変更されない");
+    }
+
+    /// <summary>
+    /// BusStopsが既に正しい場合も上書きされるが実害なし
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_既に同期済み_変更なし()
+    {
+        // Arrange
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "バス（薬院）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "薬院", Amount = 210, Balance = 500 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert
+        ledgers[0].Details[0].BusStops.Should().Be("薬院");
+    }
+
+    /// <summary>
+    /// バス利用数と「、」分割数が一致しない場合は変更しないこと
+    /// </summary>
+    [Fact]
+    public void SyncBusStopsFromSummary_バス件数不一致_変更しない()
+    {
+        // Arrange: 3件のバスDetailがあるが、摘要には2件分しかない
+        var ledgers = new List<Ledger>
+        {
+            new()
+            {
+                Id = 1,
+                Summary = "バス（薬院、天神）",
+                Details = new List<LedgerDetail>
+                {
+                    new() { IsBus = true, BusStops = "a", Amount = 210, Balance = 500 },
+                    new() { IsBus = true, BusStops = "b", Amount = 210, Balance = 290 },
+                    new() { IsBus = true, BusStops = "c", Amount = 210, Balance = 80 }
+                }
+            }
+        };
+
+        // Act
+        LedgerMergeService.SyncBusStopsFromSummary(ledgers);
+
+        // Assert: 件数不一致のため変更なし
+        ledgers[0].Details[0].BusStops.Should().Be("a");
+        ledgers[0].Details[1].BusStops.Should().Be("b");
+        ledgers[0].Details[2].BusStops.Should().Be("c");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- バス利用の履歴を分割→摘要を編集→再統合すると、編集前のバス停名に戻るバグを修正
- 根本原因: 摘要の直接編集時に`Ledger.Summary`は更新されるが`LedgerDetail.BusStops`は更新されず、統合時に`SummaryGenerator.Generate()`が古い`BusStops`から摘要を再生成していた
- 2箇所で修正:
  - `LedgerRowEditViewModel.SaveEditAsync()`: 摘要編集時にDetail.BusStopsを自動同期（根本原因の修正）
  - `LedgerMergeService.MergeAsync()`: 統合前にも摘要からBusStopsを同期（既存データへの安全策）

## Test plan
- [x] `SyncBusStopsFromSummary` の単体テスト7件追加（全合格）
- [x] 全1730テスト合格確認
- [ ] 実機テスト: バス利用2件の履歴を分割→各バス停名を編集→再統合し、編集後のバス停名が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)