### PR TITLE
fix: バス停名入力ダイアログ閉じた後に履歴画面を即時反映 (#1010)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -2054,6 +2054,12 @@ public partial class MainViewModel : ViewModelBase
                 // バス停未入力警告: 一覧ダイアログを表示（Issue #703: ダイアログ内で直接バス停名入力）
                 _navigationService.ShowDialog<Views.Dialogs.IncompleteBusStopDialog>();
 
+                // Issue #1010: バス停名入力後に履歴画面を即時反映
+                if (IsHistoryVisible)
+                {
+                    await LoadHistoryLedgersAsync();
+                }
+
                 // ダイアログ内でバス停名が入力された可能性があるため、警告を更新
                 await CheckWarningsAsync();
                 break;


### PR DESCRIPTION
## Summary
- IncompleteBusStopDialog（警告クリック経由）でバス停名を入力・保存した後、メイン画面の履歴が表示中であれば `LoadHistoryLedgersAsync()` を呼び出して即時反映するように修正
- 返却時のバス停入力パス（line 955-957）では既に同様の処理があったが、警告クリック経由の `HandleWarningClick` メソッド内では欠落していた

Closes #1010

## Test plan
- [ ] メイン画面で交通系ICカードの履歴を表示した状態にする
- [ ] 「⚠️ バス停名が未入力の履歴がN件あります」の警告をクリックして IncompleteBusStopDialog を開く
- [ ] バス停名を入力して「保存」をクリック
- [ ] ダイアログを閉じた後、メイン画面の履歴画面の摘要欄にバス停名が即時反映されていることを確認（★ → バス停名）
- [ ] 「スキップ」した場合は★のまま表示されることを確認
- [ ] 履歴画面が非表示の状態で同じ操作をしても、エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)