### PR TITLE
fix: 部署設定ファイルの削除失敗時に内容クリアで代替する

### DIFF
--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -384,8 +384,9 @@ namespace ICCardManager
                 var departmentValue = System.IO.File.ReadAllText(configPath).Trim();
 
                 // ファイルを削除（次回起動時に再適用しない）
-                try { System.IO.File.Delete(configPath); }
-                catch (Exception ex) { _logger?.LogWarning(ex, "部署設定ファイルの削除に失敗"); }
+                // インストーラー（管理者権限）が作成したファイルのため、
+                // 一般ユーザーでは削除できない場合がある（Issue #1080）
+                DeleteOrClearFile(configPath, _logger);
 
                 if (string.IsNullOrEmpty(departmentValue))
                 {
@@ -409,6 +410,47 @@ namespace ICCardManager
             {
                 _logger?.LogWarning(ex, "インストーラーからの部署設定の適用でエラー");
                 // エラーが発生してもアプリは起動させる（schema.sqlのデフォルト値が使用される）
+            }
+        }
+
+        /// <summary>
+        /// ファイルを削除する。削除できない場合はファイルの内容をクリアする（Issue #1080）
+        /// </summary>
+        /// <remarks>
+        /// インストーラー（管理者権限）が作成したファイルは、一般ユーザーでは
+        /// 削除権限がない場合がある。その場合、ファイル内容を空にすることで
+        /// 次回起動時の再適用を防ぐ。内容クリアも失敗した場合は警告ログを出力するが、
+        /// 同じ設定値の再適用は実害がないため処理を継続する。
+        /// </remarks>
+        /// <param name="filePath">削除対象のファイルパス</param>
+        /// <param name="logger">ロガー（省略可能）</param>
+        /// <returns>削除またはクリアに成功した場合true、両方失敗した場合false</returns>
+        internal static bool DeleteOrClearFile(string filePath, ILogger logger = null)
+        {
+            try
+            {
+                System.IO.File.Delete(filePath);
+                return true;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // 削除権限がない場合、内容をクリアして次回の再適用を防ぐ
+                try
+                {
+                    System.IO.File.WriteAllText(filePath, string.Empty);
+                    logger?.LogInformation("ファイルの削除権限がないため内容をクリアしました: {FilePath}", filePath);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "ファイルの削除・クリアに失敗（同一設定の再適用のため実害なし）: {FilePath}", filePath);
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "ファイルの削除に失敗: {FilePath}", filePath);
+                return false;
             }
         }
 

--- a/ICCardManager/tests/ICCardManager.Tests/DeleteOrClearFileTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/DeleteOrClearFileTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace ICCardManager.Tests;
+
+/// <summary>
+/// App.DeleteOrClearFile()のテスト
+/// ファイル削除とフォールバック（内容クリア）の動作を検証
+/// </summary>
+/// <remarks>
+/// 削除権限がないケース（UnauthorizedAccessException → WriteAllTextフォールバック）は
+/// テスト環境でACLを正確にシミュレートすることが困難なため、手動テストで確認する。
+/// </remarks>
+public class DeleteOrClearFileTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DeleteOrClearFileTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ICCardManagerTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+        }
+        catch
+        {
+            // テスト後のクリーンアップ失敗は無視
+        }
+    }
+
+    [Fact]
+    public void DeleteOrClearFile_通常のファイルの場合_削除されてtrueを返す()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        File.WriteAllText(filePath, "test content");
+
+        // Act
+        var result = App.DeleteOrClearFile(filePath);
+
+        // Assert
+        result.Should().BeTrue();
+        File.Exists(filePath).Should().BeFalse("ファイルが削除されるべき");
+    }
+
+    [Fact]
+    public void DeleteOrClearFile_存在しないファイルの場合_trueを返す()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "nonexistent.txt");
+
+        // Act
+        var result = App.DeleteOrClearFile(filePath);
+
+        // Assert
+        result.Should().BeTrue("File.Deleteは存在しないファイルに対してエラーを投げない");
+    }
+
+    [Fact]
+    public void DeleteOrClearFile_ロガーがnullの場合_例外が発生しない()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        File.WriteAllText(filePath, "test content");
+
+        // Act
+        var act = () => App.DeleteOrClearFile(filePath, null);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DeleteOrClearFile_削除後にファイルが再作成可能()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "recreate.txt");
+        File.WriteAllText(filePath, "original");
+        App.DeleteOrClearFile(filePath);
+
+        // Act: ファイルを再作成
+        File.WriteAllText(filePath, "new content");
+
+        // Assert
+        File.ReadAllText(filePath).Should().Be("new content");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1080

- `ApplyDepartmentConfigFromInstaller`でのファイル削除失敗時に、`File.WriteAllText(empty)`で内容をクリアするフォールバック処理を追加
- インストーラー（管理者権限）が作成した`department_config.txt`を一般ユーザーが削除できない問題に対応
- 内容クリア後は次回起動時に`string.IsNullOrEmpty`チェックで再適用をスキップ

### 変更の背景

インストーラーは管理者権限で`C:\ProgramData\ICCardManager\department_config.txt`を作成する。`C:\ProgramData`のデフォルトACLでは一般ユーザーにはファイル削除権限がないため、`File.Delete`が`UnauthorizedAccessException`で失敗していた。ファイル内容のクリアは書き込み権限のみで可能なため、フォールバック処理として実装。

## Test plan

- [x] 既存テスト全2089件パス
- [x] 新規ユニットテスト4件パス（DeleteOrClearFileTests）
  - 通常のファイル削除
  - 存在しないファイルの処理
  - ロガーがnullの場合の安全性
  - 削除後のファイル再作成可能性
- [ ] **手動テスト**: 管理者権限で`department_config.txt`を`C:\ProgramData\ICCardManager\`に作成し、一般ユーザーでアプリを起動。WARNINGログではなくINFOログ（「内容をクリアしました」）が出力され、設定が正常に適用されることを確認
- [ ] **手動テスト**: 2回目の起動時に部署設定が再適用されないことを確認（ファイル内容が空のため`string.IsNullOrEmpty`でスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)