### PR TITLE
feat: メイン画面の履歴表示に繰越行を追加 (#1155)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1385,6 +1385,22 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 
 ---
 
+### 2.28b 履歴画面の繰越行表示（Issue #1155）
+
+#### UT-039b: BuildCarryoverRowAsync
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 4月・前年度データあり | cardIdm, year=2026, month=4, 前年度残高=5000 | IsCarryoverRow=true, Summary="前年度より繰越", Income=5000, Balance=5000 |
+| 2 | 4月以外・前月データあり | cardIdm, year=2026, month=7, 前月残高=3000 | IsCarryoverRow=true, Summary="6月より繰越", Income=0, Balance=3000 |
+| 3 | 4月・前年度データなし | cardIdm, year=2026, month=4, 前年度残高=null | null（繰越行なし） |
+| 4 | 4月以外・前月データなし | cardIdm, year=2026, month=6, 前月残高=null | null（繰越行なし） |
+| 5 | 1月（年跨ぎ） | cardIdm, year=2026, month=1, 前月残高=2000 | Summary="12月より繰越", Balance=2000 |
+
+**テストクラス:** `MainViewModelTests`
+
+---
+
 ### 2.28 ServiceResult基底クラス
 
 #### UT-040: ServiceResult（型パラメータなし）

--- a/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
+++ b/ICCardManager/src/ICCardManager/Dtos/LedgerDto.cs
@@ -87,6 +87,11 @@ namespace ICCardManager.Dtos
         public bool IsLentRecord { get; set; }
 
         /// <summary>
+        /// 繰越行フラグ（前年度繰越・前月繰越など、合成的に表示する行）
+        /// </summary>
+        public bool IsCarryoverRow { get; set; }
+
+        /// <summary>
         /// 残高不整合フラグ（Issue #1052: 警告クリック時のハイライト表示用）
         /// </summary>
         private bool _hasBalanceInconsistency;

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1377,6 +1377,17 @@ public partial class MainViewModel : ViewModelBase
             // Issue #784: 残高チェーンに基づいて同一日内の時系列順を復元
             var ledgers = Services.LedgerOrderHelper.ReorderByBalanceChain(rawLedgers);
 
+            // Issue #1155: 1ページ目の先頭に繰越行を挿入（帳票と同じ表示）
+            if (HistoryCurrentPage == 1)
+            {
+                var carryoverDto = await BuildCarryoverRowAsync(
+                    HistoryCard.CardIdm, HistoryFromDate.Year, HistoryFromDate.Month);
+                if (carryoverDto != null)
+                {
+                    HistoryLedgers.Add(carryoverDto);
+                }
+            }
+
             foreach (var ledger in ledgers)
             {
                 var dto = ledger.ToDto();
@@ -1412,6 +1423,62 @@ public partial class MainViewModel : ViewModelBase
             // Issue #1052: 残高不整合ハイライトの適用（ページ遷移時にも再適用される）
             ApplyBalanceInconsistencyMarkers();
         }
+    }
+
+    /// <summary>
+    /// Issue #1155: 繰越行のDTOを生成する
+    /// ReportDataBuilderと同じロジックで、4月は前年度繰越、それ以外は前月繰越を生成
+    /// </summary>
+    internal async Task<LedgerDto> BuildCarryoverRowAsync(string cardIdm, int year, int month)
+    {
+        int? precedingBalance;
+        if (month == 4)
+        {
+            precedingBalance = await _ledgerRepository.GetCarryoverBalanceAsync(cardIdm, year - 1);
+        }
+        else
+        {
+            // 前月末の最新残高を取得
+            var firstDayOfMonth = new DateTime(year, month, 1);
+            var lastLedger = await _ledgerRepository.GetLatestBeforeDateAsync(cardIdm, firstDayOfMonth);
+            precedingBalance = lastLedger?.Balance;
+        }
+
+        if (!precedingBalance.HasValue)
+        {
+            return null;
+        }
+
+        string summary;
+        int income;
+        if (month == 4)
+        {
+            summary = SummaryGenerator.GetCarryoverFromPreviousYearSummary();
+            income = precedingBalance.Value;
+        }
+        else
+        {
+            int previousMonth = month == 1 ? 12 : month - 1;
+            summary = SummaryGenerator.GetCarryoverFromPreviousMonthSummary(previousMonth);
+            // 月次繰越の受入欄は空欄（受入金額を表示するのは4月の前年度繰越のみ）
+            income = 0;
+        }
+
+        return new LedgerDto
+        {
+            Id = 0,
+            CardIdm = cardIdm,
+            Date = new DateTime(year, month, 1),
+            DateDisplay = WarekiConverter.ToWareki(new DateTime(year, month, 1)),
+            Summary = summary,
+            Income = income,
+            Expense = 0,
+            Balance = precedingBalance.Value,
+            StaffName = null,
+            Note = null,
+            IsLentRecord = false,
+            IsCarryoverRow = true
+        };
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
+++ b/ICCardManager/src/ICCardManager/Views/MainWindow.xaml
@@ -419,7 +419,8 @@
                                             <CheckBox IsChecked="{Binding IsChecked, UpdateSourceTrigger=PropertyChanged}"
                                                       HorizontalAlignment="Center"
                                                       VerticalAlignment="Center"
-                                                      AutomationProperties.Name="統合対象として選択"/>
+                                                      AutomationProperties.Name="統合対象として選択"
+                                                      Visibility="{Binding IsCarryoverRow, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=invert}"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
@@ -461,7 +462,8 @@
                                 <DataGridTemplateColumn Header="操作" Width="130">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                                                        Visibility="{Binding IsCarryoverRow, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter=invert}">
                                                 <Button Content="詳細"
                                                         Command="{Binding DataContext.ShowLedgerDetailCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                                         CommandParameter="{Binding}"
@@ -488,6 +490,10 @@
                                         <Trigger Property="AlternationIndex" Value="1">
                                             <Setter Property="Background" Value="{DynamicResource AlternatingRowBrush}"/>
                                         </Trigger>
+                                        <!-- Issue #1155: 繰越行は太字で表示 -->
+                                        <DataTrigger Binding="{Binding IsCarryoverRow}" Value="True">
+                                            <Setter Property="FontWeight" Value="Bold"/>
+                                        </DataTrigger>
                                         <DataTrigger Binding="{Binding IsLentRecord}" Value="True">
                                             <Setter Property="Background" Value="{DynamicResource LendingBackgroundBrush}"/>
                                             <Setter Property="FontStyle" Value="Italic"/>

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
@@ -875,6 +875,101 @@ public class MainViewModelTests
     }
 
     #endregion
+
+    #region 繰越行表示テスト（Issue #1155）
+
+    [Fact]
+    public async Task BuildCarryoverRowAsync_4月_前年度繰越行が生成されること()
+    {
+        // Arrange
+        var cardIdm = "0102030405060708";
+        _ledgerRepositoryMock.Setup(r => r.GetCarryoverBalanceAsync(cardIdm, 2025))
+            .ReturnsAsync(5000);
+
+        // Act
+        var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 4);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsCarryoverRow.Should().BeTrue();
+        result.Summary.Should().Be(SummaryGenerator.GetCarryoverFromPreviousYearSummary());
+        result.Income.Should().Be(5000);
+        result.Balance.Should().Be(5000);
+        result.Expense.Should().Be(0);
+        result.Date.Should().Be(new DateTime(2026, 4, 1));
+        result.StaffName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildCarryoverRowAsync_4月以外_前月繰越行が生成されること()
+    {
+        // Arrange
+        var cardIdm = "0102030405060708";
+        var previousLedger = new Ledger { Balance = 3000 };
+        _ledgerRepositoryMock.Setup(r => r.GetLatestBeforeDateAsync(cardIdm, new DateTime(2026, 7, 1)))
+            .ReturnsAsync(previousLedger);
+
+        // Act
+        var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 7);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsCarryoverRow.Should().BeTrue();
+        result.Summary.Should().Be(SummaryGenerator.GetCarryoverFromPreviousMonthSummary(6));
+        result.Income.Should().Be(0, "月次繰越の受入欄は空欄");
+        result.Balance.Should().Be(3000);
+        result.Date.Should().Be(new DateTime(2026, 7, 1));
+    }
+
+    [Fact]
+    public async Task BuildCarryoverRowAsync_前年度データなし_nullが返ること()
+    {
+        // Arrange
+        var cardIdm = "0102030405060708";
+        _ledgerRepositoryMock.Setup(r => r.GetCarryoverBalanceAsync(cardIdm, 2025))
+            .ReturnsAsync((int?)null);
+
+        // Act
+        var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 4);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildCarryoverRowAsync_前月データなし_nullが返ること()
+    {
+        // Arrange
+        var cardIdm = "0102030405060708";
+        _ledgerRepositoryMock.Setup(r => r.GetLatestBeforeDateAsync(cardIdm, new DateTime(2026, 6, 1)))
+            .ReturnsAsync((Ledger)null);
+
+        // Act
+        var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 6);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildCarryoverRowAsync_1月_前月は12月であること()
+    {
+        // Arrange
+        var cardIdm = "0102030405060708";
+        var previousLedger = new Ledger { Balance = 2000 };
+        _ledgerRepositoryMock.Setup(r => r.GetLatestBeforeDateAsync(cardIdm, new DateTime(2026, 1, 1)))
+            .ReturnsAsync(previousLedger);
+
+        // Act
+        var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 1);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Summary.Should().Be(SummaryGenerator.GetCarryoverFromPreviousMonthSummary(12));
+        result.Balance.Should().Be(2000);
+    }
+
+    #endregion
 }
 
 /*


### PR DESCRIPTION
## Summary
- メイン画面中央の履歴表示で、4月は「前年度より繰越」、それ以外の月は「X月より繰越」行を先頭に表示するよう修正
- 帳票プレビュー・Excel出力と同じ繰越行表示に統一
- 繰越行は太字で表示し、チェックボックス・操作ボタンは非表示

## Changes
- `LedgerDto`: `IsCarryoverRow` プロパティを追加
- `MainViewModel`: `BuildCarryoverRowAsync()` メソッドを追加し、`LoadHistoryLedgersAsync()` の1ページ目で繰越行を挿入
- `MainWindow.xaml`: 繰越行のスタイリング（太字、チェックボックス非表示、操作ボタン非表示）
- テスト設計書: UT-039b を追加

## Test plan
- [x] 単体テスト5件追加（全2246件パス）
- [x] 4月の履歴を表示して「前年度より繰越」行が先頭に太字で表示されることを確認
- [x] 4月以外の月の履歴を表示して「X月より繰越」行が先頭に表示されることを確認
- [x] 新規カード（前年度データなし）で4月を表示した場合、繰越行が表示されないことを確認
- [x] 繰越行のチェックボックスと操作ボタンが非表示であることを確認
- [ ] ページ2以降では繰越行が表示されないことを確認
- [x] 帳票プレビュー・Excelの繰越行と金額が一致することを確認

Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)