### PR TITLE
fix: 返却時のトースト通知で残額が0と表示される場合がある

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -778,6 +778,16 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 10 | チャージLedgerの職員名 | チャージ3000円 | chargeLedger.StaffName=**null** |
 | 11 | ポイント還元の職員名 | ポイント還元500円 | pointLedger.StaffName=**null** |
 
+#### UT-017a2: 返却時の残額フォールバック（Issue #1139）
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | カード残高null＋CreatedLedgers空 | 利用履歴なし、DB直近残高5000 | Balance=5000（DBフォールバック） |
+| 2 | カード残高null＋DB履歴なし | 利用履歴なし、DB直近=null | Balance=0（デフォルト） |
+| 3 | カード残高正常読み取り | Balance=3000の利用履歴 | Balance=3000（フォールバック未使用） |
+
+**テストクラス:** `LendingServiceTests`
+
 #### UT-017b: 残高不足パターン検出（DetectInsufficientBalancePattern）
 
 | No | テストケース | チャージ | 利用 | 期待結果 |

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -556,12 +556,24 @@ namespace ICCardManager.Services
                 }
                 else
                 {
-                    // フォールバック: 作成したledgerレコードの残高を使用
-                    var latestLedger = result.CreatedLedgers.LastOrDefault();
-                    if (latestLedger != null)
+                    // フォールバック1: 作成したledgerレコードの残高を使用
+                    var latestCreatedLedger = result.CreatedLedgers.LastOrDefault();
+                    if (latestCreatedLedger != null)
                     {
-                        result.Balance = latestLedger.Balance;
+                        result.Balance = latestCreatedLedger.Balance;
                         _logger.LogDebug("LendingService: ledgerレコードの残高を使用: {Balance}円", result.Balance);
+                    }
+                    else
+                    {
+                        // Issue #1139: フォールバック2: DB内の直近の履歴残高を使用
+                        // LendAsync側のIssue #656修正と同等のフォールバック
+                        var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+                        if (latestLedger != null)
+                        {
+                            result.Balance = latestLedger.Balance;
+                            _logger.LogInformation(
+                                "ReturnAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", result.Balance);
+                        }
                     }
                 }
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
@@ -3603,4 +3603,98 @@ public class LendingServiceTests : IDisposable
     }
 
     #endregion
+
+    #region Issue #1139: 返却時の残額フォールバックテスト
+
+    /// <summary>
+    /// Issue #1139: 返却時にカード残高が読み取れず、CreatedLedgersも空の場合、
+    /// DBの直近履歴からフォールバックで残高を取得すること
+    /// </summary>
+    [Fact]
+    public async Task ReturnAsync_WithNullBalanceAndNoCreatedLedgers_FallsBackToDbHistory()
+    {
+        // Arrange
+        var card = CreateTestCard(isLent: true);
+        var staff = CreateTestStaff();
+        var lentRecord = CreateTestLentRecord();
+
+        // 利用履歴なし（Balance=null相当）
+        var usageDetails = new List<LedgerDetail>();
+
+        SetupReturnMocks(card, staff, lentRecord);
+
+        // DBの直近履歴に残高5000円があるとする
+        _ledgerRepositoryMock.Setup(x => x.GetLatestLedgerAsync(TestCardIdm))
+            .ReturnsAsync(new Ledger { Balance = 5000 });
+
+        // Act
+        var result = await _service.ReturnAsync(TestStaffIdm, TestCardIdm, usageDetails);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Balance.Should().Be(5000, "DB直近履歴の残高がフォールバックとして使用される");
+    }
+
+    /// <summary>
+    /// Issue #1139: 返却時にカード残高が読み取れず、DB履歴もない場合、残高0になること
+    /// </summary>
+    [Fact]
+    public async Task ReturnAsync_WithNullBalanceAndNoDbHistory_DefaultsToZero()
+    {
+        // Arrange
+        var card = CreateTestCard(isLent: true);
+        var staff = CreateTestStaff();
+        var lentRecord = CreateTestLentRecord();
+
+        var usageDetails = new List<LedgerDetail>();
+
+        SetupReturnMocks(card, staff, lentRecord);
+
+        // DB履歴もなし
+        _ledgerRepositoryMock.Setup(x => x.GetLatestLedgerAsync(TestCardIdm))
+            .ReturnsAsync((Ledger?)null);
+
+        // Act
+        var result = await _service.ReturnAsync(TestStaffIdm, TestCardIdm, usageDetails);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Balance.Should().Be(0, "DB履歴もない場合はデフォルトの0");
+    }
+
+    /// <summary>
+    /// Issue #1139: 返却時にカード残高が正常に読み取れた場合、フォールバックは使わないこと
+    /// </summary>
+    [Fact]
+    public async Task ReturnAsync_WithValidBalance_DoesNotUseFallback()
+    {
+        // Arrange
+        var card = CreateTestCard(isLent: true);
+        var staff = CreateTestStaff();
+        var lentRecord = CreateTestLentRecord();
+        var usageDetails = new List<LedgerDetail>
+        {
+            new()
+            {
+                UseDate = DateTime.Now,
+                EntryStation = "博多",
+                ExitStation = "天神",
+                Amount = 210,
+                Balance = 3000  // カードから正常に読み取った残高
+            }
+        };
+
+        SetupReturnMocks(card, staff, lentRecord);
+
+        // Act
+        var result = await _service.ReturnAsync(TestStaffIdm, TestCardIdm, usageDetails);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Balance.Should().Be(3000, "カードから直接読み取った残高が使用される");
+        _ledgerRepositoryMock.Verify(x => x.GetLatestLedgerAsync(It.IsAny<string>()), Times.Never,
+            "正常読み取り時はDBフォールバックを呼ばない");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Closes #1139

## Summary
- `ReturnAsync` でカード残高が読み取れず `CreatedLedgers` も空の場合、`GetLatestLedgerAsync()` によるDBフォールバックを追加
- `LendAsync` 側の Issue #656 修正と同等のパターンを返却側にも適用
- テスト3件追加、テスト設計書更新

## 修正内容

**修正前（LendingService.cs:548-566）:**
```
cardBalance読み取り失敗 → CreatedLedgers参照 → なければ残高0のまま
```

**修正後:**
```
cardBalance読み取り失敗 → CreatedLedgers参照 → なければDB直近履歴参照 → なければ残高0
```

## Test plan
- [x] 新規テスト3件が全て成功
- [x] 既存テストが全て成功
- [x] 実機で返却時にトースト通知の残額が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)