### PR TITLE
fix: データインポート/エクスポート時のプログレスバー表示タイミングを修正 (#1062)

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -362,6 +362,8 @@ public partial class DataExportImportViewModel : ViewModelBase
 
         using (BeginBusy("エクスポート中..."))
         {
+            // Issue #1062: UIスレッドにプログレスバー描画の機会を与える
+            await Task.Yield();
             try
             {
                 CsvExportResult result;
@@ -437,6 +439,8 @@ public partial class DataExportImportViewModel : ViewModelBase
 
         using (BeginBusy("プレビュー読み込み中..."))
         {
+            // Issue #1062: UIスレッドにプログレスバー描画の機会を与える
+            await Task.Yield();
             try
             {
                 CsvImportPreviewResult preview;
@@ -543,6 +547,8 @@ public partial class DataExportImportViewModel : ViewModelBase
 
         using (BeginBusy("インポート中..."))
         {
+            // Issue #1062: UIスレッドにプログレスバー描画の機会を与える
+            await Task.Yield();
             try
             {
                 CsvImportResult result;
@@ -675,6 +681,8 @@ public partial class DataExportImportViewModel : ViewModelBase
 
         using (BeginBusy("インポート中..."))
         {
+            // Issue #1062: UIスレッドにプログレスバー描画の機会を与える
+            await Task.Yield();
             try
             {
                 CsvImportResult result;


### PR DESCRIPTION
## Summary

- `BeginBusy()` 直後に `await Task.Yield()` を挿入し、WPFディスパッチャーにプログレスバー描画の機会を与えるよう修正
- エクスポート、プレビュー読込、インポート実行（プレビュー経由・直接）の全4箇所に適用

## 原因

.NET Framework 4.8のSQLite非同期メソッドは実質的に同期実行されるため、`IsBusy = true` 設定後もUIスレッドが解放されずレンダリングが行われませんでした。結果、プログレスバーはインポート完了後（完了ダイアログ表示時）に初めて表示されていました。

## Test plan

この修正はWPFの描画タイミングに関わるため、単体テストでの自動検証は困難です。以下の手動テストをお願いします：

- [x] CSVインポート（プレビュー→実行）で「インポート中...」プログレスバーがボタン押下直後に表示されること
- [ ] CSVインポート（直接インポート）で同様にプログレスバーが即時表示されること
- [ ] CSVエクスポートで「エクスポート中...」プログレスバーが即時表示されること
- [ ] プレビュー読込で「プレビュー読み込み中...」プログレスバーが即時表示されること
- [x] 既存テスト全2064件が合格すること（確認済み）

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)