### PR TITLE
fix: DEBUGビルド時のテストデータ生成を単一トランザクションで高速化

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/DebugDataService.cs
+++ b/ICCardManager/src/ICCardManager/Services/DebugDataService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 #if DEBUG
 using ICCardManager.Common;
+using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
 
@@ -14,6 +15,7 @@ namespace ICCardManager.Services
     /// </summary>
     public class DebugDataService
     {
+        private readonly DbContext _dbContext;
         private readonly IStaffRepository _staffRepository;
         private readonly ICardRepository _cardRepository;
         private readonly ILedgerRepository _ledgerRepository;
@@ -58,10 +60,12 @@ namespace ICCardManager.Services
         };
 
         public DebugDataService(
+            DbContext dbContext,
             IStaffRepository staffRepository,
             ICardRepository cardRepository,
             ILedgerRepository ledgerRepository)
         {
+            _dbContext = dbContext;
             _staffRepository = staffRepository;
             _cardRepository = cardRepository;
             _ledgerRepository = ledgerRepository;
@@ -70,12 +74,28 @@ namespace ICCardManager.Services
         /// <summary>
         /// 全テストデータを登録
         /// </summary>
+        /// <remarks>
+        /// Issue #1074: 全INSERT操作を単一トランザクションで囲むことで高速化。
+        /// SQLiteではトランザクションなしの場合、各INSERTごとに暗黙的トランザクション+
+        /// fsyncが発生するため、約12,000件のINSERTが非常に遅くなる。
+        /// 単一トランザクションで囲むことで fsync を1回に削減し、50-100倍高速化する。
+        /// </remarks>
         public async Task RegisterAllTestDataAsync()
         {
-            await RegisterTestStaffAsync();
-            await RegisterTestCardsAsync();
-            var finalBalances = await RegisterSampleHistoryAsync();
-            await RegisterSpecialScenariosAsync(finalBalances);
+            using var transaction = _dbContext.BeginTransaction();
+            try
+            {
+                await RegisterTestStaffAsync();
+                await RegisterTestCardsAsync();
+                var finalBalances = await RegisterSampleHistoryAsync();
+                await RegisterSpecialScenariosAsync(finalBalances);
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
         }
 
         /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/DebugDataServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/DebugDataServiceTests.cs
@@ -1,5 +1,7 @@
 #if DEBUG
+using System.Data.SQLite;
 using FluentAssertions;
+using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Models;
 using ICCardManager.Services;
@@ -17,8 +19,10 @@ namespace ICCardManager.Tests.Services;
 /// DebugDataServiceの単体テスト（Issue #803）
 /// テストデータの残高チェーン整合性を検証する。
 /// </summary>
-public class DebugDataServiceTests
+public class DebugDataServiceTests : IDisposable
 {
+    private readonly SQLiteConnection _connection;
+    private readonly Mock<DbContext> _dbContextMock;
     private readonly Mock<IStaffRepository> _staffRepoMock;
     private readonly Mock<ICardRepository> _cardRepoMock;
     private readonly Mock<ILedgerRepository> _ledgerRepoMock;
@@ -32,9 +36,18 @@ public class DebugDataServiceTests
 
     public DebugDataServiceTests()
     {
+        _dbContextMock = new Mock<DbContext>();
         _staffRepoMock = new Mock<IStaffRepository>();
         _cardRepoMock = new Mock<ICardRepository>();
         _ledgerRepoMock = new Mock<ILedgerRepository>();
+
+        // トランザクションのモック（Issue #1074: 全操作をトランザクションで囲む対応）
+        // SQLiteTransactionはパラメータなしコンストラクタがないためMoqでモック不可。
+        // 実際のインメモリ接続からトランザクションを取得する。
+        _connection = new SQLiteConnection("Data Source=:memory:");
+        _connection.Open();
+        var transaction = _connection.BeginTransaction();
+        _dbContextMock.Setup(x => x.BeginTransaction()).Returns(transaction);
 
         // 全職員・全カード未登録
         _staffRepoMock.Setup(r => r.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()))
@@ -65,6 +78,7 @@ public class DebugDataServiceTests
             .ReturnsAsync(true);
 
         _service = new DebugDataService(
+            _dbContextMock.Object,
             _staffRepoMock.Object,
             _cardRepoMock.Object,
             _ledgerRepoMock.Object);
@@ -257,5 +271,10 @@ public class DebugDataServiceTests
     }
 
     #endregion
+
+    public void Dispose()
+    {
+        _connection?.Dispose();
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- `DebugDataService.RegisterAllTestDataAsync()` の約12,000件のINSERTを単一トランザクションで囲み、SQLiteのfsyncオーバーヘッドを1回に削減
- 既存の `_dbContext.BeginTransaction()` + `Commit/Rollback` パターンを踏襲
- 本番コード（リポジトリ、DbContext、App.xaml.cs）は一切変更なし

Closes #1074

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `DebugDataService.cs` | `DbContext`依存を追加、`RegisterAllTestDataAsync()`をトランザクションで囲む |
| `DebugDataServiceTests.cs` | `DbContext`モックとインメモリSQLiteトランザクション設定を追加 |

## 技術的背景
SQLiteではトランザクション外の各INSERTは暗黙的に `BEGIN → INSERT → COMMIT(+fsync)` が実行される。12,000回のfsyncは非常にコストが高い。単一トランザクションで囲むことで `BEGIN → 12,000回INSERT → COMMIT(fsync 1回)` となり、50-100倍の高速化が見込める。

## Test plan
- [x] 全2,075件の単体テストがパス（DebugDataServiceTests含む）
- [x] 既存の `iccard.db` を削除し、DEBUGビルドで `dotnet run` して起動時間の短縮を確認
- [x] カード一覧・職員一覧・台帳履歴が従来と同じデータが生成されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)