### PR TITLE
fix: WSL経由のgh pr createでPR本文がbashに解釈される問題を修正

### DIFF
--- a/ICCardManager/tools/bump-version.ps1
+++ b/ICCardManager/tools/bump-version.ps1
@@ -341,11 +341,22 @@ $prBody = @"
 - ``docs/manual/管理者マニュアル.md``
 "@
 
-$prUrl = Invoke-Gh pr create `
-    --title $commitMessage `
-    --body $prBody `
-    --base main `
-    --head $branchName
+# WSL経由の場合、--body に複数行文字列を渡すとbashがバッククォート内の
+# ファイルパスをコマンド置換として解釈してしまうため、--body-file - で
+# stdin経由で渡す
+if ($script:UseWslGh) {
+    $prUrl = $prBody | & wsl.exe gh pr create `
+        --title $commitMessage `
+        --body-file - `
+        --base main `
+        --head $branchName
+} else {
+    $prUrl = Invoke-Gh pr create `
+        --title $commitMessage `
+        --body $prBody `
+        --base main `
+        --head $branchName
+}
 
 Write-Host ""
 Write-Success "PR作成完了: $prUrl"


### PR DESCRIPTION
## Summary

- `bump-version.ps1` のPR作成時、`--body` 引数に含まれるバッククォート囲みのファイルパスがWSLのbashにコマンド置換として解釈されてエラーが出ていた
- WSL経由の場合は `--body-file -` でstdin経由でPR本文を渡すよう修正

## 原因

`wsl.exe gh pr create --body "...``src/ICCardManager/ICCardManager.csproj``..."` のように渡すと、WSLのbashがバッククォート（`` ` ``）内の文字列をコマンド置換として解釈し、ファイルをスクリプトとして実行しようとしていた。

## Test plan

- [ ] 次回リリース時にエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)