### PR TITLE
feat: バスの往復利用を統合時に「往復」と表示する (#985)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
+++ b/ICCardManager/src/ICCardManager/Services/SummaryGenerator.cs
@@ -731,20 +731,67 @@ namespace ICCardManager.Services
         /// </summary>
         private string GenerateBusSummary(List<LedgerDetail> trips)
         {
-            // バス停名が入力されている場合はそれを使用
-            var busStops = trips
+            // バス停名が入力されているものを時系列順（古い→新しい）で取得
+            // ※tripsはGenerate()でReverse済みのため既に時系列順
+            var allBusStops = trips
                 .Where(t => !string.IsNullOrEmpty(t.BusStops))
                 .Select(t => t.BusStops!)
-                .Distinct()
                 .ToList();
 
-            if (busStops.Count > 0)
+            if (allBusStops.Count == 0)
             {
-                return string.Join("、", busStops);
+                // 未入力の場合は★マーク
+                return "★";
             }
 
-            // 未入力の場合は★マーク
-            return "★";
+            // Issue #985: 「A～B」形式のバス停名から往復パターンを検出
+            // 鉄道のDetectRoundTripsと同じロジックを適用する
+            // 往復検出は時系列順のまま行う（Distinctすると順序が崩れ往復の方向が逆になる）
+            var parsedRoutes = allBusStops
+                .Select(ParseBusRoute)
+                .Where(r => r.HasValue)
+                .Select(r => r!.Value)
+                .ToList();
+
+            if (parsedRoutes.Count >= 2)
+            {
+                var roundTrips = DetectRoundTrips(parsedRoutes);
+                if (roundTrips.Count > 0)
+                {
+                    var roundTripStrings = roundTrips.Select(rt => $"{rt.Start}～{rt.End} 往復");
+                    var remaining = GetRemainingRoutes(parsedRoutes, roundTrips);
+
+                    // 往復 + 残りの経路 + 解析できなかったバス停名
+                    var unparsed = allBusStops
+                        .Where(bs => !ParseBusRoute(bs).HasValue)
+                        .Distinct()
+                        .ToList();
+                    var remainingStrings = remaining.Select(r => $"{r.Entry}～{r.Exit}");
+
+                    return string.Join("、", roundTripStrings
+                        .Concat(remainingStrings)
+                        .Concat(unparsed));
+                }
+            }
+
+            // 往復なし: 重複除去して連結
+            return string.Join("、", allBusStops.Distinct());
+        }
+
+        /// <summary>
+        /// バス停名を「A～B」形式として解析（Issue #985）
+        /// </summary>
+        /// <returns>解析成功時は(Entry, Exit)のタプル、失敗時はnull</returns>
+        private static (string Entry, string Exit)? ParseBusRoute(string busStops)
+        {
+            var parts = busStops.Split('～');
+            if (parts.Length == 2 &&
+                !string.IsNullOrWhiteSpace(parts[0]) &&
+                !string.IsNullOrWhiteSpace(parts[1]))
+            {
+                return (parts[0], parts[1]);
+            }
+            return null;
         }
 
         /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
@@ -248,4 +248,140 @@ public class SummaryGeneratorTests
     }
 
     #endregion
+
+    #region バス往復検出 - Issue #985
+
+    /// <summary>
+    /// バスの往復利用（A～B、B～A）が「A～B 往復」として表示されること
+    /// </summary>
+    [Fact]
+    public void Generate_バス往復_往復と表示される()
+    {
+        // Arrange: FeliCa順（新しい順）で入力
+        // 時系列: 薬院大通→西鉄平尾駅（往路）→ 西鉄平尾駅→薬院大通（復路）
+        var details = new List<LedgerDetail>
+        {
+            new()
+            {
+                IsBus = true,
+                BusStops = "西鉄平尾駅～薬院大通",  // 復路（新しい）
+                Amount = 210,
+                Balance = 290
+            },
+            new()
+            {
+                IsBus = true,
+                BusStops = "薬院大通～西鉄平尾駅",  // 往路（古い）
+                Amount = 210,
+                Balance = 500
+            }
+        };
+
+        // Act
+        var result = _generator.Generate(details);
+
+        // Assert
+        result.Should().Be("バス（薬院大通～西鉄平尾駅 往復）");
+    }
+
+    /// <summary>
+    /// バスの片道利用では往復と表示されないこと
+    /// </summary>
+    [Fact]
+    public void Generate_バス片道_往復とならない()
+    {
+        var details = new List<LedgerDetail>
+        {
+            new()
+            {
+                IsBus = true,
+                BusStops = "薬院大通～西鉄平尾駅",
+                Amount = 210,
+                Balance = 500
+            }
+        };
+
+        var result = _generator.Generate(details);
+
+        result.Should().Be("バス（薬院大通～西鉄平尾駅）");
+    }
+
+    /// <summary>
+    /// バス停名が「A～B」形式でない場合は往復検出されず連結されること
+    /// </summary>
+    [Fact]
+    public void Generate_バス停名に経路区切りなし_連結される()
+    {
+        // FeliCa順（新しい順）: 博多(新)、天神(古)
+        var details = new List<LedgerDetail>
+        {
+            new() { IsBus = true, BusStops = "博多", Amount = 210, Balance = 290 },
+            new() { IsBus = true, BusStops = "天神", Amount = 210, Balance = 500 }
+        };
+
+        var result = _generator.Generate(details);
+
+        // Reverse後: 天神(古)→博多(新) の順
+        result.Should().Be("バス（天神、博多）");
+    }
+
+    /// <summary>
+    /// バス往復＋残りの片道がある場合の表示
+    /// </summary>
+    [Fact]
+    public void Generate_バス往復と片道混在_正しく表示される()
+    {
+        // FeliCa順（新しい順）: 博多→吉塚(片道)、天神→薬院(復路)、薬院→天神(往路)
+        var details = new List<LedgerDetail>
+        {
+            new() { IsBus = true, BusStops = "博多～吉塚", Amount = 170, Balance = 320 },
+            new() { IsBus = true, BusStops = "天神～薬院", Amount = 210, Balance = 490 },
+            new() { IsBus = true, BusStops = "薬院～天神", Amount = 210, Balance = 700 }
+        };
+
+        var result = _generator.Generate(details);
+
+        result.Should().Contain("薬院～天神 往復");
+        result.Should().Contain("博多～吉塚");
+    }
+
+    /// <summary>
+    /// 鉄道とバス往復が混在する場合
+    /// </summary>
+    [Fact]
+    public void Generate_鉄道とバス往復混在_正しく表示される()
+    {
+        // FeliCa順（新しい順）: 渡辺通→天神(復路)、天神→渡辺通(往路)、博多→天神(鉄道)
+        var details = new List<LedgerDetail>
+        {
+            new() { IsBus = true, BusStops = "渡辺通～天神", Amount = 210, Balance = 530 },
+            new() { IsBus = true, BusStops = "天神～渡辺通", Amount = 210, Balance = 740 },
+            new() { IsBus = false, EntryStation = "博多", ExitStation = "天神", Amount = 260, Balance = 1000 }
+        };
+
+        var result = _generator.Generate(details);
+
+        result.Should().Contain("鉄道（博多～天神）");
+        result.Should().Contain("バス（天神～渡辺通 往復）");
+    }
+
+    /// <summary>
+    /// バス停名が★（未入力）の場合は往復検出されないこと
+    /// </summary>
+    [Fact]
+    public void Generate_バス停名が未入力_往復検出されない()
+    {
+        var details = new List<LedgerDetail>
+        {
+            new() { IsBus = true, BusStops = "★", Amount = 210, Balance = 500 },
+            new() { IsBus = true, BusStops = "★", Amount = 210, Balance = 290 }
+        };
+
+        var result = _generator.Generate(details);
+
+        // ★はDistinctで1つになるので「バス（★）」
+        result.Should().Be("バス（★）");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- バスの「A～B」「B～A」の2件を統合した際に「バス（A～B 往復）」と表示されるようにした
- 鉄道で使用している`DetectRoundTrips`ロジックをバスにも適用
- バス停名が「A～B」形式でない場合（「★」や単一名称）は従来通りの動作

## 変更の詳細
`GenerateBusSummary()`を拡張:
1. `ParseBusRoute()`で各バス停名を「A～B」→(A, B)に分解
2. 鉄道と共通の`DetectRoundTrips()`で往復パターンを検出
3. 往復は「A～B 往復」、残りは個別表示

## Test plan
- [x] バス往復テスト（6件追加、全合格）
- [x] 全1736テスト合格確認
- [ ] 実機テスト: バス利用2件（A→B、B→A）の履歴を統合し「バス（A～B 往復）」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)