### PR TITLE
fix: バス停名入力画面でTABキーによるフォーカス遷移が効かない問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/BusStopInputDialog.xaml
@@ -50,7 +50,8 @@
                   ItemsSource="{Binding BusUsages}"
                   BorderThickness="1"
                   BorderBrush="{DynamicResource SubtleBorderBrush}"
-                  ScrollViewer.CanContentScroll="False">
+                  ScrollViewer.CanContentScroll="False"
+                  KeyboardNavigation.TabNavigation="Continue">
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid Margin="10">
@@ -140,6 +141,7 @@
                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                     <Setter Property="Padding" Value="0"/>
                     <Setter Property="Margin" Value="0"/>
+                    <Setter Property="IsTabStop" Value="False"/>
                 </Style>
             </ListView.ItemContainerStyle>
         </ListView>


### PR DESCRIPTION
## Summary
- バス停名入力画面で複数のバス利用履歴がある場合、1つ目のTextBoxからTABキーで2つ目のTextBoxにフォーカスが移動しない問題を修正

## 原因
- `ListView`の`KeyboardNavigation.TabNavigation`のデフォルト値が`Once`のため、ListView内で最初のフォーカス可能要素にTabで入った後、次のTabでListView全体を抜けていた
- `ListViewItem`自体が`IsTabStop=True`（デフォルト）のため、Tabでコンテナにフォーカスが止まり、中のTextBoxに届かなかった

## 修正内容
- `ListView`に`KeyboardNavigation.TabNavigation="Continue"`を追加：Tab順がListView内のすべてのフォーカス可能要素を巡回する
- `ListViewItem`のスタイルに`IsTabStop="False"`を追加：コンテナを飛ばしてTextBoxに直接フォーカスが移る

Closes #991

## Test plan
- [x] バス停名入力画面を開く（バス利用が2件以上ある状態で）
- [x] 1つ目のTextBoxにフォーカスがある状態でTABキーを押す → 2つ目のTextBoxにフォーカスが移ることを確認
- [x] Shift+TABで逆方向にフォーカスが戻ることを確認
- [x] 最後のTextBoxでTABを押すと「スキップ」ボタンにフォーカスが移ることを確認
- [x] サジェストポップアップの動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)