### PR TITLE
fix: インストーラーでProgramDataディレクトリにUsers権限を設定

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -58,6 +58,13 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "autostart"; Description: "Auto-start at Windows login"; GroupDescription: "{cm:AdditionalIcons}"
 
+[Dirs]
+; データディレクトリ（C:\ProgramData\ICCardManager）にUsersフルコントロールを設定
+; 複数の職員（Windowsユーザー）が同一PCで利用するため全ユーザーにアクセスを許可
+Name: "{commonappdata}\ICCardManager"; Permissions: users-full
+Name: "{commonappdata}\ICCardManager\backup"; Permissions: users-full
+Name: "{commonappdata}\ICCardManager\Logs"; Permissions: users-full
+
 [Files]
 ; メインアプリケーションと依存DLL（すべてのDLL/EXE/config/pdbを含める）
 Source: "..\publish\*.exe"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
## Summary

#1078 の根本原因を修正。

クリーンインストール時にインストーラー（管理者権限）が`C:\ProgramData\ICCardManager`ディレクトリを作成するが、デフォルトのProgramData ACLではUsersグループには読み取り権限のみが付与される。アプリ側の`EnsureDirectoryWithPermissions`は一般ユーザーにACL変更権限がないため黙って失敗していた。

InnoSetupの`[Dirs]`セクションで`Permissions: users-full`を指定し、インストーラー（管理者権限）側でディレクトリ権限を設定することで根本解決する。

### 変更内容
- `ICCardManager.iss`に`[Dirs]`セクションを追加
- `{commonappdata}\ICCardManager`（メインデータ）
- `{commonappdata}\ICCardManager\backup`（バックアップ）
- `{commonappdata}\ICCardManager\Logs`（ログ）

## Test plan

- [x] 既存テスト全2090件パス（インストーラー変更のみのため既存テストへの影響なし）
- [ ] **手動テスト**: クリーンインストール後、一般ユーザーでアプリを起動し、以下を確認
  - `department_config.txt`の警告ログが出ないこと
  - `C:\ProgramData\ICCardManager`のセキュリティタブでUsersにフルコントロールが設定されていること
  - バックアップ・ログファイルが正常に作成されること
- [ ] **手動テスト**: 既存インストール環境に上書きインストールし、ディレクトリ権限が修正されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)