### PR TITLE
fix: 月計・累計行の金額列に「縮小して全体を表示する」を設定

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -9,9 +9,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 2,030件 | xUnit + FluentAssertions + Moq |
+| 単体テスト（ICCardManager.Tests） | 2,075件 | xUnit + FluentAssertions + Moq |
 | UIテスト（ICCardManager.UITests） | 9件 | |
-| **合計** | **2,039件** | 全件パス |
+| **合計** | **2,084件** | 全件パス |
 
 ### 1.2 テスト範囲
 
@@ -1287,6 +1287,29 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 4 | bool変換継承 | 成功/失敗それぞれ | true/false |
 
 **テストクラス:** `ServiceResultTests`
+
+---
+
+### 2.29 Excel帳票書式設定（ExcelStyleFormatter）
+
+#### UT-042: 月計・累計行の書式設定（ApplySummaryRowBorder）
+
+| No | テストケース | 検証対象 | 期待結果 |
+|----|-------------|---------|---------|
+| 1 | 金額列の縮小表示（Issue #1071） | E・F・G列のShrinkToFit | true（6桁以上の金額に対応） |
+| 2 | 日付列の縮小表示 | A列のShrinkToFit | true |
+| 3 | 非金額列の縮小表示なし | H列のShrinkToFit | false |
+| 4 | 上下罫線が太線（Issue #451） | 上下Border | Medium |
+| 5 | 金額列のフォントサイズ（Issue #947） | E・F・G列のFontSize | 16pt |
+
+#### UT-043: データ行の書式設定（ApplyDataRowBorder）
+
+| No | テストケース | 検証対象 | 期待結果 |
+|----|-------------|---------|---------|
+| 1 | 金額列の縮小表示なし | E・F・G列のShrinkToFit | false（データ行は個別取引のため不要） |
+| 2 | 日付列の縮小表示 | A列のShrinkToFit | true |
+
+**テストクラス:** `ExcelStyleFormatterTests`
 
 ---
 

--- a/ICCardManager/src/ICCardManager/Services/ExcelStyleFormatter.cs
+++ b/ICCardManager/src/ICCardManager/Services/ExcelStyleFormatter.cs
@@ -111,6 +111,10 @@ namespace ICCardManager.Services
             var amountRange = worksheet.Range(row, 5, row, 7);
             amountRange.Style.Font.FontSize = 16;
 
+            // Issue #1071: 金額列（受入E・払出F・残額G）は6桁以上になりうるため、
+            // 縮小して全体を表示する
+            amountRange.Style.Alignment.ShrinkToFit = true;
+
             // B列からD列を結合（摘要）
             var summaryRange = worksheet.Range(row, 2, row, 4);
             summaryRange.Merge();

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ExcelStyleFormatterTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ExcelStyleFormatterTests.cs
@@ -1,0 +1,148 @@
+using ClosedXML.Excel;
+using FluentAssertions;
+using ICCardManager.Services;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// ExcelStyleFormatterの単体テスト
+/// </summary>
+public class ExcelStyleFormatterTests
+{
+    /// <summary>
+    /// ApplySummaryRowBorder: 金額列（E・F・G列）に「縮小して全体を表示する」が設定されること
+    /// Issue #1071: 月計・累計の金額が6桁以上になりうるための対応
+    /// </summary>
+    [Fact]
+    public void ApplySummaryRowBorder_SetsAmountColumnsShrinkToFit()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplySummaryRowBorder(worksheet, row);
+
+        // Assert - 金額列（E=5, F=6, G=7）にShrinkToFitが設定されていること
+        worksheet.Cell(row, 5).Style.Alignment.ShrinkToFit.Should().BeTrue("受入金額(E列)は6桁以上になりうるため縮小表示が必要");
+        worksheet.Cell(row, 6).Style.Alignment.ShrinkToFit.Should().BeTrue("払出金額(F列)は6桁以上になりうるため縮小表示が必要");
+        worksheet.Cell(row, 7).Style.Alignment.ShrinkToFit.Should().BeTrue("残額(G列)は6桁以上になりうるため縮小表示が必要");
+    }
+
+    /// <summary>
+    /// ApplySummaryRowBorder: A列（出納年月日）にも「縮小して全体を表示する」が設定されること
+    /// </summary>
+    [Fact]
+    public void ApplySummaryRowBorder_SetsDateColumnShrinkToFit()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplySummaryRowBorder(worksheet, row);
+
+        // Assert
+        worksheet.Cell(row, 1).Style.Alignment.ShrinkToFit.Should().BeTrue("A列(出納年月日)は縮小表示が設定されている");
+    }
+
+    /// <summary>
+    /// ApplySummaryRowBorder: 金額列以外のセルにはShrinkToFitが設定されないこと
+    /// （摘要B-D列、氏名H列、備考I-L列は折り返しまたはデフォルト）
+    /// </summary>
+    [Fact]
+    public void ApplySummaryRowBorder_NonAmountColumnsDoNotHaveShrinkToFit()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplySummaryRowBorder(worksheet, row);
+
+        // Assert - 氏名(H列)はShrinkToFitが設定されないこと
+        worksheet.Cell(row, 8).Style.Alignment.ShrinkToFit.Should().BeFalse("氏名(H列)は縮小表示不要");
+    }
+
+    /// <summary>
+    /// ApplyDataRowBorder: データ行の金額列にはShrinkToFitが設定されないこと
+    /// （データ行の金額は個別の取引金額であり、通常は6桁未満）
+    /// </summary>
+    [Fact]
+    public void ApplyDataRowBorder_AmountColumnsDoNotHaveShrinkToFit()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplyDataRowBorder(worksheet, row);
+
+        // Assert - データ行の金額列にはShrinkToFitが設定されないこと
+        worksheet.Cell(row, 5).Style.Alignment.ShrinkToFit.Should().BeFalse("データ行の受入金額(E列)は縮小表示不要");
+        worksheet.Cell(row, 6).Style.Alignment.ShrinkToFit.Should().BeFalse("データ行の払出金額(F列)は縮小表示不要");
+        worksheet.Cell(row, 7).Style.Alignment.ShrinkToFit.Should().BeFalse("データ行の残額(G列)は縮小表示不要");
+    }
+
+    /// <summary>
+    /// ApplyDataRowBorder: A列にShrinkToFitが設定されること（既存機能の確認）
+    /// </summary>
+    [Fact]
+    public void ApplyDataRowBorder_SetsDateColumnShrinkToFit()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplyDataRowBorder(worksheet, row);
+
+        // Assert
+        worksheet.Cell(row, 1).Style.Alignment.ShrinkToFit.Should().BeTrue("A列(出納年月日)は縮小表示が設定されている");
+    }
+
+    /// <summary>
+    /// ApplySummaryRowBorder: 上下罫線が太線（Medium）であること（Issue #451の確認）
+    /// </summary>
+    [Fact]
+    public void ApplySummaryRowBorder_SetsTopAndBottomBorderToMedium()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplySummaryRowBorder(worksheet, row);
+
+        // Assert
+        worksheet.Cell(row, 1).Style.Border.TopBorder.Should().Be(XLBorderStyleValues.Medium);
+        worksheet.Cell(row, 1).Style.Border.BottomBorder.Should().Be(XLBorderStyleValues.Medium);
+    }
+
+    /// <summary>
+    /// ApplySummaryRowBorder: 金額列のフォントサイズが16ptであること（Issue #947の確認）
+    /// </summary>
+    [Fact]
+    public void ApplySummaryRowBorder_SetsAmountColumnsFontSizeTo16()
+    {
+        // Arrange
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.AddWorksheet("Test");
+        var row = 5;
+
+        // Act
+        ExcelStyleFormatter.ApplySummaryRowBorder(worksheet, row);
+
+        // Assert
+        worksheet.Cell(row, 5).Style.Font.FontSize.Should().Be(16);
+        worksheet.Cell(row, 6).Style.Font.FontSize.Should().Be(16);
+        worksheet.Cell(row, 7).Style.Font.FontSize.Should().Be(16);
+    }
+}


### PR DESCRIPTION
## Summary
- 月計・累計行の金額列（受入E列・払出F列・残額G列）に `ShrinkToFit = true` を設定し、6桁以上の金額がセル幅からはみ出さないようにした
- `ExcelStyleFormatterTests` を新規作成し、書式設定の単体テスト7件を追加
- テスト設計書にセクション2.29を追加、テスト数を更新

Closes #1071

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `ExcelStyleFormatter.cs` | `ApplySummaryRowBorder()` の金額列（E・F・G列）に `ShrinkToFit = true` を追加 |
| `ExcelStyleFormatterTests.cs` | 新規テストクラス（7テストケース） |
| `07_テスト設計書.md` | セクション2.29追加、テスト規模テーブル更新 |

## Test plan
- [x] 全2,075件の単体テストがパス
- [x] 新規追加の `ExcelStyleFormatterTests` 7件がパス
- [x] 実際に月次帳票を出力し、月計・累計行の金額列が縮小表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)