### PR TITLE
chore: テストプロジェクトのNullable参照型警告を修正

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Common/ServiceResultTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/ServiceResultTests.cs
@@ -70,7 +70,7 @@ public class ServiceResultTests
     [Fact]
     public void ImplicitBoolConversion_Null_ShouldBeFalse()
     {
-        ServiceResult result = null;
+        ServiceResult? result = null;
 
         bool boolValue = result;
 
@@ -128,7 +128,7 @@ public class ServiceResultTests
     [Fact]
     public void GenericOk_WithNullData_ShouldReturnSuccessWithNullData()
     {
-        var result = ServiceResult<string>.Ok(null);
+        var result = ServiceResult<string>.Ok(null!);
 
         result.Success.Should().BeTrue();
         result.Data.Should().BeNull();

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Timing/TestTimer.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Timing/TestTimer.cs
@@ -10,7 +10,7 @@ namespace ICCardManager.Tests.Infrastructure.Timing
     {
         public TimeSpan Interval { get; set; }
         public bool IsRunning { get; private set; }
-        public event EventHandler Tick;
+        public event EventHandler? Tick;
 
         public void Start() => IsRunning = true;
 
@@ -48,7 +48,7 @@ namespace ICCardManager.Tests.Infrastructure.Timing
         /// <summary>
         /// 最後に生成されたタイマー
         /// </summary>
-        public TestTimer LastCreatedTimer { get; private set; }
+        public TestTimer? LastCreatedTimer { get; private set; }
 
         public ITimer Create()
         {

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
@@ -623,7 +623,7 @@ public class LedgerMergeServiceTests
         capturedDescription.Should().Contain("鉄道（C～D）");
 
         // UndoデータのJSONがデシリアライズ可能であること
-        var undoData = JsonSerializer.Deserialize<LedgerMergeUndoData>(capturedUndoJson, JsonOptions);
+        var undoData = JsonSerializer.Deserialize<LedgerMergeUndoData>(capturedUndoJson!, JsonOptions);
         undoData.Should().NotBeNull();
         undoData!.OriginalTarget.Id.Should().Be(1);
         undoData.DeletedSources.Should().HaveCount(1);
@@ -658,7 +658,7 @@ public class LedgerMergeServiceTests
         await _service.MergeAsync(new List<int> { 1, 2 });
 
         // Assert
-        var undoData = JsonSerializer.Deserialize<LedgerMergeUndoData>(capturedUndoJson, JsonOptions);
+        var undoData = JsonSerializer.Deserialize<LedgerMergeUndoData>(capturedUndoJson!, JsonOptions);
         undoData!.DetailOriginalLedgerMap.Should().ContainKey("10");
         undoData.DetailOriginalLedgerMap["10"].Should().Be(1);
         undoData.DetailOriginalLedgerMap.Should().ContainKey("20");

--- a/ICCardManager/tests/ICCardManager.Tests/Services/NullSafeSummaryAccessTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/NullSafeSummaryAccessTests.cs
@@ -40,8 +40,8 @@ public class NullSafeSummaryAccessTests
         var date = new DateTime(2024, 6, 10);
         var ledgers = new[]
         {
-            CreateLedger(1, date, null, 0, 300, 9700),   // Summary=null
-            CreateLedger(2, date, null, 0, 200, 9500),   // Summary=null
+            CreateLedger(1, date, null!, 0, 300, 9700),   // Summary=null
+            CreateLedger(2, date, null!, 0, 200, 9500),   // Summary=null
         };
 
         // Act - NullReferenceExceptionが発生しないこと
@@ -60,7 +60,7 @@ public class NullSafeSummaryAccessTests
         var ledgers = new[]
         {
             CreateLedger(1, date, "新規購入", 5000, 0, 5000),    // 特殊レコード
-            CreateLedger(2, date, null, 0, 300, 4700),           // Summary=null（通常レコード扱い）
+            CreateLedger(2, date, null!, 0, 300, 4700),           // Summary=null（通常レコード扱い）
         };
 
         var result = LedgerOrderHelper.ReorderByBalanceChain(ledgers);
@@ -79,7 +79,7 @@ public class NullSafeSummaryAccessTests
         var date = new DateTime(2024, 4, 1);
         var ledgers = new[]
         {
-            CreateLedger(2, date, null, 0, 200, 4800),            // Summary=null
+            CreateLedger(2, date, null!, 0, 200, 4800),            // Summary=null
             CreateLedger(1, date, "3月から繰越", 0, 0, 5000),     // 特殊レコード
         };
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/OrganizationOptionsTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/OrganizationOptionsTests.cs
@@ -77,7 +77,7 @@ public class OrganizationOptionsTests : IDisposable
     public void JSON設定からバインドできる()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["OrganizationOptions:SummaryText:ChargeSummaryMayorOffice"] = "需用費によりチャージ",
                 ["OrganizationOptions:SummaryText:RailwayLabel"] = "電車",
@@ -110,7 +110,7 @@ public class OrganizationOptionsTests : IDisposable
     public void セクションが存在しない場合はデフォルト値が使用される()
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>())
+            .AddInMemoryCollection(new Dictionary<string, string?>())
             .Build();
 
         var services = new ServiceCollection();

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
@@ -295,8 +295,8 @@ public class MainViewModelTests
 
         // Assert
         _timerFactory.LastCreatedTimer.Should().NotBeNull();
-        _timerFactory.LastCreatedTimer.IsRunning.Should().BeTrue();
-        _timerFactory.LastCreatedTimer.Interval.Should().Be(TimeSpan.FromSeconds(1));
+        _timerFactory.LastCreatedTimer!.IsRunning.Should().BeTrue();
+        _timerFactory.LastCreatedTimer!.Interval.Should().Be(TimeSpan.FromSeconds(1));
     }
 
     /// <summary>
@@ -378,7 +378,7 @@ public class MainViewModelTests
             _cardReaderMock.Object, new CardReadEventArgs { Idm = staffIdm });
         await _dispatcherService.WaitForPendingAsync();
 
-        var timer = _timerFactory.LastCreatedTimer;
+        var timer = _timerFactory.LastCreatedTimer!;
         _viewModel.RemainingSeconds.Should().Be(60);
 
         // Act - 5回Tickを発火
@@ -403,7 +403,7 @@ public class MainViewModelTests
             _cardReaderMock.Object, new CardReadEventArgs { Idm = staffIdm });
         await _dispatcherService.WaitForPendingAsync();
 
-        var timer = _timerFactory.LastCreatedTimer;
+        var timer = _timerFactory.LastCreatedTimer!;
 
         // Act - 60回Tick（タイムアウト）
         timer.SimulateTicks(60);
@@ -429,7 +429,7 @@ public class MainViewModelTests
             _cardReaderMock.Object, new CardReadEventArgs { Idm = staffIdm });
         await _dispatcherService.WaitForPendingAsync();
 
-        var timer = _timerFactory.LastCreatedTimer;
+        var timer = _timerFactory.LastCreatedTimer!;
 
         // Act
         timer.SimulateTicks(60);
@@ -453,7 +453,7 @@ public class MainViewModelTests
             _cardReaderMock.Object, new CardReadEventArgs { Idm = staffIdm });
         await _dispatcherService.WaitForPendingAsync();
 
-        var timer = _timerFactory.LastCreatedTimer;
+        var timer = _timerFactory.LastCreatedTimer!;
 
         // Act
         timer.SimulateTicks(60);
@@ -520,7 +520,7 @@ public class MainViewModelTests
             _cardReaderMock.Object, new CardReadEventArgs { Idm = staffIdm });
         await _dispatcherService.WaitForPendingAsync();
 
-        var timer = _timerFactory.LastCreatedTimer;
+        var timer = _timerFactory.LastCreatedTimer!;
 
         // Act - 59回Tick（タイムアウト手前）
         timer.SimulateTicks(59);
@@ -942,7 +942,7 @@ public class MainViewModelTests
         // Arrange
         var cardIdm = "0102030405060708";
         _ledgerRepositoryMock.Setup(r => r.GetLatestBeforeDateAsync(cardIdm, new DateTime(2026, 6, 1)))
-            .ReturnsAsync((Ledger)null);
+            .ReturnsAsync((Ledger?)null);
 
         // Act
         var result = await _viewModel.BuildCarryoverRowAsync(cardIdm, 2026, 6);


### PR DESCRIPTION
## Summary
- テストビルド時に発生していた13件のNullable参照型警告（CS8600/CS8602/CS8604/CS8618/CS8620/CS8625）を解消
- null-forgiving演算子（`null!`）、nullable型アノテーション（`?`）を適切に使い分けて修正
- テスト2246件すべて合格、警告0件を確認済み

## Test plan
- [x] `dotnet test` で警告が0件であること
- [x] テスト2246件がすべて合格すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)