### PR TITLE
fix: MigrationRunnerのoperation_logタイムスタンプをローカル時刻で保存

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Migrations/MigrationRunner.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/MigrationRunner.cs
@@ -334,8 +334,10 @@ namespace ICCardManager.Data.Migrations
                     : $"{{\"version\":{migration.Version},\"description\":\"{migration.Description}\",\"status\":\"failed\",\"error\":\"{errorMessage?.Replace("\"", "\\\"") ?? ""}\"}}";
 
                 using var command = _connection.CreateCommand();
-                command.CommandText = @"INSERT INTO operation_log (operator_idm, operator_name, target_table, target_id, action, after_data)
-VALUES (@operator_idm, @operator_name, @target_table, @target_id, @action, @after_data)";
+                // Issue #1014: CURRENT_TIMESTAMPはUTCのため、ローカル時刻を明示的に保存する
+                command.CommandText = @"INSERT INTO operation_log (timestamp, operator_idm, operator_name, target_table, target_id, action, after_data)
+VALUES (@timestamp, @operator_idm, @operator_name, @target_table, @target_id, @action, @after_data)";
+                command.Parameters.AddWithValue("@timestamp", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
                 command.Parameters.AddWithValue("@operator_idm", "SYSTEM");
                 command.Parameters.AddWithValue("@operator_name", "MigrationRunner");
                 command.Parameters.AddWithValue("@target_table", "schema_migrations");

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationRunnerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationRunnerTests.cs
@@ -432,6 +432,51 @@ public class MigrationRunnerTests : IDisposable
         runner.GetCurrentVersion().Should().Be(1);
     }
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MigrateToLatest_OperationLogのtimestampがローカル時刻で記録される_Issue1014()
+    {
+        // Arrange - operation_logテーブルを事前に作成
+        using (var cmd = _connection.CreateCommand())
+        {
+            cmd.CommandText = @"CREATE TABLE operation_log (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp     TEXT DEFAULT CURRENT_TIMESTAMP,
+                operator_idm  TEXT NOT NULL,
+                operator_name TEXT NOT NULL,
+                target_table  TEXT,
+                target_id     TEXT,
+                action        TEXT,
+                before_data   TEXT,
+                after_data    TEXT
+            )";
+            cmd.ExecuteNonQuery();
+        }
+
+        var beforeMigrate = DateTime.Now;
+
+        var migration = new TestMigration(1, "タイムスタンプテスト");
+        var runner = new MigrationRunner(_connection, new[] { migration });
+
+        // Act
+        runner.MigrateToLatest();
+
+        var afterMigrate = DateTime.Now;
+
+        // Assert: operation_logに記録されたtimestampを検証
+        using var selectCmd = _connection.CreateCommand();
+        selectCmd.CommandText = "SELECT timestamp FROM operation_log WHERE operator_name = 'MigrationRunner' LIMIT 1";
+        var timestampStr = (string)selectCmd.ExecuteScalar();
+
+        timestampStr.Should().NotBeNull();
+        var timestamp = DateTime.Parse(timestampStr);
+
+        // ローカル時刻の前後範囲内であることを検証
+        // UTCで保存されていた場合、JST環境では9時間ずれるためこの範囲に入らない
+        timestamp.Should().BeOnOrAfter(beforeMigrate.AddSeconds(-1));
+        timestamp.Should().BeOnOrBefore(afterMigrate.AddSeconds(1));
+    }
+
     /// <summary>
     /// テスト用マイグレーション
     /// </summary>


### PR DESCRIPTION
## Summary
- `MigrationRunner.LogMigrationAction`で`operation_log`にINSERTする際、`timestamp`列を明示指定していなかったため`DEFAULT CURRENT_TIMESTAMP`（UTC）が使われていた問題を修正
- #1014の関連修正として、コードベース全体のタイムスタンプ処理を網羅的に調査した結果

## Investigation Results
コードベース全体の時刻処理を調査した結果:

| テーブル | カラム | 書き込み方法 | 状態 |
|---------|--------|------------|------|
| operation_log | timestamp | `OperationLogRepository`: DateTime.Now明示指定 | OK |
| operation_log | timestamp | **`MigrationRunner`: 未指定→UTC** | **修正対象** |
| ledger_merge_history | merged_at | DateTime.Now明示指定 (#1014で修正済み) | OK |
| schema_migrations | applied_at | `datetime('now', 'localtime')` | OK |
| staff | deleted_at | `datetime('now', 'localtime')` | OK |
| ic_card | deleted_at/refunded_at | `datetime('now', 'localtime')` | OK |
| ic_card | last_lent_at | DateTime明示フォーマット | OK |
| ledger | date/lent_at/returned_at | DateTime明示フォーマット | OK |

## Test plan
- [x] `MigrateToLatest_OperationLogのtimestampがローカル時刻で記録される_Issue1014`: マイグレーション実行後、operation_logのtimestampがDateTime.Nowの前後範囲内であることを検証
- [x] 既存テスト全1800件が全て合格

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)