### PR TITLE
docs: テスト設計書を実コードに基づいて大幅に詳細化

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -9,9 +9,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 1,613件 | xUnit + FluentAssertions + Moq |
+| 単体テスト（ICCardManager.Tests） | 1,796件 | xUnit + FluentAssertions + Moq |
 | UIテスト（ICCardManager.UITests） | 9件 | |
-| **合計** | **1,622件** | 全件パス |
+| **合計** | **1,805件** | 全件パス |
 
 ### 1.2 テスト範囲
 
@@ -60,7 +60,7 @@
 
 ### 2.2 摘要文字列生成（SummaryGenerator）
 
-#### UT-002: 摘要文字列生成
+#### UT-002: 摘要文字列生成（Generate）
 
 | No | テストケース | 入力 | 期待結果 |
 |----|-------------|------|---------|
@@ -75,6 +75,102 @@
 | 9 | ポイント還元 | ポイント還元 | "ポイント還元" |
 | 10 | 払い戻し | 払い戻し処理 | "払戻しによる払出" |
 
+#### UT-002a: 摘要文字列生成（GenerateByDate — 日別集約）
+
+チャージ境界での分割、バス往復・乗り継ぎ検出、ポイント還元分離などを含む包括テスト。
+
+**基本動作（TC001〜TC007）:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| TC001 | 履歴なし | 空リスト | 0件 |
+| TC002 | 1日1回利用 | 12/9: 天神→博多, 210円, 残高4790 | 1件, Summary="鉄道（天神～博多）" |
+| TC003 | 1日チャージのみ | 12/5: チャージ3000円, 残高8000 | 1件, IsCharge=true, Summary="役務費によりチャージ" |
+| TC004 | 1日利用とチャージ | 12/9: 天神→博多 210円 + チャージ3000円 | 2件（チャージ→利用の順） |
+| TC005 | 3日間利用 | 11/30, 12/1, 12/2 各1回利用 | 3件（日付昇順） |
+| TC006 | 3日間チャージ | 12/1, 12/5, 12/8 各チャージ | 3件（全てIsCharge=true、日付昇順） |
+| TC007 | 複数日・利用とチャージ混在 | 11/30利用, 12/1チャージ+利用, 12/2チャージ | 4件（日付別に分離） |
+
+**同日複数利用の集約（TC008〜TC010）:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| TC008 | 同日往復 | 12/9: 天神→博多(残高4790) + 博多→天神(残高4580) | 1件, "鉄道（天神～博多 往復）" |
+| TC009 | 同日鉄道+バス | 12/9: 天神→博多(210円) + バス天神～博多駅(230円) | 1件, "鉄道（天神～博多）、バス（天神～博多駅）" |
+| TC010 | 同日乗継 | 12/9: 天神→中洲川端(210円) + 中洲川端→貝塚(260円) | 1件, "鉄道（天神～貝塚）" |
+
+**チャージ境界分割（TC039〜TC041）:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| TC039 | チャージが往復の間 | 薬院→博多(310円,残高690) → チャージ1000円(残高1690) → 博多→薬院(310円,残高1380) | 3件:「鉄道（薬院～博多）」→チャージ→「鉄道（博多～薬院）」 |
+| TC040 | チャージが利用の前 | チャージ1000円(残高2000) → 天神→博多(210円,残高1790) → 博多→天神(210円,残高1580) | 2件: チャージ→「鉄道（天神～博多 往復）」 |
+| TC041 | 複数日混在 | 12/8: 往復（チャージなし）, 12/9: チャージ挟み込み | 4件: 12/8往復, 12/9は3件分割 |
+
+**暗黙のポイント還元検出（TC042〜TC046, Issue #942）:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| TC042 | 暗黙のポイント還元と鉄道の分離 | 薬院→博多往復(各210円) + 暗黙還元(Amount=-240) | 2件:「鉄道（薬院～博多 往復）」+「ポイント還元」 |
+| TC043 | Generate()での暗黙還元 | 同上 | "鉄道（薬院～博多 往復）"（還元は除外） |
+| TC044 | 暗黙還元のみ | Amount=-240のみ | "ポイント還元" |
+| TC045 | IsImplicitPointRedemption判定 | 各パターン | 負額かつ非チャージかつ非明示還元→true |
+| TC046 | 明示・暗黙還元混在 | 鉄道(210円) + 暗黙還元(-240) + 明示還元(-100) | 2件:「鉄道（薬院～博多）」+「ポイント還元」 |
+
+**福岡3社混在テスト（TC034〜TC038）:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| TC034 | JR・地下鉄・西鉄混在 | 博多→吉塚(JR170円) + 天神南→薬院(地下鉄210円) + 薬院→大橋(西鉄220円) | "鉄道（博多～吉塚、天神南～大橋）" |
+| TC035 | 空港線→箱崎線乗継 | 天神→中洲川端 + 中洲川端→貝塚 | "鉄道（天神～貝塚）" |
+| TC036 | 七隈線単独往復 | 六本松→天神南(260円) + 天神南→六本松(260円) | "鉄道（六本松～天神南 往復）" |
+| TC037 | 西鉄急行区間往復 | 西鉄二日市→西鉄福岡(天神)(380円) 往復 | "鉄道（西鉄二日市～西鉄福岡(天神) 往復）" |
+| TC038 | 地下鉄＋西鉄乗り継ぎ往復 | 天神↔博多(地下鉄) + 西鉄福岡(天神)↔西鉄二日市(西鉄) | "鉄道（博多～西鉄二日市 往復）" |
+
+**テストクラス:** `SummaryGeneratorTests`, `SummaryGeneratorComprehensiveTests`
+
+#### UT-002b: バス往復・乗り継ぎ検出（Issue #985）
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | バス往復 | 薬院大通→西鉄平尾駅(210円) + 西鉄平尾駅→薬院大通(210円) | "バス（薬院大通～西鉄平尾駅 往復）" |
+| 2 | バス片道 | 薬院大通→西鉄平尾駅(210円)のみ | "バス（薬院大通～西鉄平尾駅）" |
+| 3 | バス停名に経路区切りなし | "天神" + "博多" | "バス（天神、博多）" |
+| 4 | バス往復+片道混在 | 薬院↔天神(往復) + 博多→吉塚(片道) | "薬院～天神 往復"と"博多～吉塚"を含む |
+| 5 | 鉄道+バス往復混在 | 博多→天神(鉄道260円) + 天神↔渡辺通(バス往復) | "鉄道（博多～天神）"と"バス（天神～渡辺通 往復）" |
+| 6 | バス停名未入力 | "★"×2 | "バス（★）"（往復検出されない） |
+| 7 | バス乗り継ぎ | 薬院大通→天神(210円) + 天神→博多駅(210円) | "バス（薬院大通～博多駅）" |
+| 8 | バス3区間乗り継ぎ | 薬院大通→天神→西新→藤崎 | "バス（薬院大通～藤崎）" |
+| 9 | バス乗り継ぎ往復 | 薬院→天神→博多(行き) + 博多→天神→薬院(帰り) | "バス（薬院～博多 往復）" |
+| 10 | 乗り継ぎにならない（非連続） | 薬院大通→天神 + 博多→吉塚 | "バス（薬院大通～天神、博多～吉塚）" |
+
+**テストクラス:** `SummaryGeneratorTests`
+
+#### UT-002c: 年度途中繰越（Issue #510, #599）
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 繰越摘要生成 | month=1 | "1月から繰越" |
+| 2 | 繰越摘要生成 | month=12 | "12月から繰越" |
+| 3 | 繰越摘要判定（正） | "1月から繰越" | true |
+| 4 | 繰越摘要判定（負:「より」） | "5月より繰越" | false |
+| 5 | 繰越摘要判定（負:無効月） | "13月から繰越" | false |
+| 6 | 繰越日計算 | 登録日=2026-02-09, month=1 | 2026-02-01 |
+| 7 | 繰越日計算（12月） | 登録日=2026-01-15, month=12 | 2026-01-01 |
+| 8 | 繰越日計算（年度開始） | 登録日=2026-04-01, month=3 | 2026-04-01 |
+
+**テストクラス:** `SummaryGeneratorTests`
+
+#### UT-002d: GroupIdによる往復・乗継検出抑制（Issue #633）
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | 個別GroupIdで往復抑制 | 博多→天神(GroupId=1) + 天神→博多(GroupId=2) | "鉄道（博多～天神、天神～博多）"（往復にならない） |
+| 2 | 個別GroupIdで乗継抑制 | 博多→天神(GroupId=1) + 天神→薬院(GroupId=2) | "鉄道（博多～天神、天神～薬院）"（統合されない） |
+| 3 | GroupId=nullで通常検出 | 博多→天神(null) + 天神→博多(null) | "鉄道（博多～天神 往復）" |
+
+**テストクラス:** `SummaryGeneratorTests`
+
 ---
 
 ### 2.3 和暦変換（WarekiConverter）
@@ -88,6 +184,14 @@
 | 3 | 平成最終日 | 2019-04-30 | "H31.04.30" |
 | 4 | 1桁月日 | 2025-01-05 | "R7.01.05" |
 | 5 | 年度開始日 | 2025-04-01 | "R7.04.01" |
+| 6 | 年月変換 | 2025-11-05 | "R7.11" |
+| 7 | 和暦→西暦変換 | "R7.01.05" | 2025-01-05 |
+| 8 | 和暦→西暦（無効） | "X1.01.01" | null |
+| 9 | 年度計算 | 2026-03-15 | 年度=2025 |
+| 10 | 年度開始日 | 年度2025 | 2025-04-01 |
+| 11 | 年度末日 | 年度2025 | 2026-03-31 |
+
+**テストクラス:** `WarekiConverterTests`
 
 ---
 
@@ -109,16 +213,50 @@
 
 #### UT-005: 履歴分割処理
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | 2グループに分割 | 元Ledger更新 + 新Ledger1件作成 |
-| 2 | 3グループ以上に分割 | 元Ledger更新 + 新Ledger(N-1)件作成 |
-| 3 | 金額再計算（CalculateGroupFinancials） | グループ内の受入/払出/残額が正しく算出される |
-| 4 | 分割後にGroupIdがクリアされる | 全DetailのGroupId = null |
-| 5 | 分割後に摘要が再生成される | SummaryGeneratorで再生成された値 |
-| 6 | 空摘要の場合「（分割）」がフォールバック | summary = "（分割）" |
-| 7 | IsLentRecordが常にfalse | 新規Ledger.IsLentRecord = false |
-| 8 | 操作ログが記録される | OperationLogger.LogAsync("SPLIT") |
+**バリデーション:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 1グループのみ | Detail2件とも GroupId=1 | Success=false, "2つ以上のグループ" |
+| 2 | GroupId未設定 | Detail2件とも GroupId=null | Success=false, "2つ以上のグループ" |
+| 3 | Ledger未存在 | LedgerId=999（存在しない） | Success=false, "見つかりません" |
+
+**分割処理:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 4 | 2グループ分割 | 博多→天神(260円,残高740,GrpId=1) + 天神→赤坂(200円,残高540,GrpId=2) | Success=true, 新Ledger1件作成, CreatedLedgerIds=[100] |
+| 5 | 3グループ分割 | 3区間(博多→天神→赤坂→薬院) 各別GroupId | Success=true, 新Ledger2件作成 |
+
+**金額計算（CalculateGroupFinancials）:**
+
+| No | テストケース | 入力データ | 期待: income | 期待: expense | 期待: balance |
+|----|-------------|-----------|-------------|--------------|--------------|
+| 6 | 利用のみ | 博多→天神(260円,残高740) + 天神→赤坂(200円,残高540) | 0 | 460 | 540 |
+| 7 | チャージのみ | チャージ3000円, 残高3500 | 3000 | 0 | 3500 |
+| 8 | 3件の最終残高 | 3区間(残高740→540→340) | 0 | 660 | 340（時系列順で最後） |
+| 9 | ポイント還元 | ポイント還元100円, 残高600 | 0 | 0（expenseに含まない） | 600 |
+| 10 | 利用+ポイント還元（Issue #1004） | 薬院→博多(420円,残高1456) + ポイント還元(240円,残高1696) 同日 | 0 | 420 | **1696**（還元が時系列的に後。残高チェーン順で判定） |
+| 11 | チャージ+利用 同日 | チャージ3000円(残高3500) + 博多→天神(260円,残高3240) 同日 | 3000 | 260 | 3240 |
+
+**FeliCa順序互換性:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 12 | FeliCa逆順入力でも正しい残高 | 3区間(SequenceNumber=3,2,1 ※新しい順) 残高740,540,340 | balance=340（時系列最後） |
+| 13 | 同日FeliCa逆順 | 3区間すべて同日同時刻, SequenceNumber=3,2,1 | balance=340 |
+| 14 | FeliCa逆順の2グループ分割 | GrpId=1(博多→天神), GrpId=2(天神→赤坂+赤坂→薬院) | 元Ledger.Balance=740, 新Ledger.Balance=340 |
+
+**メタデータ・副作用:**
+
+| No | テストケース | 検証内容 | 期待結果 |
+|----|-------------|---------|---------|
+| 15 | メタデータコピー | CardIdm, StaffName, LenderIdm, ReturnerIdm, LentAt, ReturnedAt | すべて元Ledgerからコピーされる |
+| 16 | GroupIdクリア | 分割後の全DetailのGroupId | すべてnull |
+| 17 | 摘要再生成 | 各グループの摘要 | SummaryGeneratorで再生成（博多～天神、天神～赤坂） |
+| 18 | 操作ログ | 操作ログ記録 | Action="SPLIT", TargetTable="ledger" |
+| 19 | 金額再計算（2グループ） | 元Ledger(Expense=460,Balance=540) → 分割 | 元:Expense=260,Balance=740 / 新:Expense=200,Balance=540 |
+| 20 | 逆順挿入（FeliCa互換） | GrpId=2に天神→赤坂+赤坂→薬院 | insertedDetails[0]=薬院(新しい), [1]=赤坂(古い) |
 
 **テストクラス:** `LedgerSplitServiceTests`
 
@@ -128,13 +266,15 @@
 
 #### UT-006: 残高チェーン整合性検証
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | 整合性のある履歴チェーン | IsConsistent = true |
-| 2 | 残高不整合がある場合 | IsConsistent = false、Inconsistenciesに不整合レコード |
-| 3 | 前回残高+受入-払出≠今回残高 | 期待残高と実際残高の差分を検出 |
-| 4 | 1件のみの場合 | IsConsistent = true（比較対象なし） |
-| 5 | 直前Ledgerを含む検証 | CheckConsistencyWithPreviousAsync正常動作 |
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | 空リスト | 空 | IsConsistent=true, Inconsistencies=空 |
+| 2 | 1件のみ | Income=1000, Expense=0, Balance=1000 | IsConsistent=true |
+| 3 | 整合チェーン3件 | 1000(チャージ)→800(利用-200)→580(利用-220) | IsConsistent=true |
+| 4 | 不整合1箇所 | 1000→**750**(期待800, 利用-200)→530 | IsConsistent=false, Inconsistencies=[Ledger2: 期待800, 実際750] |
+| 5 | 不整合2箇所 | 1000→750(期待800)→700(期待650) | IsConsistent=false, Inconsistencies.Count=2 |
+| 6 | チャージ+利用混在 | 500(繰越)→3500(チャージ+3000)→3290(利用-210) | IsConsistent=true |
+| 7 | 同日ポイント還元+利用（Issue #1004） | 3/9:残高1876 → 3/10:利用(残高1456) → 3/10:還元(残高1696)。ID順(16→17)だと不整合だが**残高チェーン順**(17→16)で整合 | IsConsistent=**true**（LedgerOrderHelper.ReorderByBalanceChainで並替え後に検証） |
 
 **テストクラス:** `LedgerConsistencyCheckerTests`
 
@@ -144,95 +284,205 @@
 
 #### UT-007: Ledger順序の復元
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | 正常なチェーンの順序維持 | 入力順序が維持される |
-| 2 | 順序が乱れたチェーンの復元 | 残高チェーンに基づく正しい順序 |
-| 3 | 前回残高指定ありの場合 | precedingBalanceから開始して正しい順序 |
-| 4 | 特殊レコード（チャージ等）の処理 | 特殊レコードが正しく位置付けられる |
-| 5 | 空リストの場合 | 空リストが返される |
+| No | テストケース | 入力データ | precedingBalance | 期待結果 |
+|----|-------------|-----------|-----------------|---------|
+| 1 | 空リスト | 空 | - | 空 |
+| 2 | 1件 | 鉄道(Expense=300, Balance=9700) | - | そのまま |
+| 3 | 異なる日付 | 6/15(Id=2,Balance=9400) + 6/10(Id=1,Balance=9700) | - | Id=1→Id=2（日付順） |
+| 4 | 同日チャージ→利用 | チャージ(Income=3000,Balance=4000) + 利用(Expense=200,Balance=3800) | 1000 | チャージ→利用 |
+| 5 | 同日利用→チャージ→利用 | 利用(Exp=300,Bal=9700) + チャージ(Inc=5000,Bal=14700) + 利用(Exp=300,Bal=14400) | 10000 | 利用→チャージ→利用 |
+| 6 | 新規購入は常に先頭 | 利用(Bal=1700) + 新規購入(Inc=2000,Bal=2000) | - | 新規購入→利用 |
+| 7 | 繰越は常に先頭 | 利用(Bal=4700) + "3月から繰越"(Inc=5000,Bal=5000) | - | 繰越→利用 |
+| 8 | precedingBalanceなしで自動検出 | 3件（利用→チャージ→利用、残高9700→14700→14400） | なし | 正しい順序 |
+| 9 | 不整合残高→Id順フォールバック | 3件（Balance=500,800,100、チェーン不成立） | 9999 | Id=1→2→3（Id昇順） |
+| 10 | 複数日独立ソート | 6/5:チャージ + 6/10:利用→チャージ→利用 | 0 | 日ごとに独立して残高チェーン順 |
+| 11 | 同額チャージ+利用（利用→チャージ） | チャージ(Inc=500,Bal=1500) + 利用(Exp=500,Bal=1000) | 1500 | 利用→チャージ |
+| 12 | 同額チャージ+利用（チャージ→利用） | チャージ(Inc=500,Bal=1500) + 利用(Exp=500,Bal=1000) | 1000 | チャージ→利用 |
 
 **テストクラス:** `LedgerOrderHelperTests`
 
 ---
 
-### 2.8 入力バリデーション（ValidationService）
+### 2.8 残高チェーン順ソート（LedgerDetailChronologicalSorter）
+
+#### UT-007a: LedgerDetail残高チェーン順ソート
+
+残高チェーンアルゴリズム: 各明細の「処理前残高(balance_before)」を逆算し、前の明細のBalance == 次の明細のbalance_before となるチェーンを辿る。
+- 利用（残高減少）: balance_before = Balance + Amount
+- チャージ・ポイント還元（残高増加）: balance_before = Balance - Amount
+
+| No | テストケース | 入力データ（残高チェーン） | 期待順序 |
+|----|-------------|------------------------|---------|
+| 1 | 空リスト | 空 | 空 |
+| 2 | 1件 | 天神→博多(210円,残高790) | そのまま |
+| 3 | 2件（逆順入力） | [博多→天神(残高580), 天神→博多(残高790)] | [残高790, 残高580] |
+| 4 | 2件（正順入力） | [天神→博多(残高790), 博多→天神(残高580)] | [残高790, 残高580] |
+| 5 | チャージ挟み3件 | [利用(残高1580), チャージ(残高1790), 利用(残高790)] | [残高790→1790→1580] |
+| 6 | チャージが先頭 | [利用(残高1290), チャージ(残高1500)] | [残高1500→1290] |
+| 7 | Balance欠損（preserveOrder=true） | [天神→博多(Balance=null), 博多→天神(Balance=580)] | 入力順を維持 |
+| 8 | Balance欠損（preserveOrder=false） | [天神→博多(Balance=null), 博多→天神(Balance=580)] | 逆順（FeliCa入力想定） |
+| 9 | 循環チェーン | [A→B(Amount=210,Balance=500), B→A(Amount=210,Balance=710)] | 例外なし（フォールバック） |
+| 10 | 入力順序に非依存 | 3件を3パターンの順序で入力 | すべて同じ結果 [残高790→580→370] |
+| 11 | ポイント還元（Issue #1004） | [還元(240円,残高1696,IsPointRedemption=true), 利用(420円,残高1456)] | [残高1456（利用）→残高1696（還元）] |
+| 12 | チャージ+利用+還元 | [還元(240円,残高1320), チャージ(1000円,残高1500), 利用(420円,残高1080)] | [残高1500→1080→1320] |
+
+**テストクラス:** `LedgerDetailChronologicalSorterTests`
+
+---
+
+### 2.9 入力バリデーション（ValidationService）
 
 #### UT-008: 入力値の検証
 
+**カードIDm:**
+
 | No | テストケース | 入力 | 期待結果 |
 |----|-------------|------|---------|
-| 1 | 正しいIDm（16桁16進数） | "0123456789ABCDEF" | IsValid = true |
-| 2 | IDm長さ不正 | "01234567" | IsValid = false |
-| 3 | IDm非16進数文字 | "GHIJKLMNOPQRSTUV" | IsValid = false |
-| 4 | カード番号最大長超過 | 21文字以上 | IsValid = false |
-| 5 | 職員名必須チェック | "" | IsValid = false |
-| 6 | 職員名最大長超過 | 51文字以上 | IsValid = false |
-| 7 | 警告残高範囲チェック（正常） | 5000 | IsValid = true |
-| 8 | 警告残高範囲チェック（超過） | 25000 | IsValid = false |
-| 9 | バス停名最大長チェック | 101文字以上 | IsValid = false |
+| 1 | 正しいIDm（大文字） | "0123456789ABCDEF" | IsValid=true |
+| 2 | 正しいIDm（小文字） | "abcdef0123456789" | IsValid=true |
+| 3 | 正しいIDm（実在パターン） | "07FE112233445566" | IsValid=true |
+| 4 | null | null | IsValid=false, "入力されていません" |
+| 5 | 空文字 | "" | IsValid=false, "入力されていません" |
+| 6 | 空白のみ | "   " | IsValid=false, "入力されていません" |
+| 7 | 長さ不足（9桁） | "012345678" | IsValid=false, "16桁" |
+| 8 | 長さ超過（17桁） | "0123456789ABCDEFG" | IsValid=false, "16桁" |
+| 9 | 非16進数文字 | "0123456789ABCDEG" | IsValid=false, "16進数" |
+
+**カード管理番号:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 10 | 正常 | "H-001" | IsValid=true |
+| 11 | 空（自動採番） | "" | IsValid=true |
+| 12 | 20文字超過 | "A"×21 | IsValid=false, "20文字" |
+| 13 | 日本語文字 | "カード001" | IsValid=false, "英数字" |
+
+**カード種別:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 14 | はやかけん | "はやかけん" | IsValid=true |
+| 15 | nimoca | "nimoca" | IsValid=true |
+| 16 | null | null | IsValid=false, "選択" |
+
+**職員名:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 17 | 正常 | "山田太郎" | IsValid=true |
+| 18 | 50文字ちょうど | "あ"×50 | IsValid=true |
+| 19 | null | null | IsValid=false, "必須" |
+| 20 | 51文字超過 | "あ"×51 | IsValid=false, "50文字" |
+
+**警告残高:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 21 | 0円 | 0 | IsValid=true |
+| 22 | 20000円 | 20000 | IsValid=true |
+| 23 | 負数 | -1 | IsValid=false, "0円以上" |
+| 24 | 上限超過 | 20001 | IsValid=false, "20,000円以下" |
+
+**ValidationResult変換:**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 25 | Success→bool | ValidationResult.Success() | true |
+| 26 | Failure→bool | ValidationResult.Failure("エラー") | false |
 
 **テストクラス:** `ValidationServiceTests`
 
 ---
 
-### 2.9 バックアップサービス（BackupService）
+### 2.10 バックアップサービス（BackupService）
 
 #### UT-009: バックアップ・リストア処理
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | 自動バックアップ成功 | バックアップファイルが作成される |
-| 2 | バックアップパス未設定時のフォールバック | デフォルトパスが使用される |
-| 3 | 無効なパスのフォールバック | デフォルトパスにフォールバック |
-| 4 | バックアップファイル一覧取得 | 日時降順でファイル一覧 |
-| 5 | 30世代超過時の古いファイル削除 | 最新30件のみ保持 |
-| 6 | リストア成功 | DB接続クローズ→ファイル差替え→成功 |
-| 7 | リストア失敗時のロールバック | .tempから元DBを復元 |
+**自動バックアップ:**
+
+| No | テストケース | 条件 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 正常バックアップ | デフォルト設定 | ファイル名が"backup_"で始まり".db"で終わる |
+| 2 | バックアップ内容 | デフォルト設定 | ファイルサイズがソースDBと一致 |
+| 3 | カスタムパス | backup_path=C:\Backup | 指定パスに作成 |
+| 4 | パス未設定 | backup_path="" | デフォルトパスにフォールバック |
+| 5 | 30世代超過 | 32ファイル存在時 | 30件以下に削減 |
+| 6 | ディレクトリ未存在 | 新規パス | ディレクトリが自動作成される |
+| 7 | 29世代以下 | 29ファイル存在時 | 全30件保持（削除なし） |
+| 8 | 空ディレクトリ | ファイルなし | 正常に1件作成 |
+
+**リストア:**
+
+| No | テストケース | 条件 | 期待結果 |
+|----|-------------|------|---------|
+| 9 | 正常リストア | 有効なバックアップファイル | 成功、サイズ一致 |
+| 10 | ファイル未存在 | 存在しないパス | false |
+| 11 | ファイルロック中 | FileShare.Noneでロック | false、元ファイル残存 |
+| 12 | 既存DB上書き | 異なる内容のDB | リストア後の内容がバックアップと一致 |
+| 13 | DB接続中のリストア | 接続オープン中 | 接続クローズ→リストア→再接続可能 |
+
+**ファイル一覧取得:**
+
+| No | テストケース | 条件 | 期待結果 |
+|----|-------------|------|---------|
+| 14 | 一覧取得 | 3ファイル存在 | 3件、"backup_"始まり".db"終わり |
+| 15 | 日時降順ソート | 12:00, 13:00, 14:00 | 14:00→13:00→12:00 |
+| 16 | ディレクトリ未存在 | 存在しないパス | 空リスト |
+| 17 | 他ファイル除外 | backup_*.db + other.db + backup.txt | backup_*.dbのみ |
 
 **テストクラス:** `BackupServiceTests`
 
 ---
 
-### 2.10 キャッシュサービス（CacheService）
+### 2.11 キャッシュサービス（CacheService）
 
 #### UT-010: メモリキャッシュ操作
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | キャッシュの取得・設定 | Set→Get で同じ値が返る |
-| 2 | GetOrCreateAsync初回呼び出し | factory関数が実行される |
-| 3 | GetOrCreateAsync2回目（キャッシュヒット） | factory関数が実行されない |
-| 4 | キャッシュの無効化（Invalidate） | 指定キーが削除される |
-| 5 | プレフィックスによる一括無効化 | 該当キーが全て削除される |
-| 6 | 全クリア（Clear） | 全キーが削除される |
-| 7 | 有効期限切れ | 期限後はnull/factory再実行 |
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | Set→Get | Set("test:key","test-value",1min) | Get→"test-value" |
+| 2 | 未登録キー | Get("non-existent") | null（参照型）/ 0（値型） |
+| 3 | 複合オブジェクト | Set({Id=1,Name="Test"}) | Get→同じプロパティ |
+| 4 | 上書き | Set("original")→Set("updated") | Get→"updated" |
+| 5 | GetOrCreate（ミス） | キャッシュなし + factory | factory実行、"factory-value" |
+| 6 | GetOrCreate（ヒット） | 事前Set済み + factory | factory非実行、"cached-value" |
+| 7 | GetOrCreate結果キャッシュ | 2回呼び出し | factory1回のみ実行 |
+| 8 | Invalidate | Set key1,key2 → Invalidate("key1") | key1=null, key2="value2" |
+| 9 | プレフィックス無効化 | "card:all","card:lent","staff:all" → InvalidateByPrefix("card:") | card系=null, staff="value3" |
+| 10 | 全クリア | Set 3キー → Clear() | すべてnull |
+| 11 | 期限切れ | Set(100ms期限) → 150ms待機 | null |
+| 12 | 期限内 | Set(10s期限) → 50ms待機 | 値あり |
+| 13 | 並行アクセス | 100並行タスクでSet/Get | 全結果一致（スレッドセーフ） |
 
 **テストクラス:** `CacheServiceTests`
 
 ---
 
-### 2.11 ViewModelBase基底クラス
+### 2.12 ViewModelBase基底クラス
 
 #### UT-011: ビジー状態・プログレス管理
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | 初期状態 | IsBusy=false, IsIndeterminate=true |
-| 2 | SetBusy(true) | IsBusy=true, BusyMessage設定 |
-| 3 | SetBusy(false) | プログレスがリセットされる |
-| 4 | SetProgress | IsIndeterminate=false, 値更新 |
-| 5 | BeginBusy スコープ開始/終了 | IsBusy遷移 true→false |
-| 6 | BeginCancellableBusy | CanCancel=true |
-| 7 | CancelOperation | IsCancellationRequested=true |
-| 8 | BusyScope.ReportProgress | プログレス値更新 |
-| 9 | BusyScope.ThrowIfCancellationRequested | キャンセル後にOperationCanceledException |
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 初期状態 | - | IsBusy=false, IsIndeterminate=true, ProgressValue=0, ProgressMax=100, CanCancel=false |
+| 2 | SetBusy(true) | SetBusy(true, "処理中...") | IsBusy=true, BusyMessage="処理中..." |
+| 3 | SetBusy(false) | SetBusy(true)→SetProgress(50,200)→SetBusy(false) | IsBusy=false, ProgressValue=0, ProgressMax=100, IsIndeterminate=true |
+| 4 | SetProgress | SetProgress(30, 100) | IsIndeterminate=false, ProgressValue=30, ProgressMax=100 |
+| 5 | SetProgress（メッセージ付き） | SetProgress(5, 10, "5/10 完了") | BusyMessage="5/10 完了" |
+| 6 | BeginBusy スコープ | using(BeginBusy("読み込み中...")) | 開始:IsBusy=true → 終了:IsBusy=false |
+| 7 | BeginCancellableBusy | using(StartCancellableBusy()) | CanCancel=true, Token.CanBeCanceled=true |
+| 8 | CancelOperation | StartCancellableBusy()→CancelOperation() | IsCancellationRequested=true, BusyMessage="キャンセル中..." |
+| 9 | CancelOperation（トークン伝播） | 同上 | Token.IsCancellationRequested=true |
+| 10 | CancelOperation（非キャンセルスコープ） | BeginBusy()→CancelOperation() | IsCancellationRequested=false（無視） |
+| 11 | ReportProgress | StartCancellableBusy()→ReportProgress(50,100,"50%完了") | ProgressValue=50, BusyMessage="50%完了" |
+| 12 | ThrowIfCancellationRequested（未キャンセル） | StartCancellableBusy()→ThrowIfCancellation... | 例外なし |
+| 13 | ThrowIfCancellationRequested（キャンセル後） | CancelOperation()→ThrowIfCancellation... | OperationCanceledException |
 
 **テストクラス:** `ViewModelBaseTests`
 
 ---
 
-### 2.12 ErrorDialogHelperエラー情報マッピング
+### 2.13 ErrorDialogHelperエラー情報マッピング
 
 #### UT-012: 例外→エラーコード変換
 
@@ -255,7 +505,7 @@
 
 ---
 
-### 2.13 FileOperationException例外
+### 2.14 FileOperationException例外
 
 #### UT-013: ファイル操作例外のファクトリメソッド
 
@@ -275,19 +525,479 @@
 
 ---
 
-### 2.14 DtoMapperマッピング
+### 2.15 DtoMapperマッピング
 
 #### UT-014: DTO変換
 
-| No | テストケース | 期待結果 |
-|----|-------------|---------|
-| 1 | Staff → StaffDto変換 | 全プロパティが正しくマッピング |
-| 2 | IcCard → CardDto変換 | 全プロパティが正しくマッピング |
-| 3 | Ledger → LedgerDto変換 | Detail含む全プロパティがマッピング |
-| 4 | null入力 | 例外またはnull返却 |
-| 5 | コレクション変換 | リスト全要素が正しく変換 |
+**Entity→DTO変換:**
+
+| No | テストケース | 入力 | 検証内容 |
+|----|-------------|------|---------|
+| 1 | IcCard→CardDto | 全プロパティ設定済み, staffName="山田太郎" | 全プロパティ一致 |
+| 2 | IcCard→CardDto（未貸出） | IsLent=false | LentStaffName=null, LentAt=null |
+| 3 | CardDto表示プロパティ | IsLent=true, LentAt=2025/1/15 10:30 | DisplayName="はやかけん H-001", LentStatusDisplay="貸出中", LentAtDisplay="2025/01/15 10:30" |
+| 4 | CardDto（在庫） | IsLent=false | LentStatusDisplay="在庫" |
+| 5 | Staff→StaffDto | 全プロパティ設定済み | 全プロパティ一致 |
+| 6 | StaffDto表示（番号あり） | Name="山田太郎", Number="001" | DisplayName="001 山田太郎" |
+| 7 | StaffDto表示（番号なし） | Name="山田太郎", Number=null | DisplayName="山田太郎" |
+| 8 | Ledger→LedgerDto | Detail含む全プロパティ | DateDisplayに"R7"含む |
+| 9 | LedgerDto金額表示 | Income=1000, Expense=210, Balance=12345 | "1,000", "210", "12,345" |
+| 10 | LedgerDto金額表示（0） | Income=0, Expense=0 | ""（空文字） |
+| 11 | LedgerDetail→LedgerDetailDto | 全プロパティ設定 | UseDateDisplay="2025/01/15 09:30" |
+| 12 | RouteDisplay（鉄道） | EntryStation="博多駅", ExitStation="天神駅" | "博多駅～天神駅" |
+| 13 | RouteDisplay（チャージ） | IsCharge=true | "チャージ" |
+| 14 | RouteDisplay（バス・停名あり） | IsBus=true, BusStops="博多駅前→天神" | "バス（博多駅前→天神）" |
+| 15 | RouteDisplay（バス・停名なし） | IsBus=true, BusStops=null | "バス（★）" |
+
+**DTO→Entity変換:**
+
+| No | テストケース | 入力 | 検証内容 |
+|----|-------------|------|---------|
+| 16 | CardDto→IcCard | 全プロパティ設定 | LentAt → entity.LastLentAt |
+| 17 | StaffDto→Staff | 全プロパティ設定 | 全プロパティ一致 |
+| 18 | SettingsDto→AppSettings | 全プロパティ設定 | 全プロパティ一致 |
 
 **テストクラス:** `DtoMapperTests`
+
+---
+
+### 2.16 CSVエクスポート（CsvExportService）
+
+#### UT-015: CSVエクスポート処理
+
+**カードエクスポート:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | 正常2件 | Suica/001 + PASMO/002 | Success=true, ExportedCount=2, ヘッダ+2行 |
+| 2 | 削除済み含む | 1件削除済み, includeDeleted=true | 2件出力、削除フラグ列に"0"/"1" |
+| 3 | 0件 | 空リスト | ヘッダ行のみ |
+| 4 | 特殊文字エスケープ | CardType="Su,ica", Note="テスト\"備考\"" | カンマ→引用符囲み、引用符→二重引用符 |
+
+**Ledgerエクスポート:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 5 | 正常2件 | 鉄道(Expense=260,Balance=9740) + チャージ(Income=5000) | Success=true, ExportedCount=2 |
+| 6 | カード別グルーピング | カードA×3件 + カードB×2件 | カード種別→管理番号順でグループ化 |
+| 7 | カード内日付順 | 1/20, 1/5, 1/10（入力順バラバラ） | 1/5→1/10→1/20（昇順） |
+| 8 | カード種別→番号順ソート | nimoca/001, nimoca/002, はやかけん/001 | nimoca/001→002→はやかけん/001 |
+| 9 | 同日ポイント還元+利用（Issue #1004） | 3/10: 還元(Id=16,残高1696) + 利用(Id=17,残高1456) | 利用(1456)→還元(1696)（**残高チェーン順**、Id順ではない） |
+| 10 | 同日チャージ+利用 | 3/4: チャージ(残高2726) + 利用(残高2306) | チャージ→利用（残高チェーン順） |
+
+**LedgerDetailエクスポート:**
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 11 | 正常2件 | 博多→天神(Seq=2) + 天神→博多(Seq=1) | 時系列順（残高チェーン順）で出力 |
+| 12 | 0件 | 空 | ヘッダ行のみ |
+| 13 | NULL値 | UseDate=null, 駅名=null, Amount=null | 空欄で出力 |
+| 14 | ブール値 | IsCharge=true / IsPointRedemption=true / IsBus=true | "1"/"0"で出力 |
+| 15 | 特殊文字 | EntryStation="新宿,東口", ExitStation="渋谷\"駅\"" | エスケープ処理 |
+| 16 | SequenceNumber順≠残高チェーン順 | Seq=20(残高1316) + Seq=1(残高1526) | 残高チェーン順:1526→1316 |
+| 17 | 同日別Ledger | LedgerId=9(残高646,436) + LedgerId=8(残高216,6) | LedgerId=9→8（残高チェーン順） |
+
+**テストクラス:** `CsvExportServiceTests`
+
+---
+
+### 2.17 CSVインポート（CsvImportService）
+
+#### UT-016: CSVインポート処理
+
+| No | テストケース | 入力データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | カード正常インポート | 有効2件 | Success=true, ImportedCount=2, ErrorCount=0 |
+| 2 | 既存カードスキップ | 登録済みカード, skipExisting=true | ImportedCount=0, SkippedCount=1 |
+| 3 | IDm不正 | "INVALID_IDM" | Success=false, エラー"IDmの形式" |
+| 4 | 必須フィールド欠損 | CardIdm空 | "カードIDmは必須" |
+| 5 | ヘッダのみ | データ行なし | "データがありません" |
+| 6 | 職員正常インポート | 有効2件 | Success=true, ImportedCount=2 |
+| 7 | 職員名欠損 | Name空 | "氏名は必須" |
+| 8 | カードプレビュー | 新規2件 | IsValid=true, NewCount=2, Action=Insert |
+| 9 | プレビュー（既存スキップ） | 登録済み1件, skipExisting=true | SkipCount=1, Action=Skip |
+| 10 | プレビュー（既存更新） | 登録済み(番号異なる), skipExisting=false | UpdateCount=1, Action=Update |
+| 11 | 引用符フィールド | カンマ含む値 | 正しくパース |
+| 12 | エスケープ引用符 | 二重引用符 | 正しくパース |
+
+**テストクラス:** `CsvImportServiceTests`
+
+---
+
+### 2.18 貸出・返却サービス（LendingService）
+
+#### UT-017: 貸出処理（LendAsync）
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 正常貸出 | 有効な職員IDm+カードIDm | Success=true, OperationType=Lend |
+| 2 | 貸出レコード作成 | 同上 | CardIdm, LenderIdm, StaffName="テスト太郎", IsLentRecord=true, Summary="（貸出中）" |
+| 3 | 貸出中カード | IsLent=true | Success=false, "既に貸出中" |
+| 4 | カード未登録 | 存在しないCardIdm | Success=false, "カードが登録されていません" |
+| 5 | 職員未登録 | 存在しないStaffIdm | Success=false, "職員証が登録されていません" |
+| 6 | DB例外 | InsertAsync throws Exception | Success=false, "エラーが発生しました" |
+| 7 | 残高指定あり | balance=1500 | Balance=1500 |
+| 8 | 残高null（DB参照） | balance=null, DB最新残高=2300 | Balance=2300 |
+| 9 | 残高null+DB履歴なし | balance=null, DB空 | Balance=0 |
+| 10 | 残高0（DBフォールバックなし） | balance=0 | Balance=0, GetLatestLedgerAsync未呼出 |
+
+#### UT-017a: 返却処理（ReturnAsync）
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 正常返却 | 貸出中カード + 空利用明細 | Success=true, OperationType=Return |
+| 2 | 利用明細なし | 空リスト | HasBusUsage=false |
+| 3 | バス利用あり | IsBus=true, 200円 | HasBusUsage=true |
+| 4 | チャージあり | IsCharge=true, 3000円 | 別途チャージLedger作成(Income=3000) |
+| 5 | 残高不足警告 | 最新残高5000, 警告閾値10000 | IsLowBalance=true |
+| 6 | 未貸出カード | IsLent=false | Success=false, "貸出されていません" |
+| 7 | 貸出レコード未存在 | GetLentRecordAsync=null | Success=false, "貸出レコードが見つかりません" |
+| 8 | 複数日利用 | 3日分の利用明細 | 日別にLedger3件作成 |
+| 9 | 同日チャージ+利用 | チャージ+利用が同日 | 別々のLedger作成(Income/Expense分離) |
+| 10 | チャージLedgerの職員名 | チャージ3000円 | chargeLedger.StaffName=**null** |
+| 11 | ポイント還元の職員名 | ポイント還元500円 | pointLedger.StaffName=**null** |
+
+#### UT-017b: 残高不足パターン検出（DetectInsufficientBalancePattern）
+
+| No | テストケース | チャージ | 利用 | 期待結果 |
+|----|-------------|--------|------|---------|
+| 1 | 基本パターン | 10円(残高210) | 210円(残高0) | 検出: Charge.Amount=10, Usage.Amount=210 |
+| 2 | 通常チャージ | 3000円(残高5000) | 260円(残高4740) | 非検出（通常チャージ） |
+| 3 | 残高非ゼロ | 10円(残高210) | 210円(残高100) | 非検出（残高が残る） |
+| 4 | 残高不一致 | 10円(残高200≠210) | 210円(残高0) | 非検出 |
+| 5 | ポイント還元は除外 | 10円(残高210) | 210円(残高0,IsPointRedemption=true) | 非検出 |
+| 6 | 端数チャージ | 140円(残高216) | 210円(残高6) | 検出: Charge=140, Usage=210 |
+| 7 | ちょうどチャージ | 210円(残高210) | 210円(残高0) | 検出 |
+| 8 | 閾値境界 | 420円(残高520) | 420円(残高100) | 非検出（残高≥閾値100） |
+| 9 | 閾値未満 | 400円(残高499) | 400円(残高99) | 検出（残高<閾値100） |
+
+#### UT-017c: 残高不足マージ処理
+
+| No | テストケース | チャージ | 利用 | 期待結果 |
+|----|-------------|--------|------|---------|
+| 1 | 端数チャージマージ | 140円(残高216) | 210円(残高6) | Expense=70(210-140), Balance=6, Note="不足額140円…支払額210円" |
+
+#### UT-017d: 30秒ルール（再タッチ判定）
+
+| No | テストケース | 条件 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | タイムアウト内 | 貸出直後に同一カード | true |
+| 2 | 異なるカード | 貸出後に別カード | false |
+| 3 | 操作履歴なし | 初回チェック | false |
+| 4 | ClearHistory後 | 貸出→ClearHistory | false, LastProcessedCardIdm=null |
+| 5 | 貸出後の逆操作 | Lend後にチェック | LastOperationType=Lend（→Return実行） |
+| 6 | 返却後の逆操作 | Return後にチェック | LastOperationType=Return（→Lend実行） |
+
+#### UT-017e: 同日既存Ledger統合
+
+| No | テストケース | 既存Ledger | 新規利用 | 期待結果 |
+|----|-------------|-----------|---------|---------|
+| 1 | 同日利用統合 | 天神→博多(260円) | 博多→天神(260円) | 既存に統合, Expense=520, Summary="往復" |
+| 2 | 既存なし | なし | 博多→天神(260円) | 新規Ledger作成(Expense=260) |
+| 3 | 既存チャージ | チャージ(Income=3000) | 利用(260円) | 統合せず新規作成 |
+| 4 | 既存Noteあり | 不足額パターン(Note設定済み) | 利用(260円) | 統合せず新規作成 |
+
+#### UT-017f: 排他制御（CardLockManager）
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 同一カード同時貸出 | 2スレッドで同時LendAsync | 1件成功、1件失敗("既に貸出中"or"処理が実行中") |
+| 2 | 異なるカード同時貸出 | 2スレッドで異なるカードLend | 両方成功 |
+| 3 | 同一カード同時返却 | 2スレッドで同時ReturnAsync | 1件成功 |
+| 4 | ロックタイムアウト | 1スレッドがロック保持中に2スレッド目 | "処理が実行中" |
+| 5 | 連続10操作 | 10回連続LendAsync | デッドロックなし、全完了 |
+
+#### UT-017g: 履歴完全性チェック
+
+| No | テストケース | 履歴データ | 期待結果 |
+|----|-------------|-----------|---------|
+| 1 | 20件全て当月 | 20件すべて2月 | true |
+| 2 | 前月含む | 15件2月 + 5件1月 | false |
+| 3 | 20件未満 | 15件 | false |
+| 4 | 空 | 0件 | false |
+
+#### UT-017h: 貸出状態修復（RepairLentStatusConsistencyAsync）
+
+| No | テストケース | カード状態 | 貸出レコード | 期待結果 |
+|----|-------------|-----------|-------------|---------|
+| 1 | 正常（一致） | is_lent=1 | あり | 修復なし(count=0) |
+| 2 | 不整合（false→true） | is_lent=0 | あり | 修復(count=1)、true に更新 |
+| 3 | 不整合（true→false） | is_lent=1 | なし | 修復(count=1)、false に更新 |
+| 4 | 複数不整合 | A:false+レコードあり, B:true+なし, C:正常 | 修復(count=2) |
+
+**テストクラス:** `LendingServiceTests`
+
+---
+
+### 2.19 月次帳票データ構築（ReportDataBuilder）
+
+#### UT-018: 帳票データ構築
+
+| No | テストケース | 対象月 | 繰越残高 | 期待結果 |
+|----|-------------|-------|---------|---------|
+| 1 | カード未存在 | - | - | null |
+| 2 | 4月（年度初め・繰越あり） | 4月 | 5000 | Carryover.Income=5000, MonthlyTotal.Balance=4790 |
+| 3 | 4月（繰越なし） | 4月 | null | Carryover=null |
+| 4 | 4月（データなし） | 4月 | 5000 | MonthlyTotal.Balance=5000 |
+| 5 | 通常月（7月） | 7月 | - | Carryover.Balance=4000, CumulativeTotal.Income=5000, Expense=710, Balance=8790 |
+| 6 | 3月（年度末） | 3月 | - | CarryoverToNextYear設定あり, CumulativeTotal設定あり |
+| 7 | 貸出中レコード除外 | 5月 | - | Summary="（貸出中）"のレコードを除外 |
+| 8 | 1月（年度跨ぎ） | 1月 | - | 前年12月からの繰越, CumulativeTotal設定あり |
+| 9 | データなし月 | 6月 | - | Ledgers空, Income=0, Expense=0 |
+
+**テストクラス:** `ReportDataBuilderTests`
+
+---
+
+### 2.20 月次帳票Excel出力（ReportService）
+
+#### UT-019: 月次帳票出力
+
+| No | テストケース | 対象月 | 期待結果 |
+|----|-------------|-------|---------|
+| 1 | 1ヶ月分正常出力 | 6月 | Success=true, Excelファイル作成 |
+| 2 | 4月（前年度繰越行） | 4月 | Row5に繰越行、Date="R6.4.1", Summary="前年度より繰越", Income=10000 |
+| 3 | 3月（累計+次年度繰越行） | 3月 | 月計行+累計行+次年度繰越行 |
+| 4 | チャージ+利用混在 | 7月 | 月計: Income=13000, Expense=1100 |
+| 5 | 貸出中レコード除外 | 8月 | IsLentRecord=trueを除外 |
+| 6 | 日付+ID順ソート | 9月 | 日付昇順→ID昇順 |
+| 7 | 複数カード一括出力 | 10月 | AllSuccess=true, SuccessfulFiles=2件 |
+| 8 | データなし月 | 11月 | 繰越行+月計行のみ |
+| 9 | カード未存在 | - | Success=false |
+| 10 | ヘッダ情報 | 5月 | E2=カード種別, H2=管理番号 |
+| 11 | 金額0の表示 | 6月 | 0円セル→空白 |
+| 12 | 集計行の太字 | 3月 | 繰越行=通常, データ行=通常, 月計/累計/次年度繰越=太字 |
+| 13 | 4月繰越0円 | 4月 | 繰越行にIncome=0を出力 |
+| 14 | 4月繰越なし（新規カード） | 4月 | 繰越行なし、データがRow5から |
+| 15 | 同日チャージ+利用の順序 | 6月 | 残高チェーン順（チャージ→利用） |
+
+**テストクラス:** `ReportServiceTests`
+
+---
+
+### 2.21 リポジトリ（データアクセス層）
+
+#### UT-020: LedgerRepository
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 正常Insert | Ledger(Expense=260) | ID>0、取得可能 |
+| 2 | チャージInsert | Income=3000, Balance=13000 | 値が正しく保存 |
+| 3 | 貸出レコードInsert | IsLentRecord=true, StaffName="山田太郎" | 全フィールド保存 |
+| 4 | ID取得 | 既存ID | 正しいLedger取得 |
+| 5 | 存在しないID | 99999 | null |
+| 6 | 日付範囲取得 | -5日,-3日,今日 → 範囲(-4〜今日) | 2件 |
+| 7 | 全カード取得 | CardIdm=null | 全カードのレコード |
+| 8 | 同日受入優先ソート | 同日にチャージ+バス+購入 | 購入→チャージ→バス |
+| 9 | 月別取得 | 6月3件+7月1件 → 6月指定 | 3件 |
+| 10 | 貸出レコード取得 | IsLentRecord=true | Summary="（貸出中）" |
+| 11 | 更新 | Summary変更 | true、値反映 |
+| 12 | 削除（カスケード） | Detail付きLedger | Ledger+Detail両方削除 |
+| 13 | 年度末残高取得 | 3/25,3/31,4/1 → FY2023 | 3/31の残高(9200) |
+| 14 | Detail挿入順序 | 2件逆順挿入 | 時系列順（古い→新しい）取得 |
+| 15 | ページング | 5件→page=1,size=2 | 2件, totalCount=5 |
+
+**テストクラス:** `LedgerRepositoryTests`
+
+#### UT-021: CardRepository
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 全件取得 | 2件登録 | 2件（削除済み除く） |
+| 2 | 削除済み除外 | 1件削除 | 1件のみ |
+| 3 | IDm取得 | 既存IDm | カード取得 |
+| 4 | 削除済みIDm | 削除済み | null（includeDeleted=falseのデフォルト） |
+| 5 | 削除済みIDm（include） | 削除済み, includeDeleted=true | カード取得, IsDeleted=true |
+| 6 | 重複IDm | 同一IDm2回Insert | 2回目false |
+| 7 | 貸出状態更新 | SetLent=true | IsLent=true, LastLentAt設定 |
+| 8 | 論理削除 | 未貸出カード | true, IsDeleted=true, DeletedAt設定 |
+| 9 | 貸出中削除 | 貸出中カード | false（削除不可） |
+| 10 | 自動採番 | 空DB | "1" |
+| 11 | 種別別採番 | はやかけん="5", nimoca="10" | はやかけん→"6", nimoca→"11", SUGOCA→"1" |
+
+**テストクラス:** `CardRepositoryTests`
+
+#### UT-022: StaffRepository
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 全件取得 | 2件登録 | 2件（削除済み除く） |
+| 2 | 名前順ソート | 山田太郎, 鈴木花子, 佐藤一郎 | Unicode順（佐藤→山田→鈴木） |
+| 3 | 重複IDm | 同一IDm2回Insert | 2回目false |
+| 4 | 論理削除 | 既存職員 | true, IsDeleted=true, DeletedAt設定 |
+| 5 | 削除済み再削除 | 削除済み職員 | false |
+| 6 | ExistsAsync（削除済み） | 削除済み職員 | true（物理存在） |
+
+**テストクラス:** `StaffRepositoryTests`
+
+#### UT-023: SettingsRepository
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | デフォルト設定読込 | 初期化直後 | WarningBalance=10000, FontSize=Medium |
+| 2 | カスタム設定読込 | warning_balance="5000", font_size="large" | WarningBalance=5000, FontSize=Large |
+| 3 | 無効な値 | warning_balance="invalid" | デフォルト(10000)にフォールバック |
+| 4 | FontSizeパース | "small","medium","large","xlarge","SMALL","invalid" | Small,Medium,Large,ExtraLarge,Small,Medium |
+| 5 | ラウンドトリップ | SaveAppSettingsAsync→GetAppSettingsAsync | 全値一致 |
+| 6 | SkipBusStopInput | "TRUE"/"invalid"/"" | true/false/false |
+
+**テストクラス:** `SettingsRepositoryTests`
+
+---
+
+### 2.22 ViewModel層テスト
+
+#### UT-024: SettingsViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 設定読込 | LoadSettingsAsync() | WarningBalance, FontSize等がDB値と一致, HasChanges=false |
+| 2 | 負の警告残高 | WarningBalance=-100 → Save | エラー"0以上", 保存されない |
+| 3 | 上限超過警告残高 | WarningBalance=30000 → Save | エラー"20,000円以下", 保存されない |
+| 4 | 正常保存 | WarningBalance=3000, FontSize=Large → Save | Repository呼出あり |
+| 5 | 保存失敗 | Repository.Save returns false | エラー"失敗" |
+| 6 | 変更検知 | WarningBalance変更 | HasChanges=true |
+| 7 | フォントサイズ選択肢 | FontSizeOptions | 4項目: Small/12, Medium/14, Large/16, ExtraLarge/20 |
+| 8 | サウンドモード選択肢 | SoundModeOptions | 4項目: Beep, VoiceMale, VoiceFemale, None |
+
+**テストクラス:** `SettingsViewModelTests`
+
+#### UT-025: CardManageViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | カード読込 | LoadCardsAsync() | 種別→番号順ソート |
+| 2 | 新規登録開始 | StartNewCard() | IsEditing=true, IsNewCard=true, IsWaitingForCard=true |
+| 3 | IDm指定新規 | StartNewCardWithIdmAsync("0102...") | EditCardIdm設定, EditCardType="nimoca" |
+| 4 | 編集開始 | StartEdit() | IsEditing=true, IsNewCard=false, 各プロパティ設定 |
+| 5 | 新規保存 | IDm/Type/Number設定 → Save | InsertAsync呼出, IsEditing=false |
+| 6 | 重複IDm | 登録済みIDm | "既に登録"+管理番号表示 |
+| 7 | 空IDm | EditCardIdm="" | "IDm"エラー |
+| 8 | 空管理番号（自動採番） | EditCardNumber="" | GetNextCardNumberAsync呼出 |
+| 9 | 更新保存 | 既存カード編集 → Save | UpdateAsync呼出 |
+| 10 | 削除 | 未貸出カード | DeleteAsync呼出 |
+| 11 | 貸出中削除 | IsLent=true | "貸出中"エラー |
+| 12 | 新規登録時の購入Ledger | SetPreReadBalance(5000) | Summary="新規購入", Income=5000, Balance=5000 |
+| 13 | 繰越モード（残高指定） | CarryoverBalance=5000 | Income=5000, Summary="5月から繰越" |
+| 14 | 繰越モード（残高未指定→フォールバック） | CarryoverBalance=null, PreReadBalance=4780 | Income=4780 |
+
+**テストクラス:** `CardManageViewModelTests`
+
+#### UT-026: StaffManageViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 職員読込 | LoadStaffAsync() | 番号→名前順ソート |
+| 2 | 新規登録 | IDm/Name設定 → Save | InsertAsync呼出 |
+| 3 | 重複IDm | 登録済みIDm | "既に登録"+職員名表示 |
+| 4 | 空IDm/空Name | 各エラーケース | 適切なエラーメッセージ |
+| 5 | 空番号 | EditNumber="" | Number=nullで保存 |
+| 6 | 更新 | Name変更 → Save | UpdateAsync呼出 |
+| 7 | 削除 | 既存職員 | DeleteAsync呼出 |
+| 8 | 削除失敗 | Repository.Delete=false | "失敗"エラー |
+
+**テストクラス:** `StaffManageViewModelTests`
+
+#### UT-027: ReportViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 初期値 | コンストラクタ | 前月が選択, 年は過去5年分+今年 |
+| 2 | カード読込 | LoadCardsAsync() | 種別→番号順、全選択 |
+| 3 | 全選択ON | IsAllSelected=true | 全カードIsSelected=true |
+| 4 | 全選択OFF | IsAllSelected=false | SelectedCards.Count=0 |
+| 5 | カード未選択で作成 | SelectedCards空 → Create | "カードを1つ以上選択" |
+| 6 | 出力先未設定 | OutputFolder="" → Create | "出力先フォルダを選択" |
+| 7 | 今月選択 | SelectThisMonth() | 今月の年月, IsThisMonthSelected=true |
+| 8 | 先月選択 | SelectLastMonth() | 先月の年月, IsLastMonthSelected=true |
+| 9 | 手動選択（ハイライト解除） | 2020年6月選択 | 両ボタンハイライトなし |
+
+**テストクラス:** `ReportViewModelTests`
+
+#### UT-028: DataExportImportViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | プレビューなしでインポート | ImportPreview=null → Execute | "プレビューを実行してください" |
+| 2 | インポート成功 | 有効プレビュー → Execute | ShowInformation("3件"), StatusMessage="3件を登録" |
+| 3 | スキップ付き成功 | ImportedCount=2, SkippedCount=1 | "2件"+"スキップ"+"1件" |
+| 4 | インポート失敗 | ErrorMessage付き結果 | ShowError呼出 |
+| 5 | 部分成功 | ImportedCount=2, ErrorCount=1 | ShowWarning呼出 |
+| 6 | 成功後プレビュークリア | 成功結果 | HasPreview=false |
+| 7 | 成功後HasImported設定 | ImportedCount=3 | HasImported=true |
+| 8 | 0件インポート | ImportedCount=0, SkippedCount=3 | HasImported=false |
+
+**テストクラス:** `DataExportImportViewModelTests`
+
+#### UT-029: LedgerDetailViewModel
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 仕切り挿入（2件） | ToggleDividerAt(0) | Items[0].GroupId≠Items[1].GroupId |
+| 2 | 仕切り挿入（3件→先頭後） | ToggleDividerAt(0) | GroupId: 1, 2, 2 |
+| 3 | 仕切りトグル解除 | ToggleDividerAt(0)×2 | 全GroupId=null |
+| 4 | 全分割 | SplitAllCommand(3件) | GroupId: 1, 2, 3 |
+| 5 | 全統合 | 分割後 → MergeAllCommand | 全GroupId=null |
+| 6 | 仕切り→HasChanges | ToggleDividerAt(0) | HasChanges=true |
+| 7 | 仕切り→HasMultipleGroups | ToggleDividerAt(0) | HasMultipleGroups=true |
+| 8 | 統合→HasMultipleGroups | MergeAll | HasMultipleGroups=false |
+
+**テストクラス:** `LedgerDetailViewModelTests`
+
+---
+
+### 2.23 パスバリデーション（PathValidator）
+
+#### UT-030: バックアップパス検証
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | null/空 | null, "", "   " | IsValid=false |
+| 2 | パス長超過 | 261文字以上 | IsValid=false |
+| 3 | UNCパス | \\\\server\\share | IsValid=false |
+| 4 | 相対パス | ..\\backup | IsValid=false |
+| 5 | パストラバーサル | C:\\..\\secret | IsValid=false |
+| 6 | 有効なパス | C:\\Backup\\ICCardManager | IsValid=true |
+| 7 | 日本語パス | C:\\バックアップ | IsValid=true |
+| 8 | スペース含む | C:\\My Backup | IsValid=true |
+| 9 | 不正文字 | パスに制御文字 | IsValid=false |
+
+**テストクラス:** `PathValidatorTests`
+
+---
+
+### 2.24 DBマイグレーション
+
+#### UT-031: データベース初期化・マイグレーション
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 新規DB初期化 | InitializeDatabase() | マイグレーション適用 |
+| 2 | テーブル作成確認 | 初期化後 | 全テーブル存在 |
+| 3 | レガシーDB | バージョン情報なし | Version=1として記録 |
+| 4 | 二重初期化 | InitializeDatabase()×2 | マイグレーション重複なし |
+| 5 | 初期化前バージョン | GetDatabaseVersion() | 0 |
+| 6 | 保留マイグレーション | HasPendingMigrations() | true |
+| 7 | デフォルト設定挿入 | 初期化後 | デフォルト設定が存在 |
+
+**テストクラス:** `DbContextMigrationTests`
+
+---
+
+### 2.25 データ保持期限（6年自動削除）
+
+#### UT-032: Ledger自動削除
+
+| No | テストケース | データ | 期待結果 |
+|----|-------------|-------|---------|
+| 1 | 6年未満 | 5年前のレコード | 削除されない |
+| 2 | 空テーブル | データなし | 0件 |
+| 3 | 境界値（6年-1日） | 6年前の前日 | 削除されない |
+| 4 | 混在データ | 古い+新しい | 古いもののみ削除 |
+| 5 | 大量データ性能 | 大量レコード | 適正時間内に完了 |
+| 6 | Detail連鎖削除 | Detail付きLedger | カスケード削除 |
+
+**テストクラス:** `DbContextCleanupTests`
 
 ---
 
@@ -650,7 +1360,7 @@
 
 | 項目 | 基準 |
 |------|------|
-| 単体テスト | 全件パス（現在1,613件） |
+| 単体テスト | 全件パス（現在1,796件） |
 | 結合テスト | 全件パス |
 | UIテスト | 全件パス（現在9件） |
 | システムテスト | 重大バグ0件、軽微バグ5件以下 |
@@ -662,7 +1372,7 @@
 |------|------|
 | コードカバレッジ | 80%以上 |
 | 性能テスト | 全項目が目標値以内 |
-| 自動テスト合計 | 1,600件以上を維持 |
+| 自動テスト合計 | 1,800件以上を維持 |
 
 ---
 
@@ -702,8 +1412,10 @@
 
 テスト用の履歴データは、以下のパターンを網羅するように作成:
 - 鉄道利用（片道、往復、乗継、複数区間）
-- バス利用
-- チャージ
+- バス利用（片道、往復、乗り継ぎ）
+- チャージ（通常、残高不足時）
+- ポイント還元（明示的、暗黙的）
 - 複数日にまたがる利用
 - 月をまたぐ利用
 - 年度をまたぐ利用
+- 残高不足パターン（チャージ+利用マージ）


### PR DESCRIPTION
## Summary
- テスト設計書（07_テスト設計書.md）を実際のテストコード（1,796件）に基づいて大幅に詳細化
- 既存UT-001〜UT-014を具体的な入力値・期待値で拡充
- 新規セクション UT-015〜UT-032 を追加（CSVエクスポート/インポート、貸出・返却サービス、月次帳票、リポジトリ層、ViewModel層、パスバリデーション等）
- テスト数を1,613→1,796件に更新

### 背景
コードの内容を読まずにテストの正確性を確認できるよう、各テストケースに具体的な入力値と期待される出力を記載しました。

## Test plan
- [ ] テスト設計書の各テストケースが実際のテストコードと整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)