### PR TITLE
fix: リストア完了ダイアログ表示時にプログレスバーが残る問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SystemManageViewModel.cs
@@ -173,6 +173,8 @@ public partial class SystemManageViewModel : ViewModelBase
             return;
         }
 
+        bool restoreSuccess = false;
+
         using (BeginBusy("リストア中..."))
         {
             try
@@ -199,18 +201,10 @@ public partial class SystemManageViewModel : ViewModelBase
                 }
 
                 // リストア実行
-                var success = _backupService.RestoreFromBackup(SelectedBackup.FilePath);
-                if (success)
+                restoreSuccess = _backupService.RestoreFromBackup(SelectedBackup.FilePath);
+                if (restoreSuccess)
                 {
                     SetStatus("リストアが完了しました。アプリケーションを再起動してください。", false);
-
-                    // 再起動を促すダイアログ
-                    MessageBox.Show(
-                        "リストアが完了しました。\n\n" +
-                        "変更を反映するには、アプリケーションを再起動してください。",
-                        "リストア完了",
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Information);
                 }
                 else
                 {
@@ -226,6 +220,17 @@ public partial class SystemManageViewModel : ViewModelBase
             {
                 SetStatus($"リストアに失敗しました: {ex.Message}", true);
             }
+        }
+
+        // プログレスバーを非表示にしてから再起動を促すダイアログを表示
+        if (restoreSuccess)
+        {
+            MessageBox.Show(
+                "リストアが完了しました。\n\n" +
+                "変更を反映するには、アプリケーションを再起動してください。",
+                "リストア完了",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
         }
     }
 
@@ -296,6 +301,8 @@ public partial class SystemManageViewModel : ViewModelBase
             return;
         }
 
+        bool restoreFromFileSuccess = false;
+
         using (BeginBusy("リストア中..."))
         {
             try
@@ -322,21 +329,10 @@ public partial class SystemManageViewModel : ViewModelBase
                 }
 
                 // リストア実行
-                var success = _backupService.RestoreFromBackup(dialog.FileName);
-                if (success)
+                restoreFromFileSuccess = _backupService.RestoreFromBackup(dialog.FileName);
+                if (restoreFromFileSuccess)
                 {
                     SetStatus("リストアが完了しました。アプリケーションを再起動してください。", false);
-
-                    // 再起動を促すダイアログ
-                    MessageBox.Show(
-                        "リストアが完了しました。\n\n" +
-                        "変更を反映するには、アプリケーションを再起動してください。",
-                        "リストア完了",
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Information);
-
-                    // バックアップ一覧を更新
-                    await LoadBackupsAsync();
                 }
                 else
                 {
@@ -352,6 +348,20 @@ public partial class SystemManageViewModel : ViewModelBase
             {
                 SetStatus($"リストアに失敗しました: {ex.Message}", true);
             }
+        }
+
+        // プログレスバーを非表示にしてから再起動を促すダイアログを表示
+        if (restoreFromFileSuccess)
+        {
+            MessageBox.Show(
+                "リストアが完了しました。\n\n" +
+                "変更を反映するには、アプリケーションを再起動してください。",
+                "リストア完了",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+
+            // バックアップ一覧を更新
+            await LoadBackupsAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
- リストア完了時の `MessageBox.Show()` が `BeginBusy` の `using` ブロック内で呼ばれていたため、完了ダイアログの背後にプログレスバーオーバーレイが残っていた問題を修正
- `RestoreAsync()` と `RestoreFromFileAsync()` の両方で、`MessageBox.Show()` を `using` ブロックの外に移動し、プログレスバーが非表示になってから完了ダイアログを表示するように変更

Closes #1154

## Test plan
- [ ] システム管理画面でバックアップ一覧からリストアを実行し、完了ダイアログ表示時にプログレスバーが消えていることを確認
- [x] 「ファイルからリストア」でも同様にプログレスバーが消えてから完了ダイアログが表示されることを確認
- [ ] リストア失敗時にエラーメッセージが正しく表示されることを確認
- [x] リストアキャンセル時の動作に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)