### PR TITLE
fix: 返却時に孤立した貸出中レコードが残る問題を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/ILedgerRepository.cs
@@ -66,6 +66,17 @@ namespace ICCardManager.Data.Repositories
         Task<bool> DeleteAsync(int id);
 
         /// <summary>
+        /// 指定カードの貸出中レコードをすべて削除
+        /// </summary>
+        /// <remarks>
+        /// 共有モードで複数PCから同時に貸出された場合に重複する貸出中レコードを
+        /// すべてクリーンアップするための防御的削除メソッド。
+        /// </remarks>
+        /// <param name="cardIdm">カードIDm</param>
+        /// <returns>削除した件数</returns>
+        Task<int> DeleteAllLentRecordsAsync(string cardIdm);
+
+        /// <summary>
         /// 利用履歴詳細を登録
         /// </summary>
         Task<bool> InsertDetailAsync(LedgerDetail detail);

--- a/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
+++ b/ICCardManager/src/ICCardManager/Data/Repositories/LedgerRepository.cs
@@ -223,6 +223,26 @@ WHERE id = @id";
         }
 
         /// <inheritdoc/>
+        public async Task<int> DeleteAllLentRecordsAsync(string cardIdm)
+        {
+            var connection = _dbContext.GetConnection();
+
+            // 貸出中レコードに紐づく詳細レコードを先に削除
+            using var deleteDetailCommand = connection.CreateCommand();
+            deleteDetailCommand.CommandText = @"DELETE FROM ledger_detail
+WHERE ledger_id IN (SELECT id FROM ledger WHERE card_idm = @cardIdm AND is_lent_record = 1)";
+            deleteDetailCommand.Parameters.AddWithValue("@cardIdm", cardIdm);
+            await deleteDetailCommand.ExecuteNonQueryAsync();
+
+            // 貸出中レコードをすべて削除
+            using var command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM ledger WHERE card_idm = @cardIdm AND is_lent_record = 1";
+            command.Parameters.AddWithValue("@cardIdm", cardIdm);
+
+            return await command.ExecuteNonQueryAsync();
+        }
+
+        /// <inheritdoc/>
         public async Task<bool> InsertDetailAsync(LedgerDetail detail)
         {
             var connection = _dbContext.GetConnection();

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -535,8 +535,9 @@ namespace ICCardManager.Services
                         // バス利用の有無をチェック
                         result.HasBusUsage = usageSinceLent.Any(d => d.IsBus);
 
-                        // 貸出レコードを削除（履歴に「（貸出中）」が残らないようにする）
-                        await _ledgerRepository.DeleteAsync(lentRecord.Id);
+                        // 貸出レコードをすべて削除（履歴に「（貸出中）」が残らないようにする）
+                        // 共有モードで重複した貸出中レコードがある場合にも対応
+                        await _ledgerRepository.DeleteAllLentRecordsAsync(cardIdm);
 
                         // カードの貸出状態を更新
                         await _cardRepository.UpdateLentStatusAsync(cardIdm, false, null, null);

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
@@ -48,6 +48,11 @@ public class LendingServiceTests : IDisposable
         _ledgerRepositoryMock = new Mock<ILedgerRepository>();
         _settingsRepositoryMock = new Mock<ISettingsRepository>();
         _settingsRepositoryMock.Setup(s => s.GetAppSettings()).Returns(new AppSettings());
+
+        // デフォルトのモック設定（個別テストでオーバーライド可能）
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(It.IsAny<string>()))
+            .ReturnsAsync(1);
+
         _summaryGenerator = new SummaryGenerator();
         _lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);
 
@@ -838,8 +843,8 @@ public class LendingServiceTests : IDisposable
             .ReturnsAsync(true);
         _ledgerRepositoryMock.Setup(x => x.GetLentRecordAsync(TestCardIdm))
             .ReturnsAsync(CreateTestLentRecord());
-        _ledgerRepositoryMock.Setup(x => x.DeleteAsync(It.IsAny<int>()))
-            .ReturnsAsync(true);
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(It.IsAny<string>()))
+            .ReturnsAsync(1);
         _ledgerRepositoryMock.Setup(x => x.GetLatestBeforeDateAsync(TestCardIdm, It.IsAny<DateTime>()))
             .ReturnsAsync(new Ledger { Balance = 5000 });
         _settingsRepositoryMock.Setup(x => x.GetAppSettingsAsync())
@@ -1112,8 +1117,8 @@ public class LendingServiceTests : IDisposable
             .ReturnsAsync(1);
         _ledgerRepositoryMock.Setup(x => x.UpdateAsync(It.IsAny<Ledger>()))
             .ReturnsAsync(true);
-        _ledgerRepositoryMock.Setup(x => x.DeleteAsync(It.IsAny<int>()))
-            .ReturnsAsync(true);
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(TestCardIdm))
+            .ReturnsAsync(1);
         _ledgerRepositoryMock.Setup(x => x.InsertDetailAsync(It.IsAny<LedgerDetail>()))
             .ReturnsAsync(true);
         _ledgerRepositoryMock.Setup(x => x.InsertDetailsAsync(It.IsAny<int>(), It.IsAny<IEnumerable<LedgerDetail>>()))
@@ -1254,7 +1259,7 @@ public class LendingServiceTests : IDisposable
                     return returnCount == 0 ? lentRecord : null;
                 }
             });
-        _ledgerRepositoryMock.Setup(x => x.DeleteAsync(It.IsAny<int>()))
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(TestCardIdm))
             .Callback(() =>
             {
                 lock (lockObj)
@@ -1262,7 +1267,7 @@ public class LendingServiceTests : IDisposable
                     returnCount++;
                 }
             })
-            .ReturnsAsync(true);
+            .ReturnsAsync(1);
         _cardRepositoryMock.Setup(x => x.UpdateLentStatusAsync(TestCardIdm, false, null, null))
             .ReturnsAsync(true);
         _settingsRepositoryMock.Setup(x => x.GetAppSettingsAsync())
@@ -1408,7 +1413,7 @@ public class LendingServiceTests : IDisposable
             });
         _ledgerRepositoryMock.Setup(x => x.InsertAsync(It.IsAny<Ledger>()))
             .ReturnsAsync(1);
-        _ledgerRepositoryMock.Setup(x => x.DeleteAsync(It.IsAny<int>()))
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(TestCardIdm))
             .Callback(() =>
             {
                 lock (lockObj)
@@ -1416,7 +1421,7 @@ public class LendingServiceTests : IDisposable
                     cardLent = false;
                 }
             })
-            .ReturnsAsync(true);
+            .ReturnsAsync(1);
         _cardRepositoryMock.Setup(x => x.UpdateLentStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<string?>()))
             .ReturnsAsync(true);
         _settingsRepositoryMock.Setup(x => x.GetAppSettingsAsync())


### PR DESCRIPTION
## Summary
- 返却処理で貸出中レコード（`is_lent_record=1`）を削除する際、`LIMIT 1` で取得した1件のみを削除していたため、孤立レコードが残る可能性があった
- `DeleteAllLentRecordsAsync` を新設し、返却時にカードの全貸出中レコードを一括削除するよう変更
- 孤立レコードの発生原因は完全には特定できていないが、次回返却時に確実にクリーンアップされるようになる

## 変更内容
| ファイル | 変更 |
|---|---|
| `ILedgerRepository.cs` | `DeleteAllLentRecordsAsync` メソッド追加 |
| `LedgerRepository.cs` | 同メソッドの実装（`WHERE card_idm AND is_lent_record=1` で全件削除） |
| `LendingService.cs` | `ReturnAsync` 内の `DeleteAsync(lentRecord.Id)` → `DeleteAllLentRecordsAsync(cardIdm)` に変更 |
| `LendingServiceTests.cs` | モック設定を新メソッドに対応 |

## Test plan
- [x] 全2246件のユニットテスト合格
- [ ] 実機で貸出→返却→履歴確認で「（貸出中）」が残らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)