### PR TITLE
chore: CLI操作.txtをGit追跡から除外

### DIFF
--- a/CLI操作.txt
+++ b/CLI操作.txt
@@ -1,3 +1,0 @@
-・Ubuntu起動
-・cd /mnt/d/OneDrive/交通系/src/
-・claude -c


### PR DESCRIPTION
## Summary
- ローカル専用メモファイル `CLI操作.txt` をGit追跡から除外
- `.gitignore` には既に記載済みだったが、追跡が残っていたため `git rm --cached` で解除
- ローカルファイルは削除されず、GitHub上からのみ削除される

## Test plan
- [ ] マージ後、GitHub上から `CLI操作.txt` が消えていることを確認
- [ ] ローカルに `CLI操作.txt` が残っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)