### PR TITLE
fix: カード番号採番の競合状態を防止するUNIQUE制約を追加

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -135,6 +135,7 @@ erDiagram
 **インデックス:**
 - `idx_card_deleted` ON ic_card(is_deleted)
 - `idx_card_lent_deleted` ON ic_card(is_lent, is_deleted)
+- `idx_card_type_number_active` UNIQUE ON ic_card(card_type, card_number) WHERE is_deleted = 0 — 有効カード間での種別＋番号の重複を防止
 
 **外部キー:**
 - last_lent_staff → staff(staff_idm)
@@ -271,6 +272,7 @@ ICカードの個別利用記録を保存するテーブル。
 |----------|----------------|--------|------|
 | staff | idx_staff_deleted | is_deleted | 有効な職員の検索 |
 | ic_card | idx_card_deleted | is_deleted | 有効なカードの検索 |
+| ic_card | idx_card_type_number_active | card_type, card_number (WHERE is_deleted = 0) | 種別＋番号の重複防止（UNIQUE、部分インデックス） |
 | ledger | idx_ledger_date | date | 日付での検索 |
 | ledger | idx_ledger_summary | summary | 摘要での検索 |
 | ledger | idx_ledger_card_date | card_idm, date | カード×日付の複合検索 |

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -939,8 +939,12 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 9 | 貸出中削除 | 貸出中カード | false（削除不可） |
 | 10 | 自動採番 | 空DB | "1" |
 | 11 | 種別別採番 | はやかけん="5", nimoca="10" | はやかけん→"6", nimoca→"11", SUGOCA→"1" |
+| 12 | 同一種別・同一番号のINSERT | 同種別・同番号で2枚目登録 | DuplicateCardNumberException |
+| 13 | 異なる種別の同一番号 | はやかけん"1"とnimoca"1" | 両方成功 |
+| 14 | 削除済みカードと同一番号 | 削除済み+同種別・同番号で新規 | 成功（部分ユニークインデックス） |
+| 15 | 競合シミュレーション | 同時採番→先着INSERT→後着リトライ | 最終的に異なる番号で登録 |
 
-**テストクラス:** `CardRepositoryTests`
+**テストクラス:** `CardRepositoryTests`, `CardNumberUniqueConstraintTests`
 
 #### UT-022: StaffRepository
 
@@ -1002,6 +1006,8 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 6 | 重複IDm | 登録済みIDm | "既に登録"+管理番号表示 |
 | 7 | 空IDm | EditCardIdm="" | "IDm"エラー |
 | 8 | 空管理番号（自動採番） | EditCardNumber="" | GetNextCardNumberAsync呼出 |
+| 8a | 自動採番の番号競合（リトライ） | 他PCが同番号を先に登録 | DuplicateCardNumberException→再採番→リトライ成功 |
+| 8b | 手動指定の番号競合 | 他PCと同じ種別・番号を指定 | "管理番号は既に使用されています"エラー |
 | 9 | 更新保存 | 既存カード編集 → Save | UpdateAsync呼出 |
 | 10 | 削除 | 未貸出カード | DeleteAsync呼出 |
 | 11 | 貸出中削除 | IsLent=true | "貸出中"エラー |

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_008_AddCardTypeNumberUniqueIndex.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_008_AddCardTypeNumberUniqueIndex.cs
@@ -1,0 +1,145 @@
+using System.Data.SQLite;
+
+namespace ICCardManager.Data.Migrations
+{
+    /// <summary>
+    /// カード種別＋管理番号のユニークインデックスを追加するマイグレーション
+    /// </summary>
+    /// <remarks>
+    /// Issue #1106: 共有フォルダモードで複数PCから同一種別のカードを同時に登録すると、
+    /// GetNextCardNumberAsync の SELECT MAX + 1 パターンにより同じ管理番号が採番される。
+    /// 部分ユニークインデックス（is_deleted = 0）を追加し、有効なカード間での番号重複を防止する。
+    /// </remarks>
+    public class Migration_008_AddCardTypeNumberUniqueIndex : IMigration
+    {
+        public int Version => 8;
+        public string Description => "カード種別＋管理番号のユニークインデックス追加";
+
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // 既存データの重複を解消（安全策: 同一種別・同一番号の有効カードが複数あれば番号をずらす）
+            ResolveDuplicates(connection, transaction);
+
+            // 部分ユニークインデックスを追加
+            // is_deleted = 0 のカードのみ対象（削除済みカードは重複を許容する）
+            // レガシーDBではis_deletedカラムが存在しない場合があるが、
+            // Migration_001が先に適用されるため通常はis_deletedが存在する
+            var hasIsDeleted = HasColumn(connection, transaction, "ic_card", "is_deleted");
+            if (hasIsDeleted)
+            {
+                ExecuteNonQuery(connection, transaction,
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_card_type_number_active ON ic_card(card_type, card_number) WHERE is_deleted = 0");
+            }
+            else
+            {
+                // is_deletedがない場合は全カードを対象とするユニークインデックス
+                ExecuteNonQuery(connection, transaction,
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_card_type_number_active ON ic_card(card_type, card_number)");
+            }
+        }
+
+        public void Down(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            ExecuteNonQuery(connection, transaction,
+                "DROP INDEX IF EXISTS idx_card_type_number_active");
+        }
+
+        /// <summary>
+        /// 既存データに同一種別・同一番号の有効カードが複数ある場合、番号をずらして重複を解消する
+        /// </summary>
+        private static void ResolveDuplicates(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // is_deletedカラムの存在を確認（レガシーDBでは存在しない場合がある）
+            var hasIsDeleted = HasColumn(connection, transaction, "ic_card", "is_deleted");
+            var whereClause = hasIsDeleted ? "WHERE is_deleted = 0" : "";
+
+            // 重複しているcard_type + card_numberの組を検出
+            using var findCmd = connection.CreateCommand();
+            findCmd.Transaction = transaction;
+            findCmd.CommandText = $@"SELECT card_type, card_number, COUNT(*) as cnt
+FROM ic_card
+{whereClause}
+GROUP BY card_type, card_number
+HAVING cnt > 1";
+
+            var duplicates = new System.Collections.Generic.List<(string cardType, string cardNumber)>();
+            using (var reader = findCmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    duplicates.Add((reader.GetString(0), reader.GetString(1)));
+                }
+            }
+
+            foreach (var (cardType, cardNumber) in duplicates)
+            {
+                // 重複カードのIDmを取得（最初の1件は元の番号を保持、残りをリナンバー）
+                using var listCmd = connection.CreateCommand();
+                listCmd.Transaction = transaction;
+                var listWhere = hasIsDeleted
+                    ? "WHERE card_type = @cardType AND card_number = @cardNumber AND is_deleted = 0"
+                    : "WHERE card_type = @cardType AND card_number = @cardNumber";
+                listCmd.CommandText = $@"SELECT card_idm FROM ic_card
+{listWhere}
+ORDER BY card_idm
+LIMIT -1 OFFSET 1";
+                listCmd.Parameters.AddWithValue("@cardType", cardType);
+                listCmd.Parameters.AddWithValue("@cardNumber", cardNumber);
+
+                var duplicateIdms = new System.Collections.Generic.List<string>();
+                using (var reader = listCmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        duplicateIdms.Add(reader.GetString(0));
+                    }
+                }
+
+                // 重複カードに新しい番号を割り当て
+                foreach (var idm in duplicateIdms)
+                {
+                    // 現在の最大番号を取得して+1
+                    using var maxCmd = connection.CreateCommand();
+                    maxCmd.Transaction = transaction;
+                    maxCmd.CommandText = @"SELECT MAX(CAST(card_number AS INTEGER))
+FROM ic_card WHERE card_type = @cardType";
+                    maxCmd.Parameters.AddWithValue("@cardType", cardType);
+                    var maxResult = maxCmd.ExecuteScalar();
+                    var nextNumber = (maxResult == System.DBNull.Value ? 0 : System.Convert.ToInt32(maxResult)) + 1;
+
+                    using var updateCmd = connection.CreateCommand();
+                    updateCmd.Transaction = transaction;
+                    updateCmd.CommandText = "UPDATE ic_card SET card_number = @newNumber WHERE card_idm = @cardIdm";
+                    updateCmd.Parameters.AddWithValue("@newNumber", nextNumber.ToString());
+                    updateCmd.Parameters.AddWithValue("@cardIdm", idm);
+                    updateCmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 指定テーブルに指定カラムが存在するかを確認
+        /// </summary>
+        private static bool HasColumn(SQLiteConnection connection, SQLiteTransaction transaction, string tableName, string columnName)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = $"PRAGMA table_info({tableName})";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                if (reader.GetString(1) == columnName)
+                    return true;
+            }
+            return false;
+        }
+
+        private static void ExecuteNonQuery(SQLiteConnection connection, SQLiteTransaction transaction, string sql)
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = sql;
+            command.ExecuteNonQuery();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Data/Repositories/CardRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/CardRepository.cs
@@ -200,6 +200,9 @@ WHERE card_idm = @cardIdm AND is_deleted = 0";
         /// <summary>
         /// カード登録の内部実装
         /// </summary>
+        /// <exception cref="DuplicateCardNumberException">
+        /// 同一種別で同一管理番号のカードが既に存在する場合（UNIQUE制約違反）
+        /// </exception>
         private async Task<bool> InsertAsyncInternal(IcCard card, SQLiteTransaction? transaction)
         {
             var connection = _dbContext.GetConnection();
@@ -226,10 +229,28 @@ VALUES (@cardIdm, @cardType, @cardNumber, @note, 0, NULL, 0, NULL, NULL, @starti
                 }
                 return result > 0;
             }
+            catch (SQLiteException ex) when (IsDuplicateCardNumberError(ex))
+            {
+                throw new DuplicateCardNumberException(card.CardType, card.CardNumber, ex);
+            }
             catch (SQLiteException)
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// SQLiteExceptionがカード種別＋管理番号のUNIQUE制約違反かどうかを判定
+        /// </summary>
+        private static bool IsDuplicateCardNumberError(SQLiteException ex)
+        {
+            // SQLiteのUNIQUE制約違反はConstraintで報告される
+            // メッセージに "ic_card.card_type, ic_card.card_number" が含まれるかで判別
+            if (ex.ResultCode != SQLiteErrorCode.Constraint || ex.Message == null)
+                return false;
+
+            return ex.Message.Contains("ic_card.card_type") &&
+                   ex.Message.Contains("ic_card.card_number");
         }
 
         /// <inheritdoc/>

--- a/ICCardManager/src/ICCardManager/Data/Repositories/DuplicateCardNumberException.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/DuplicateCardNumberException.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace ICCardManager.Data.Repositories
+{
+    /// <summary>
+    /// カード種別＋管理番号の重複時にスローされる例外
+    /// </summary>
+    /// <remarks>
+    /// Issue #1106: 共有フォルダモードで複数PCから同時にカードを登録した場合に、
+    /// UNIQUE制約（idx_card_type_number_active）違反を検出するために使用。
+    /// </remarks>
+    public class DuplicateCardNumberException : Exception
+    {
+        /// <summary>
+        /// 重複したカード種別
+        /// </summary>
+        public string CardType { get; }
+
+        /// <summary>
+        /// 重複した管理番号
+        /// </summary>
+        public string CardNumber { get; }
+
+        public DuplicateCardNumberException(string cardType, string cardNumber, Exception innerException)
+            : base($"同一種別（{cardType}）で同一管理番号（{cardNumber}）のカードが既に登録されています。", innerException)
+        {
+            CardType = cardType;
+            CardNumber = cardNumber;
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/CardManageViewModel.cs
@@ -357,7 +357,8 @@ namespace ICCardManager.ViewModels
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(sanitizedCardNumber))
+            var isAutoNumbered = string.IsNullOrWhiteSpace(sanitizedCardNumber);
+            if (isAutoNumbered)
             {
                 // 自動採番
                 sanitizedCardNumber = await _cardRepository.GetNextCardNumberAsync(EditCardType);
@@ -442,7 +443,30 @@ namespace ICCardManager.ViewModels
                         StartingPageNumber = modeResult.StartingPageNumber
                     };
 
-                    var success = await _cardRepository.InsertAsync(card);
+                    bool success;
+                    try
+                    {
+                        success = await _cardRepository.InsertAsync(card);
+                    }
+                    catch (DuplicateCardNumberException)
+                    {
+                        if (isAutoNumbered)
+                        {
+                            // Issue #1106: 自動採番で番号が競合した場合、再採番してリトライ
+                            sanitizedCardNumber = await _cardRepository.GetNextCardNumberAsync(EditCardType);
+                            card.CardNumber = sanitizedCardNumber;
+                            success = await _cardRepository.InsertAsync(card);
+                        }
+                        else
+                        {
+                            // 手動指定の番号が重複
+                            StatusMessage = $"管理番号 {sanitizedCardNumber} は同じ種別で既に使用されています。別の番号を指定してください。";
+                            IsStatusError = true;
+                            _registrationModeResult = null;
+                            return;
+                        }
+                    }
+
                     if (success)
                     {
                         // 操作ログを記録

--- a/ICCardManager/tests/ICCardManager.Tests/Data/CardNumberUniqueConstraintTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/CardNumberUniqueConstraintTests.cs
@@ -1,0 +1,281 @@
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Caching;
+using ICCardManager.Models;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Data.SQLite;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ICCardManager.Tests.Data;
+
+/// <summary>
+/// Issue #1106: カード種別＋管理番号のユニーク制約テスト
+/// 共有フォルダモードで複数PCから同時にカード登録した際の番号重複を防止する。
+/// </summary>
+public class CardNumberUniqueConstraintTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly CardRepository _repository;
+    private readonly Mock<ICacheService> _cacheServiceMock;
+
+    public CardNumberUniqueConstraintTests()
+    {
+        _dbContext = TestDbContextFactory.Create();
+        _cacheServiceMock = new Mock<ICacheService>();
+        _cacheServiceMock.Setup(c => c.GetOrCreateAsync(
+            It.IsAny<string>(),
+            It.IsAny<Func<Task<IEnumerable<IcCard>>>>(),
+            It.IsAny<TimeSpan>()))
+            .Returns((string key, Func<Task<IEnumerable<IcCard>>> factory, TimeSpan expiration) => factory());
+
+        _repository = new CardRepository(_dbContext, _cacheServiceMock.Object, Options.Create(new CacheOptions()));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    #region UNIQUE制約の基本動作テスト
+
+    /// <summary>
+    /// 同一種別・同一番号のカード登録でDuplicateCardNumberExceptionがスローされることを確認
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InsertAsync_DuplicateCardTypeAndNumber_ThrowsDuplicateCardNumberException()
+    {
+        // Arrange
+        var card1 = CreateTestCard("CARD000000000001", "はやかけん", "1");
+        var card2 = CreateTestCard("CARD000000000002", "はやかけん", "1");
+
+        await _repository.InsertAsync(card1);
+
+        // Act & Assert
+        var act = async () => await _repository.InsertAsync(card2);
+
+        var ex = await act.Should().ThrowAsync<DuplicateCardNumberException>();
+        ex.Which.CardType.Should().Be("はやかけん");
+        ex.Which.CardNumber.Should().Be("1");
+    }
+
+    /// <summary>
+    /// 異なる種別なら同一番号でも登録できることを確認
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InsertAsync_SameNumberDifferentType_Succeeds()
+    {
+        // Arrange
+        var card1 = CreateTestCard("CARD000000000001", "はやかけん", "1");
+        var card2 = CreateTestCard("CARD000000000002", "nimoca", "1");
+
+        // Act
+        var result1 = await _repository.InsertAsync(card1);
+        var result2 = await _repository.InsertAsync(card2);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 同一種別でも異なる番号なら登録できることを確認
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InsertAsync_DifferentNumberSameType_Succeeds()
+    {
+        // Arrange
+        var card1 = CreateTestCard("CARD000000000001", "はやかけん", "1");
+        var card2 = CreateTestCard("CARD000000000002", "はやかけん", "2");
+
+        // Act
+        var result1 = await _repository.InsertAsync(card1);
+        var result2 = await _repository.InsertAsync(card2);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 削除済みカードと同じ種別・番号のカードを登録できることを確認
+    /// （部分ユニークインデックスはis_deleted = 0のみ対象）
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InsertAsync_SameNumberAsDeletedCard_Succeeds()
+    {
+        // Arrange
+        var card1 = CreateTestCard("CARD000000000001", "はやかけん", "1");
+        await _repository.InsertAsync(card1);
+        await _repository.DeleteAsync("CARD000000000001");
+
+        var card2 = CreateTestCard("CARD000000000002", "はやかけん", "1");
+
+        // Act
+        var result = await _repository.InsertAsync(card2);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region マイグレーション テスト
+
+    /// <summary>
+    /// マイグレーション008でユニークインデックスが作成されることを確認
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Migration008_CreatesUniqueIndex()
+    {
+        // Assert: インデックスの存在を確認
+        var connection = _dbContext.GetConnection();
+        IndexShouldExist(connection, "idx_card_type_number_active");
+    }
+
+    /// <summary>
+    /// マイグレーション008が既存の重複データを解消することを確認
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Migration008_ResolvesDuplicatesBeforeCreatingIndex()
+    {
+        // Arrange: インメモリDBを直接作成し、重複状態にする
+        using var connection = new SQLiteConnection("Data Source=:memory:");
+        connection.Open();
+
+        // ic_cardテーブルを作成（ユニーク制約なし）
+        SetupSchemaWithoutMigration008(connection);
+
+        // 重複データを挿入
+        ExecuteNonQuery(connection, "INSERT INTO ic_card (card_idm, card_type, card_number, is_deleted) VALUES ('IDM001', 'はやかけん', '1', 0)");
+        ExecuteNonQuery(connection, "INSERT INTO ic_card (card_idm, card_type, card_number, is_deleted) VALUES ('IDM002', 'はやかけん', '1', 0)");
+
+        // Act: マイグレーション008を適用
+        var migration = new ICCardManager.Data.Migrations.Migration_008_AddCardTypeNumberUniqueIndex();
+        using var transaction = connection.BeginTransaction();
+        migration.Up(connection, transaction);
+        transaction.Commit();
+
+        // Assert: 重複が解消されていること
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT card_number FROM ic_card WHERE card_idm = 'IDM001' AND is_deleted = 0";
+        var number1 = cmd.ExecuteScalar()?.ToString();
+
+        cmd.CommandText = "SELECT card_number FROM ic_card WHERE card_idm = 'IDM002' AND is_deleted = 0";
+        var number2 = cmd.ExecuteScalar()?.ToString();
+
+        number1.Should().NotBe(number2, "重複が解消され、異なる番号が割り当てられているべき");
+    }
+
+    #endregion
+
+    #region GetNextCardNumberAsync + Insert 競合シミュレーション
+
+    /// <summary>
+    /// 同じ番号を2つのカードに割り当てようとした場合、UNIQUE制約で防止されることを確認
+    /// （共有フォルダモードでの競合状態のシミュレーション）
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ConcurrentRegistration_SameAutoNumber_SecondInsertThrowsException()
+    {
+        // Arrange: 初期カードを登録
+        var existingCard = CreateTestCard("CARD000000000001", "はやかけん", "1");
+        await _repository.InsertAsync(existingCard);
+
+        // Act: 2つの「PC」が同時に次の番号を取得（両方とも "2" を取得）
+        var nextNumber1 = await _repository.GetNextCardNumberAsync("はやかけん");
+        var nextNumber2 = await _repository.GetNextCardNumberAsync("はやかけん");
+
+        nextNumber1.Should().Be("2");
+        nextNumber2.Should().Be("2", "同時に取得すると同じ番号になる");
+
+        // PC-Aが先にINSERT成功
+        var cardA = CreateTestCard("CARD000000000002", "はやかけん", nextNumber1);
+        var resultA = await _repository.InsertAsync(cardA);
+        resultA.Should().BeTrue();
+
+        // PC-BのINSERTは番号重複でDuplicateCardNumberExceptionがスロー
+        var cardB = CreateTestCard("CARD000000000003", "はやかけん", nextNumber2);
+        var act = async () => await _repository.InsertAsync(cardB);
+        await act.Should().ThrowAsync<DuplicateCardNumberException>();
+
+        // PC-Bが再採番してリトライ
+        var retryNumber = await _repository.GetNextCardNumberAsync("はやかけん");
+        retryNumber.Should().Be("3", "PC-Aの登録後は3が採番される");
+
+        cardB.CardNumber = retryNumber;
+        var resultB = await _repository.InsertAsync(cardB);
+        resultB.Should().BeTrue();
+
+        // Assert: 最終的に2枚のカードが異なる番号で登録されている
+        var allCards = await _repository.GetAllAsync();
+        var hayakakenCards = allCards.Where(c => c.CardType == "はやかけん").ToList();
+        hayakakenCards.Should().HaveCount(3); // 元の1枚 + 新規2枚
+        hayakakenCards.Select(c => c.CardNumber).Should().OnlyHaveUniqueItems();
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private static IcCard CreateTestCard(string cardIdm, string cardType, string cardNumber)
+    {
+        return new IcCard
+        {
+            CardIdm = cardIdm,
+            CardType = cardType,
+            CardNumber = cardNumber,
+            IsDeleted = false,
+            IsLent = false
+        };
+    }
+
+    private static void IndexShouldExist(SQLiteConnection connection, string indexName)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='index' AND name=@name";
+        cmd.Parameters.AddWithValue("@name", indexName);
+        var result = cmd.ExecuteScalar();
+        result.Should().NotBeNull($"インデックス '{indexName}' が存在するべき");
+    }
+
+    private static void SetupSchemaWithoutMigration008(SQLiteConnection connection)
+    {
+        ExecuteNonQuery(connection, @"CREATE TABLE IF NOT EXISTS ic_card (
+    card_idm        TEXT PRIMARY KEY,
+    card_type       TEXT NOT NULL,
+    card_number     TEXT NOT NULL,
+    note            TEXT,
+    is_deleted      INTEGER DEFAULT 0,
+    deleted_at      TEXT,
+    is_lent         INTEGER DEFAULT 0,
+    last_lent_at    TEXT,
+    last_lent_staff TEXT,
+    starting_page_number INTEGER DEFAULT 1,
+    is_refunded     INTEGER DEFAULT 0,
+    refunded_at     TEXT
+)");
+    }
+
+    private static void ExecuteNonQuery(SQLiteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/DbContextMigrationTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/DbContextMigrationTests.cs
@@ -120,8 +120,8 @@ CREATE TABLE settings (
         _dbContext.InitializeDatabase();
 
         // Assert
-        // レガシーDBはバージョン1として認識され、その後Migration_002〜007も適用されるので最終バージョンは7
-        _dbContext.GetDatabaseVersion().Should().Be(7);
+        // レガシーDBはバージョン1として認識され、その後Migration_002〜008も適用されるので最終バージョンは8
+        _dbContext.GetDatabaseVersion().Should().Be(8);
         TableShouldExist(connection, "schema_migrations");
 
         // バージョン1（既存DB認識）の記録が存在することを確認
@@ -149,8 +149,8 @@ CREATE TABLE settings (
         var count = Convert.ToInt32(cmd.ExecuteScalar());
 
         // 現在のマイグレーション数と一致するはず（重複していないこと）
-        // Migration_001 〜 Migration_007 = 7
-        count.Should().Be(7);
+        // Migration_001 〜 Migration_008 = 8
+        count.Should().Be(8);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1106

共有フォルダモードで複数PCから同一種別のカードを同時に登録した場合に、`GetNextCardNumberAsync` の SELECT MAX + 1 パターンにより同じ管理番号が採番される問題を修正。

- **Migration_008**: `ic_card(card_type, card_number) WHERE is_deleted = 0` の部分ユニークインデックスを追加。既存の重複データがある場合はマイグレーション時に自動解消
- **CardRepository**: UNIQUE制約違反を `DuplicateCardNumberException` として検出・スロー（他のSQLiteエラーとの区別）
- **CardManageViewModel**: 自動採番で番号が競合した場合は再採番してリトライ、手動指定の場合は明確なエラーメッセージを表示
- **設計書**: DB設計書にインデックス情報追加、テスト設計書にテストケース追加

## Test plan

- [x] 同一種別・同一番号のINSERTで `DuplicateCardNumberException` がスローされる
- [x] 異なる種別の同一番号は登録可能
- [x] 削除済みカードと同じ種別・番号の新規カードは登録可能（部分インデックス）
- [x] マイグレーション008でユニークインデックスが作成される
- [x] マイグレーション008が既存の重複データを自動解消する
- [x] 競合シミュレーション（同時採番→先着INSERT→後着リトライ）が成功する
- [x] 既存テスト全2118件パス
- [x] 手動テスト: カード管理画面で手動指定した番号が重複する場合にエラーメッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)