### PR TITLE
fix: システム管理画面のバックアップ一覧が表示されない問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Views/Dialogs/SystemManageDialog.xaml
+++ b/ICCardManager/src/ICCardManager/Views/Dialogs/SystemManageDialog.xaml
@@ -8,10 +8,11 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:SystemManageViewModel}"
         Title="システム管理"
-        Height="620"
+        Height="750"
         Width="650"
+        MinHeight="620"
         WindowStartupLocation="CenterOwner"
-        ResizeMode="NoResize"
+        ResizeMode="CanResize"
         Loaded="Window_Loaded"
         FontSize="{DynamicResource BaseFontSize}"
         AutomationProperties.Name="システム管理ダイアログ"
@@ -102,7 +103,8 @@
                            Margin="0,0,0,10"/>
 
                 <!-- バックアップ一覧 -->
-                <Border Grid.Row="1" BorderBrush="{DynamicResource NeutralBorderBrush}" BorderThickness="1" CornerRadius="4">
+                <Border Grid.Row="1" BorderBrush="{DynamicResource NeutralBorderBrush}" BorderThickness="1" CornerRadius="4"
+                        MinHeight="120">
                     <ListView ItemsSource="{Binding BackupFiles}"
                               SelectedItem="{Binding SelectedBackup}"
                               SelectionMode="Single"


### PR DESCRIPTION
## Summary
- ウィンドウ高さ不足によりListViewの表示領域がほぼゼロになり、バックアップ一覧が表示されない問題を修正
- ウィンドウ高さを620→750に拡大し、`ResizeMode`を`CanResize`に変更（他のリスト付きダイアログと統一）
- ListViewの`MinHeight=120`を追加し、フォントサイズが大/特大でも最低限の行が表示されることを保証

Closes #1153

## 原因分析
ステータスメッセージに「30件のバックアップが見つかりました」と表示されていたことから、データ取得は成功していたがListViewの**表示領域が不足**していた。  
`Height="620"` + `ResizeMode="NoResize"` の固定レイアウトで、Auto高さの他の要素（操作ログ、手動バックアップ、ステータス、閉じるボタン）がスペースを消費し、`*`行のListViewにほぼスペースが残らない状態だった。

## Test plan
- [x] システム管理画面を開き、バックアップ一覧が正常に表示されることを確認
- [x] ウィンドウのリサイズが可能で、リサイズ時にListViewの表示領域が適切に拡縮されることを確認
- [x] フォントサイズを「特大」に設定した状態でも、バックアップ一覧が表示されることを確認
- [x] ウィンドウを最小限に縮小しても（MinHeight=620）、UIが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)