### PR TITLE
fix: バス停名入力のスキップ時に入力済み内容が保存される問題を修正

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1139,6 +1139,42 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 
 ---
 
+### 2.22b バス停名入力ViewModel（BusStopInputViewModel）
+
+#### UT-029b: バス停名入力・スキップ
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 初期化（バス利用のみ抽出） | バス2件+鉄道1件 | BusUsages=2件 |
+| 2 | 初期化（バス利用なし） | 鉄道のみ | StatusMessage="バス利用の履歴がありません" |
+| 3 | 初期化（既存バス停名保持） | BusStops="天神～博多" | BusStops="天神～博多" |
+| 4 | 初期化（null→空文字） | BusStops=null | BusStops="" |
+| 5 | 非同期初期化（サジェスト読込） | 2件のサジェスト候補 | BusStopSuggestions=2件 |
+| 6 | 保存（未入力に★） | BusStops="" → SaveAsync | Detail.BusStops="★" |
+| 7 | 保存（入力済み保持） | BusStops="天神" → SaveAsync | Detail.BusStops="天神" |
+| 8 | 保存成功 | SaveAsync → UpdateAsync=true | IsSaved=true |
+| 9 | 保存失敗 | SaveAsync → UpdateAsync=false | IsSaved=false |
+| 10 | スキップ（未入力→★） | BusStops="" → SkipAsync | Detail.BusStops="★" |
+| 11 | スキップ（入力済みも★にリセット） | BusStops="天神～博多" → SkipAsync | Detail.BusStops="★"（Issue #1156） |
+| 12 | スキップ（Ledger=null） | Ledger未設定 → SkipAsync | UpdateAsync未呼出 |
+
+#### UT-029c: バス停名サジェスト（BusStopInputItem）
+
+| No | テストケース | 操作 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 先頭一致優先 | "天神" → 候補["天神バス停","大天神"] | 先頭一致が先に表示 |
+| 2 | 空入力 | BusStops="" | ShowSuggestions=false |
+| 3 | 完全一致 | "天神バス停"（候補と同一） | ShowSuggestions=false |
+| 4 | 候補なし | SetSuggestions([]) → 入力 | ShowSuggestions=false |
+| 5 | 最大8件制限 | 10件の候補 → 入力 | FilteredSuggestions≤8 |
+| 6 | 大文字小文字無視 | "abc" → 候補["ABC停留所"] | ShowSuggestions=true |
+| 7 | 候補選択 | SelectSuggestion("天神バス停") | BusStops="天神バス停", ShowSuggestions=false |
+| 8 | 非表示 | HideSuggestions | ShowSuggestions=false |
+
+**テストクラス:** `BusStopInputViewModelTests`, `BusStopInputItemTests`
+
+---
+
 ### 2.23 パスバリデーション（PathValidator）
 
 #### UT-030: バックアップパス検証

--- a/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/BusStopInputViewModel.cs
@@ -246,13 +246,11 @@ public partial class BusStopInputViewModel : ViewModelBase
 
         using (BeginBusy("保存中..."))
         {
-            // 未入力のバス停に★マークを付ける
+            // Issue #1156: スキップ時は入力済みの内容も破棄し、すべて★マークにする
             foreach (var item in BusUsages)
             {
-                if (string.IsNullOrWhiteSpace(item.BusStops))
-                {
-                    item.Detail.BusStops = "★";
-                }
+                item.BusStops = "★";
+                item.Detail.BusStops = "★";
             }
 
             // Issue #593: バス停名をledger_detailに保存

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/BusStopInputViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/BusStopInputViewModelTests.cs
@@ -311,15 +311,14 @@ public class BusStopInputViewModelTests
     #region SkipAsync
 
     [Fact]
-    public async Task SkipAsync_未入力のバス停のみに星マークが付くこと()
+    public async Task SkipAsync_未入力のバス停に星マークが付くこと()
     {
         // Arrange
         var detail1 = new LedgerDetail { IsBus = true, BusStops = null, Amount = 200, SequenceNumber = 1 };
-        var detail2 = new LedgerDetail { IsBus = true, BusStops = "天神バス停", Amount = 150, SequenceNumber = 2 };
         var ledger = new Ledger
         {
             Id = 1,
-            Details = new List<LedgerDetail> { detail1, detail2 }
+            Details = new List<LedgerDetail> { detail1 }
         };
 
         _settingsRepoMock.Setup(s => s.GetAppSettingsAsync())
@@ -337,8 +336,54 @@ public class BusStopInputViewModelTests
 
         // Assert
         detail1.BusStops.Should().Be("★");
-        detail2.BusStops.Should().Be("天神バス停"); // 入力済みは変更なし
         _viewModel.IsSaved.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SkipAsync_入力済みのバス停も星マークにリセットされること()
+    {
+        // Arrange: Issue #1156 — スキップ時は入力済みの内容も破棄する
+        var detail1 = new LedgerDetail { IsBus = true, BusStops = null, Amount = 200, SequenceNumber = 1 };
+        var detail2 = new LedgerDetail { IsBus = true, BusStops = "天神バス停～博多駅前", Amount = 150, SequenceNumber = 2 };
+        var ledger = new Ledger
+        {
+            Id = 1,
+            Details = new List<LedgerDetail> { detail1, detail2 }
+        };
+
+        _settingsRepoMock.Setup(s => s.GetAppSettingsAsync())
+            .ReturnsAsync(new AppSettings());
+        _ledgerRepoMock.Setup(r => r.UpdateDetailBusStopsAsync(
+                It.IsAny<int>(), It.IsAny<List<(int, string)>>()))
+            .Returns(Task.CompletedTask);
+        _ledgerRepoMock.Setup(r => r.UpdateAsync(It.IsAny<Ledger>()))
+            .ReturnsAsync(true);
+
+        _viewModel.InitializeWithDetails(ledger, ledger.Details);
+
+        // ユーザーがバス停名を入力した状態をシミュレート
+        _viewModel.BusUsages[0].BusStops = "薬院大通～六本松三丁目";
+
+        // Act: スキップを実行
+        await _viewModel.SkipAsync();
+
+        // Assert: 入力済みの内容も含め、すべて★にリセットされる
+        detail1.BusStops.Should().Be("★");
+        detail2.BusStops.Should().Be("★");
+        _viewModel.BusUsages[0].BusStops.Should().Be("★");
+        _viewModel.BusUsages[1].BusStops.Should().Be("★");
+        _viewModel.IsSaved.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SkipAsync_Ledgerがnullの場合は何もしないこと()
+    {
+        // Act（Ledgerを設定せずにスキップ）
+        await _viewModel.SkipAsync();
+
+        // Assert: リポジトリは呼ばれない
+        _ledgerRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<Ledger>()), Times.Never);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- **Issue**: #1156
- バス停名入力画面で、バス停名を入力した後に「後で入力（スキップ）」をクリックしても、入力済みの内容がそのまま保存されていた
- `SkipAsync()` で未入力（空欄）のバス停のみ `★` にリセットしていたため、ユーザーが入力したバス停名がスキップ操作で破棄されなかった
- すべてのバス停名を `★` にリセットするよう修正

## Changes
- `BusStopInputViewModel.SkipAsync()`: 条件分岐を削除し、全アイテムを `★` にリセット
- テスト: 既存テストを修正し、入力済みでもスキップ時にリセットされることを検証するテストを追加
- テスト設計書: BusStopInputViewModel/BusStopInputItem のテストケース一覧を追加

## Test plan
- [x] 既存テスト 71件全て合格
- [x] 新規テスト `SkipAsync_入力済みのバス停も星マークにリセットされること` 合格
- [x] 手動確認: バス停名を入力後「後で入力（スキップ）」→ 履歴の摘要が「バス（★）」になること
- [x] 手動確認: スキップ後「未入力の履歴があります」の警告が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)