### PR TITLE
fix: Ledger.Summaryのnullアクセスによる潜在的NullReferenceExceptionを修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/LedgerOrderHelper.cs
+++ b/ICCardManager/src/ICCardManager/Services/LedgerOrderHelper.cs
@@ -124,7 +124,7 @@ namespace ICCardManager.Services
         /// 新規購入または繰越レコードかどうかを判定する。
         /// </summary>
         private static bool IsSpecialRecord(Ledger l) =>
-            l.Summary == "新規購入" || l.Summary.EndsWith("月から繰越");
+            l.Summary == "新規購入" || l.Summary?.EndsWith("月から繰越") == true;
 
         /// <summary>
         /// チェーン構築用の内部データ構造。

--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -260,7 +260,7 @@ namespace ICCardManager.Services
                 return DataRowHeight;
 
             var maxChars = isLandscape ? SummaryCharsLandscape : SummaryCharsPortrait;
-            return row.Summary.Length <= maxChars ? DataRowHeight : DataRowHeightDouble;
+            return (row.Summary?.Length ?? 0) <= maxChars ? DataRowHeight : DataRowHeightDouble;
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/ViewModels/IncompleteBusStopViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/IncompleteBusStopViewModel.cs
@@ -80,7 +80,7 @@ namespace ICCardManager.ViewModels
 
                 var ledgers = await _ledgerRepository.GetByDateRangeAsync(
                     null, DateTime.Now.AddYears(-1), DateTime.Now);
-                var incompleteLedgers = ledgers.Where(l => l.Summary.Contains("★")).ToList();
+                var incompleteLedgers = ledgers.Where(l => l.Summary?.Contains("★") == true).ToList();
 
                 var cards = await _cardRepository.GetAllAsync();
                 var cardMap = cards.ToDictionary(c => c.CardIdm, c => $"{c.CardType} {c.CardNumber}");

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -505,7 +505,7 @@ public partial class MainViewModel : ViewModelBase
         var ledgers = await _ledgerRepository.GetByDateRangeAsync(
             null, DateTime.Now.AddYears(-1), DateTime.Now);
 
-        var incompleteCount = ledgers.Count(l => l.Summary.Contains("★"));
+        var incompleteCount = ledgers.Count(l => l.Summary?.Contains("★") == true);
         if (incompleteCount > 0)
         {
             WarningMessages.Add(new WarningItem

--- a/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/IncompleteBusStopDialog.xaml.cs
@@ -54,7 +54,7 @@ namespace ICCardManager.Views.Dialogs
             {
                 // Issue #709: 更新済み摘要を表示してからハイライト→削除
                 var updatedItem = await _viewModel.UpdateItemSummaryAsync(ledgerId);
-                if (updatedItem != null && !updatedItem.Summary.Contains("★"))
+                if (updatedItem != null && updatedItem.Summary?.Contains("★") != true)
                 {
                     // 摘要が完全に更新された場合：ハイライト→2秒後に一覧から削除
                     await Dispatcher.InvokeAsync(() =>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/NullSafeSummaryAccessTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/NullSafeSummaryAccessTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// Ledger.Summaryがnullの場合にNullReferenceExceptionが発生しないことを検証するテスト。
+///
+/// Ledger.Summaryのデフォルト値はstring.Emptyだが、DBからの読み込みやリフレクション等で
+/// nullが設定される可能性があるため、Summary参照箇所にはnull安全なアクセスが必要。
+/// </summary>
+public class NullSafeSummaryAccessTests
+{
+    private static Ledger CreateLedger(int id, DateTime date, string summary, int income, int expense, int balance) =>
+        new Ledger
+        {
+            Id = id,
+            CardIdm = "0102030405060708",
+            Date = date,
+            Summary = summary,
+            Income = income,
+            Expense = expense,
+            Balance = balance
+        };
+
+    #region LedgerOrderHelper — IsSpecialRecord のnull安全性
+
+    /// <summary>
+    /// Summary=nullのLedgerがReorderByBalanceChainでNullReferenceExceptionを起こさないこと。
+    /// IsSpecialRecordメソッドがnull安全であることを検証する。
+    /// </summary>
+    [Fact]
+    public void ReorderByBalanceChain_SummaryNull_DoesNotThrow()
+    {
+        var date = new DateTime(2024, 6, 10);
+        var ledgers = new[]
+        {
+            CreateLedger(1, date, null, 0, 300, 9700),   // Summary=null
+            CreateLedger(2, date, null, 0, 200, 9500),   // Summary=null
+        };
+
+        // Act - NullReferenceExceptionが発生しないこと
+        var act = () => LedgerOrderHelper.ReorderByBalanceChain(ledgers, precedingBalance: 10000);
+
+        act.Should().NotThrow<NullReferenceException>();
+    }
+
+    /// <summary>
+    /// Summary=nullのLedgerが通常レコードとして扱われること（特殊レコードではない）。
+    /// </summary>
+    [Fact]
+    public void ReorderByBalanceChain_SummaryNull_TreatedAsNormalRecord()
+    {
+        var date = new DateTime(2024, 6, 10);
+        var ledgers = new[]
+        {
+            CreateLedger(1, date, "新規購入", 5000, 0, 5000),    // 特殊レコード
+            CreateLedger(2, date, null, 0, 300, 4700),           // Summary=null（通常レコード扱い）
+        };
+
+        var result = LedgerOrderHelper.ReorderByBalanceChain(ledgers);
+
+        result.Should().HaveCount(2);
+        result[0].Summary.Should().Be("新規購入", "特殊レコードが先頭");
+        result[1].Summary.Should().BeNull("nullの通常レコードが後");
+    }
+
+    /// <summary>
+    /// Summary=nullとSummary="3月から繰越"が混在する場合、繰越のみ特殊レコードと判定されること。
+    /// </summary>
+    [Fact]
+    public void ReorderByBalanceChain_SummaryNullWithCarryover_OnlyCarryoverIsSpecial()
+    {
+        var date = new DateTime(2024, 4, 1);
+        var ledgers = new[]
+        {
+            CreateLedger(2, date, null, 0, 200, 4800),            // Summary=null
+            CreateLedger(1, date, "3月から繰越", 0, 0, 5000),     // 特殊レコード
+        };
+
+        var result = LedgerOrderHelper.ReorderByBalanceChain(ledgers);
+
+        result.Should().HaveCount(2);
+        result[0].Summary.Should().Be("3月から繰越", "繰越が先頭");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- テストカバレッジギャップ分析（#1041）の過程で発見された実装バグを修正
- `Ledger.Summary`がnullの場合に`NullReferenceException`が発生する箇所が5箇所存在
- null条件演算子（`?.`）を使用してnull安全なアクセスに修正

## 問題の詳細

`Ledger.Summary`のデフォルト値は`string.Empty`だが、DBからの読み込み時等にnullが設定される可能性がある。実際に`MainViewModel.cs:944`では`l.Summary != null &&`のnullガードが既に存在しており、**コード自体がnullの可能性を認識していた**。しかし他の5箇所ではガードなしで`.Contains()`/`.EndsWith()`/`.Length`を呼び出しており、`NullReferenceException`の潜在的リスクがあった。

## 修正箇所（5箇所）

| ファイル | 行 | 修正前 | 修正後 |
|---|---|---|---|
| `LedgerOrderHelper.cs` | 127 | `l.Summary.EndsWith("月から繰越")` | `l.Summary?.EndsWith("月から繰越") == true` |
| `MainViewModel.cs` | 508 | `l.Summary.Contains("★")` | `l.Summary?.Contains("★") == true` |
| `IncompleteBusStopViewModel.cs` | 83 | `l.Summary.Contains("★")` | `l.Summary?.Contains("★") == true` |
| `PrintService.cs` | 263 | `row.Summary.Length` | `(row.Summary?.Length ?? 0)` |
| `IncompleteBusStopDialog.xaml.cs` | 57 | `!updatedItem.Summary.Contains("★")` | `updatedItem.Summary?.Contains("★") != true` |

## Test plan

- [x] 修正を検証するテスト3件追加（`NullSafeSummaryAccessTests`）
- [x] 全1,899テスト成功（リグレッションなし）
- [x] ビルドエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)