### PR TITLE
feat: フォルダパスの直接入力を可能にする (#1026)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -955,6 +955,9 @@
 | 10 | 保存済み出力先読込 | InitializeAsync（保存値あり） | 保存フォルダがOutputFolderに設定される |
 | 11 | 出力先未保存時デフォルト | InitializeAsync（保存値空） | マイドキュメントのまま |
 | 12 | 出力先null時デフォルト | InitializeAsync（保存値なし） | マイドキュメントのまま |
+| 13 | 直接入力で保存 | 初期化後にOutputFolder変更 | SaveAppSettingsAsyncが呼ばれる |
+| 14 | 初期化前は保存しない | 初期化前にOutputFolder変更 | SaveAppSettingsAsyncが呼ばれない |
+| 15 | UNCパス入力 | `\\server\share\reports`を設定 | 値が保持され保存される |
 
 **テストクラス:** `ReportViewModelTests`
 

--- a/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
@@ -27,6 +27,7 @@ public partial class ReportViewModel : ViewModelBase
     private readonly ICardRepository _cardRepository;
     private readonly INavigationService _navigationService;
     private readonly ISettingsRepository _settingsRepository;
+    private bool _isInitialized;
 
     [ObservableProperty]
     private ObservableCollection<CardDto> _cards = new();
@@ -105,6 +106,17 @@ public partial class ReportViewModel : ViewModelBase
     {
         await LoadCardsAsync();
         await LoadOutputFolderAsync();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// 出力先フォルダが変更されたときに設定を保存
+    /// </summary>
+    partial void OnOutputFolderChanged(string value)
+    {
+        // 初期化完了前（コンストラクタやLoadOutputFolderAsyncでの設定）は保存しない
+        if (!_isInitialized) return;
+        _ = SaveOutputFolderAsync();
     }
 
     /// <summary>
@@ -342,7 +354,7 @@ public partial class ReportViewModel : ViewModelBase
     /// 出力フォルダを選択
     /// </summary>
     [RelayCommand]
-    public async Task BrowseOutputFolderAsync()
+    public void BrowseOutputFolder()
     {
         // .NET Framework 4.8ではOpenFolderDialogがないためFolderBrowserDialogを使用
         using (var dialog = new System.Windows.Forms.FolderBrowserDialog
@@ -357,7 +369,6 @@ public partial class ReportViewModel : ViewModelBase
             if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 OutputFolder = dialog.SelectedPath;
-                await SaveOutputFolderAsync();
             }
         }
     }

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/ReportDialog.xaml
@@ -115,11 +115,10 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <TextBox Grid.Column="0"
-                             Text="{Binding OutputFolder}"
-                             IsReadOnly="True"
+                             Text="{Binding OutputFolder, UpdateSourceTrigger=LostFocus}"
                              Padding="8"
-                             Background="{DynamicResource NeutralBackgroundBrush}"
-                             AutomationProperties.Name="出力先フォルダパス"/>
+                             AutomationProperties.Name="出力先フォルダパス"
+                             ToolTip="フォルダパスを直接入力できます（UNCパスも可）"/>
                     <Button Grid.Column="1"
                             Content="参照"
                             Command="{Binding BrowseOutputFolderCommand}"

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SettingsDialog.xaml
@@ -185,9 +185,8 @@
                             <TextBox Grid.Column="0"
                                      Text="{Binding BackupPath, UpdateSourceTrigger=PropertyChanged}"
                                      Padding="8"
-                                     IsReadOnly="True"
-                                     Background="{DynamicResource NeutralBackgroundBrush}"
-                                     AutomationProperties.Name="バックアップ先フォルダパス"/>
+                                     AutomationProperties.Name="バックアップ先フォルダパス"
+                                     ToolTip="フォルダパスを直接入力できます（UNCパスも可）"/>
                             <Button Grid.Column="1"
                                     Content="参照..."
                                     Command="{Binding BrowseBackupPathCommand}"

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/ReportViewModelTests.cs
@@ -720,4 +720,67 @@ public class ReportViewModelTests
     }
 
     #endregion
+
+    #region Issue #1026: 出力先フォルダ直接入力テスト
+
+    /// <summary>
+    /// 初期化完了後にOutputFolderを変更すると設定が保存されること
+    /// </summary>
+    [Fact]
+    public async Task OutputFolder_AfterInitialize_WhenChanged_ShouldSaveToSettings()
+    {
+        // Arrange
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<IcCard>());
+        _settingsRepositoryMock.Setup(s => s.SaveAppSettingsAsync(It.IsAny<AppSettings>())).ReturnsAsync(true);
+        await _viewModel.InitializeAsync();
+
+        // Act - ユーザーがテキストボックスに直接入力した場合をシミュレート
+        _viewModel.OutputFolder = @"\\server\share\reports";
+
+        // Assert - 設定が保存されること
+        // fire-and-forgetのため少し待つ
+        await Task.Delay(100);
+        _settingsRepositoryMock.Verify(
+            s => s.SaveAppSettingsAsync(It.Is<AppSettings>(a => a.ReportOutputFolder == @"\\server\share\reports")),
+            Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// 初期化完了前にOutputFolderを変更しても設定が保存されないこと
+    /// </summary>
+    [Fact]
+    public void OutputFolder_BeforeInitialize_WhenChanged_ShouldNotSave()
+    {
+        // Act - コンストラクタ後（InitializeAsync前）にフォルダを変更
+        _viewModel.OutputFolder = @"D:\SomeFolder";
+
+        // Assert - SaveAppSettingsAsyncが呼ばれないこと
+        _settingsRepositoryMock.Verify(
+            s => s.SaveAppSettingsAsync(It.IsAny<AppSettings>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// UNCパスを出力先フォルダに設定できること
+    /// </summary>
+    [Fact]
+    public async Task OutputFolder_WithUncPath_ShouldAcceptAndSave()
+    {
+        // Arrange
+        _cardRepositoryMock.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<IcCard>());
+        _settingsRepositoryMock.Setup(s => s.SaveAppSettingsAsync(It.IsAny<AppSettings>())).ReturnsAsync(true);
+        await _viewModel.InitializeAsync();
+
+        // Act
+        _viewModel.OutputFolder = @"\\192.168.1.100\共有フォルダ\帳票";
+
+        // Assert
+        _viewModel.OutputFolder.Should().Be(@"\\192.168.1.100\共有フォルダ\帳票");
+        await Task.Delay(100);
+        _settingsRepositoryMock.Verify(
+            s => s.SaveAppSettingsAsync(It.Is<AppSettings>(a => a.ReportOutputFolder == @"\\192.168.1.100\共有フォルダ\帳票")),
+            Times.AtLeastOnce);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- 帳票作成画面の出力先フォルダと設定画面のバックアップ先フォルダのTextBoxを編集可能にし、UNCパスを含む任意のパスを直接入力できるようにした
- 「参照」ボタンによるフォルダ選択ダイアログも引き続き使用可能
- 帳票作成画面では、テキスト入力によるフォルダ変更も自動的にDBに永続化される

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `ReportDialog.xaml` | OutputFolder TextBoxから`IsReadOnly="True"`を除去、ToolTip追加 |
| `SettingsDialog.xaml` | BackupPath TextBoxから`IsReadOnly="True"`を除去、ToolTip追加 |
| `ReportViewModel.cs` | `OnOutputFolderChanged`追加（初期化後の変更を自動保存）、`_isInitialized`フラグで初期化中の不要保存を防止 |
| `ReportViewModelTests.cs` | テスト3件追加 |
| `07_テスト設計書.md` | テストケース3件追記 |

## Test plan
- [x] 単体テスト全1815件合格
- [x] 帳票作成画面で出力先フォルダのテキストボックスに直接パスを入力→帳票作成が正常に動作することを確認
- [ ] UNCパス（例: `\\server\share\folder`）を入力して帳票作成が動作することを確認
- [x] 「参照」ボタンによるフォルダ選択が従来通り動作することを確認
- [x] 設定画面でバックアップ先フォルダのテキストボックスに直接パスを入力→保存が正常に動作することを確認
- [x] 存在しないパスを入力した場合、帳票作成時に「出力先フォルダが存在しません」エラーが表示されることを確認

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)