### PR TITLE
fix: 共有モードでのリストア操作の安全性を確保

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1781,8 +1781,14 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 |----|-------------|------|---------|
 | 1 | ローカルDBバックアップ | ローカルDB | バックアップファイルが正しく作成される |
 | 2 | 共有モードでバックアップ | 共有フォルダ上のDB | 他PC接続中でもバックアップ成功 |
+| 3 | 排他ロック取得可（未使用ファイル） | ロックなし | CanAcquireExclusiveLock = true |
+| 4 | 排他ロック取得不可（他PC接続中） | ファイルロック中 | CanAcquireExclusiveLock = false |
+| 5 | 共有モードリストア（他PC接続中） | ファイルロック中 | RestoreFromBackup = false |
+| 6 | 共有モードリストア（他PC接続なし） | ロックなし | RestoreFromBackup = true |
+| 7 | リストア後のジャーナルファイル清掃 | .db-journal存在 | リストア後に削除される |
+| 8 | IsSharedModeプロパティ | DbContext共有/ローカル | 正しく反映 |
 
-**テストクラス:** `BackupServiceTests`
+**テストクラス:** `BackupServiceTests`, `BackupServiceRestoreSafetyTests`
 
 ### 7a.2 結合テスト
 

--- a/ICCardManager/src/ICCardManager/Services/BackupService.cs
+++ b/ICCardManager/src/ICCardManager/Services/BackupService.cs
@@ -50,6 +50,11 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 共有モードかどうか（DbContextの状態を公開）
+        /// </summary>
+        public bool IsSharedMode => _dbContext.IsSharedMode;
+
+        /// <summary>
         /// 自動バックアップを実行
         /// </summary>
         /// <returns>作成されたバックアップファイルのパス（失敗時はnull）</returns>
@@ -218,17 +223,19 @@ namespace ICCardManager.Services
                     return false;
                 }
 
-                // 共有モード時は警告（他PCの接続が残っているとリストアが失敗する可能性がある）
-                if (_dbContext.IsSharedMode)
-                {
-                    _logger.LogWarning(
-                        "共有モードでリストアを実行します。他のPCでアプリケーションが起動している場合、リストアが失敗する可能性があります。");
-                }
-
                 // Issue #508: DBファイルを置き換える前に接続を閉じる
                 // SQLite接続が開いているとファイルがロックされ、置き換えに失敗する
                 _dbContext.CloseConnection();
                 _logger.LogDebug("リストア準備: DB接続を閉じました");
+
+                // Issue #1108: 共有モード時は他PCの接続を検出し、接続があればリストアを拒否する
+                if (_dbContext.IsSharedMode && !CanAcquireExclusiveLock(targetPath))
+                {
+                    _logger.LogWarning(
+                        "共有モードでリストアが拒否されました: 他のPCがデータベースに接続中です。" +
+                        "すべてのPCでアプリケーションを終了してから再度お試しください。");
+                    return false;
+                }
 
                 // 現在のDBを退避
                 if (File.Exists(targetPath))
@@ -244,6 +251,12 @@ namespace ICCardManager.Services
                 try
                 {
                     File.Copy(backupFilePath, targetPath, overwrite: true);
+
+                    // Issue #1108: ジャーナルファイルを清掃
+                    // リストア前のジャーナルが残っていると、次回接続時にジャーナルリカバリが
+                    // 実行され、リストアした内容が上書きされる可能性がある
+                    CleanupJournalFiles(targetPath);
+
                     // 成功したら退避ファイルを削除
                     if (File.Exists(tempPath))
                     {
@@ -398,6 +411,74 @@ namespace ICCardManager.Services
             catch
             {
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// データベースファイルの排他ロックを取得できるか確認する
+        /// </summary>
+        /// <remarks>
+        /// Issue #1108: 共有モードでリストア前に、他PCがDBに接続中かどうかを検出する。
+        /// FileShare.Noneで排他的にファイルを開き、成功すれば他の接続がないと判断する。
+        /// SMB越しでもWindowsのファイルロックが機能するため、この方法で検出可能。
+        /// </remarks>
+        /// <param name="dbPath">データベースファイルのパス</param>
+        /// <returns>排他ロックが取得できた場合true（他接続なし）</returns>
+        internal static bool CanAcquireExclusiveLock(string dbPath)
+        {
+            if (!File.Exists(dbPath))
+                return true;
+
+            try
+            {
+                // FileShare.Noneで開くことで排他ロックを試行
+                using var stream = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return true;
+            }
+            catch (IOException)
+            {
+                // 他プロセスがファイルを使用中
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // アクセス権限がない場合も安全のためfalse
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// SQLiteのジャーナルファイルを清掃する
+        /// </summary>
+        /// <remarks>
+        /// Issue #1108: リストア後に古いジャーナルファイルが残っていると、
+        /// 次回接続時にSQLiteがジャーナルリカバリを実行し、
+        /// リストアした内容が上書きされる可能性がある。
+        /// </remarks>
+        /// <param name="dbPath">データベースファイルのパス</param>
+        internal void CleanupJournalFiles(string dbPath)
+        {
+            var journalFiles = new[]
+            {
+                dbPath + "-journal",
+                dbPath + "-wal",
+                dbPath + "-shm"
+            };
+
+            foreach (var file in journalFiles)
+            {
+                try
+                {
+                    if (File.Exists(file))
+                    {
+                        File.Delete(file);
+                        _logger.LogDebug("ジャーナルファイルを削除しました: {Path}", file);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "ジャーナルファイルの削除に失敗しました: {Path}", file);
+                }
             }
         }
 

--- a/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
@@ -150,10 +150,17 @@ public partial class SystemManageViewModel : ViewModelBase
         }
 
         // 確認ダイアログ
+        // Issue #1108: 共有モード時は他PCの終了を促す警告を追加
+        var sharedModeWarning = _backupService.IsSharedMode
+            ? "【重要】共有モードで使用中のため、リストア前にすべてのPCでアプリケーションを終了してください。\n" +
+              "他のPCが接続中の場合、リストアは実行できません。\n\n"
+            : "";
+
         var result = MessageBox.Show(
             $"以下のバックアップからデータを復元します。\n\n" +
             $"ファイル: {SelectedBackup.FileName}\n" +
             $"作成日時: {DisplayFormatters.FormatTimestamp(SelectedBackup.CreatedAt)}\n\n" +
+            sharedModeWarning +
             $"現在のデータは上書きされます。\n" +
             $"（復元前に現在のデータは自動バックアップされます）\n\n" +
             $"続行しますか？",
@@ -207,7 +214,12 @@ public partial class SystemManageViewModel : ViewModelBase
                 }
                 else
                 {
-                    SetStatus("リストアに失敗しました", true);
+                    // Issue #1108: 共有モード時は他PC接続が原因の可能性を示唆
+                    var errorMessage = _backupService.IsSharedMode
+                        ? "リストアに失敗しました。他のPCでアプリケーションが起動中の可能性があります。" +
+                          "すべてのPCでアプリケーションを終了してから再度お試しください。"
+                        : "リストアに失敗しました";
+                    SetStatus(errorMessage, true);
                 }
             }
             catch (Exception ex)
@@ -262,9 +274,16 @@ public partial class SystemManageViewModel : ViewModelBase
         }
 
         // 確認ダイアログ
+        // Issue #1108: 共有モード時は他PCの終了を促す警告を追加
+        var sharedModeWarning2 = _backupService.IsSharedMode
+            ? "【重要】共有モードで使用中のため、リストア前にすべてのPCでアプリケーションを終了してください。\n" +
+              "他のPCが接続中の場合、リストアは実行できません。\n\n"
+            : "";
+
         var result = MessageBox.Show(
             $"以下のファイルからデータを復元します。\n\n" +
             $"ファイル: {Path.GetFileName(dialog.FileName)}\n\n" +
+            sharedModeWarning2 +
             $"現在のデータは上書きされます。\n" +
             $"（復元前に現在のデータは自動バックアップされます）\n\n" +
             $"続行しますか？",
@@ -321,7 +340,12 @@ public partial class SystemManageViewModel : ViewModelBase
                 }
                 else
                 {
-                    SetStatus("リストアに失敗しました", true);
+                    // Issue #1108: 共有モード時は他PC接続が原因の可能性を示唆
+                    var errorMessage2 = _backupService.IsSharedMode
+                        ? "リストアに失敗しました。他のPCでアプリケーションが起動中の可能性があります。" +
+                          "すべてのPCでアプリケーションを終了してから再度お試しください。"
+                        : "リストアに失敗しました";
+                    SetStatus(errorMessage2, true);
                 }
             }
             catch (Exception ex)

--- a/ICCardManager/tests/ICCardManager.Tests/Services/BackupServiceRestoreSafetyTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/BackupServiceRestoreSafetyTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// Issue #1108: BackupServiceのリストア安全性テスト
+/// 共有モードで他PCの接続を検出し、リストアを拒否する機能を検証する。
+/// </summary>
+public class BackupServiceRestoreSafetyTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly string _backupDirectory;
+
+    public BackupServiceRestoreSafetyTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"RestoreSafetyTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+        _backupDirectory = Path.Combine(_testDirectory, "backup");
+        Directory.CreateDirectory(_backupDirectory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testDirectory))
+                Directory.Delete(_testDirectory, recursive: true);
+        }
+        catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    #region CanAcquireExclusiveLock テスト
+
+    /// <summary>
+    /// ファイルが存在しない場合、排他ロックは取得可能（trueを返す）
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CanAcquireExclusiveLock_ファイル未存在でtrueを返すこと()
+    {
+        var nonExistentPath = Path.Combine(_testDirectory, "nonexistent.db");
+
+        BackupService.CanAcquireExclusiveLock(nonExistentPath).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// ファイルが存在し他プロセスが使用していない場合、排他ロックが取得できること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CanAcquireExclusiveLock_未使用ファイルでtrueを返すこと()
+    {
+        var dbPath = Path.Combine(_testDirectory, "unlocked.db");
+        File.WriteAllText(dbPath, "test");
+
+        BackupService.CanAcquireExclusiveLock(dbPath).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// ファイルが他プロセスにロックされている場合、falseを返すこと
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CanAcquireExclusiveLock_ロック中ファイルでfalseを返すこと()
+    {
+        var dbPath = Path.Combine(_testDirectory, "locked.db");
+        File.WriteAllText(dbPath, "test");
+
+        // 他プロセスによるロックをシミュレート
+        using var lockStream = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        BackupService.CanAcquireExclusiveLock(dbPath).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// ファイルが読み取り共有で開かれている場合、排他ロックが取得できないこと
+    /// （他PCのSQLite接続をシミュレート）
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CanAcquireExclusiveLock_読み取り共有ロック中でfalseを返すこと()
+    {
+        var dbPath = Path.Combine(_testDirectory, "shared_read.db");
+        File.WriteAllText(dbPath, "test");
+
+        // SQLiteの典型的なロック（Read/Write + ReadWrite共有）をシミュレート
+        using var lockStream = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+        BackupService.CanAcquireExclusiveLock(dbPath).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region CleanupJournalFiles テスト
+
+    /// <summary>
+    /// ジャーナルファイルが存在する場合に削除されること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CleanupJournalFiles_ジャーナルファイルを削除すること()
+    {
+        var dbPath = Path.Combine(_testDirectory, "cleanup.db");
+        File.WriteAllText(dbPath, "test");
+
+        // ジャーナルファイルを作成
+        File.WriteAllText(dbPath + "-journal", "journal");
+        File.WriteAllText(dbPath + "-wal", "wal");
+        File.WriteAllText(dbPath + "-shm", "shm");
+
+        var service = CreateService(dbPath);
+        service.CleanupJournalFiles(dbPath);
+
+        File.Exists(dbPath + "-journal").Should().BeFalse();
+        File.Exists(dbPath + "-wal").Should().BeFalse();
+        File.Exists(dbPath + "-shm").Should().BeFalse();
+        // DBファイル自体は削除されないこと
+        File.Exists(dbPath).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// ジャーナルファイルが存在しない場合もエラーにならないこと
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CleanupJournalFiles_ファイル未存在でもエラーにならないこと()
+    {
+        var dbPath = Path.Combine(_testDirectory, "no_journal.db");
+
+        var service = CreateService(dbPath);
+        var act = () => service.CleanupJournalFiles(dbPath);
+
+        act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region RestoreFromBackup 共有モード テスト
+
+    /// <summary>
+    /// 共有モードで他PCが接続中の場合、リストアが拒否されること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromBackup_共有モードで他接続ありの場合falseを返すこと()
+    {
+        var dbPath = Path.Combine(_testDirectory, "shared_restore.db");
+        using var dbContext = new DbContext(dbPath);
+        dbContext.InitializeDatabase();
+
+        // バックアップファイルを作成
+        var backupPath = Path.Combine(_backupDirectory, "backup.db");
+        File.Copy(dbPath, backupPath);
+
+        var service = new BackupService(
+            dbContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+
+        // 他プロセスのロックをシミュレート（DBファイルを排他的に開く）
+        // まず自PCの接続を閉じてから他PCロックをシミュレートする
+        dbContext.CloseConnection();
+        using var otherPcLock = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+        // Act
+        var result = service.RestoreFromBackup(backupPath);
+
+        // Assert
+        result.Should().BeFalse("他PCが接続中のためリストアは拒否されるべき");
+    }
+
+    /// <summary>
+    /// 共有モードで他PCが接続していない場合、リストアが成功すること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromBackup_共有モードで他接続なしの場合成功すること()
+    {
+        var dbPath = Path.Combine(_testDirectory, "shared_restore_ok.db");
+        using var dbContext = new DbContext(dbPath);
+        dbContext.InitializeDatabase();
+
+        // バックアップファイルを作成
+        var backupPath = Path.Combine(_backupDirectory, "backup_ok.db");
+        File.Copy(dbPath, backupPath);
+
+        var service = new BackupService(
+            dbContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+
+        // Act（他接続なし）
+        var result = service.RestoreFromBackup(backupPath);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// リストア成功後にジャーナルファイルが清掃されること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromBackup_成功後にジャーナルファイルが削除されること()
+    {
+        var dbPath = Path.Combine(_testDirectory, "journal_cleanup.db");
+        using var dbContext = new DbContext(dbPath);
+        dbContext.InitializeDatabase();
+
+        // バックアップファイルを作成
+        var backupPath = Path.Combine(_backupDirectory, "backup_jc.db");
+        File.Copy(dbPath, backupPath);
+
+        // ジャーナルファイルを作成（リストア前の古いジャーナル）
+        File.WriteAllText(dbPath + "-journal", "old journal");
+
+        var service = new BackupService(
+            dbContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+
+        // Act
+        var result = service.RestoreFromBackup(backupPath);
+
+        // Assert
+        result.Should().BeTrue();
+        File.Exists(dbPath + "-journal").Should().BeFalse("リストア後にジャーナルファイルが清掃されるべき");
+    }
+
+    /// <summary>
+    /// IsSharedModeプロパティがDbContextの状態を正しく反映すること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void IsSharedMode_DbContextの状態を反映すること()
+    {
+        var dbPath = Path.Combine(_testDirectory, "shared_check.db");
+        using var sharedContext = new DbContext(dbPath);
+        var sharedService = new BackupService(
+            sharedContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+        sharedService.IsSharedMode.Should().BeTrue();
+
+        using var localContext = new DbContext();
+        var localService = new BackupService(
+            localContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+        localService.IsSharedMode.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region ヘルパーメソッド
+
+    private BackupService CreateService(string dbPath)
+    {
+        var dbContext = new DbContext(dbPath);
+        return new BackupService(
+            dbContext,
+            CreateSettingsRepositoryMock().Object,
+            NullLogger<BackupService>.Instance);
+    }
+
+    private Mock<ISettingsRepository> CreateSettingsRepositoryMock()
+    {
+        var mock = new Mock<ISettingsRepository>();
+        mock.Setup(x => x.GetAppSettingsAsync())
+            .ReturnsAsync(new AppSettings { BackupPath = _backupDirectory });
+        return mock;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Closes #1108

共有フォルダモードでリストア実行時に、他PCのDB接続が残ったまま処理が進みDB破壊やIOExceptionが発生する問題を修正。

- **排他ロック検出**: リストア前に `FileShare.None` で排他ファイルロックを試行し、他PCの接続を検出。検出時はリストアを拒否
- **ジャーナルファイル清掃**: リストア成功後に `.db-journal` / `.db-wal` / `.db-shm` を削除。古いジャーナルによるリカバリでリストア内容が上書きされるのを防止
- **確認ダイアログ強化**: 共有モード時は「すべてのPCでアプリケーションを終了してください」の警告を追加
- **エラーメッセージ改善**: リストア失敗時に共有モード特有の原因（他PC接続中）を示唆

## Test plan

- [x] 排他ロック取得可能（未使用ファイル）→ true
- [x] 排他ロック取得不可（他プロセスがロック中）→ false
- [x] 排他ロック取得不可（読み取り共有ロック中）→ false
- [x] 共有モードリストア（他PC接続中）→ false で拒否
- [x] 共有モードリストア（他PC接続なし）→ 成功
- [x] リストア成功後にジャーナルファイルが削除される
- [x] IsSharedMode プロパティが DbContext の状態を反映
- [x] 既存テスト全 2140 件パス
- [ ] 手動テスト: 共有モードでリストア確認ダイアログに警告が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)