### PR TITLE
fix: ReadHistoryAsyncの例外飲み込みによりリーダーエラーと履歴ゼロ件が区別不能な問題を修正 (#1169)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1550,6 +1550,11 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 5 | フェーズ遷移時のError通知 (#1168) | 上限超過 | Errorイベントが1回発火 |
 | 6 | 低頻度フェーズ中の重複Error抑制 (#1168) | フェーズ遷移後5回追加 | Errorは合計1回のみ |
 | 7 | 低頻度フェーズからの自動回復 (#1168) | リーダー復活→OnReconnectAttempt | Connected、IsInSlowRetryPhase=false |
+| 8 | TryReadHistoryAsync リーダー未接続時Fail (#1169) | GetReaders=null | Success=false, Errorあり |
+| 9 | TryReadHistoryAsync エラーイベント発火 (#1169) | GetReaders=null | Errorイベント発火 |
+| 10 | ReadHistoryAsync 後方互換 (#1169) | GetReaders=null | 空リストを返す |
+| 11 | CardReadResult.Ok (#1169) | Ok生成 | Success=true, Value設定 |
+| 12 | CardReadResult.Fail (#1169) | Fail生成 | Success=false, Error設定 |
 
 **テストクラス:** `PcScCardReaderTests`
 

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/CardReadResult.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/CardReadResult.cs
@@ -1,0 +1,45 @@
+using ICCardManager.Common.Exceptions;
+
+namespace ICCardManager.Infrastructure.CardReader
+{
+    /// <summary>
+    /// Issue #1169: カード読み取り操作の結果を表すResult型。
+    /// 成功時は値を、失敗時はエラー情報を保持し、リーダーエラーと
+    /// 「正常だがデータゼロ件」を呼び出し元で区別できるようにする。
+    /// </summary>
+    /// <typeparam name="T">読み取り結果の型</typeparam>
+    public sealed class CardReadResult<T>
+    {
+        /// <summary>
+        /// 操作が成功したかどうか
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// 成功時の値（失敗時はdefault）
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// 失敗時のエラー情報（成功時はnull）
+        /// </summary>
+        public CardReaderException Error { get; }
+
+        private CardReadResult(bool success, T value, CardReaderException error)
+        {
+            Success = success;
+            Value = value;
+            Error = error;
+        }
+
+        /// <summary>
+        /// 成功結果を生成する
+        /// </summary>
+        public static CardReadResult<T> Ok(T value) => new CardReadResult<T>(true, value, null);
+
+        /// <summary>
+        /// 失敗結果を生成する
+        /// </summary>
+        public static CardReadResult<T> Fail(CardReaderException error) => new CardReadResult<T>(false, default, error);
+    }
+}

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/FelicaCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/FelicaCardReader.cs
@@ -282,6 +282,34 @@ namespace ICCardManager.Infrastructure.CardReader
             return details;
         }
 
+        /// <inheritdoc/>
+        public async Task<CardReadResult<IReadOnlyList<LedgerDetail>>> TryReadHistoryAsync(string idm)
+        {
+            // Issue #1169: 既存ReadHistoryAsyncに委譲しつつ、エラー判定を加味する。
+            // FelicaCardReader.ReadHistoryAsyncは内部でtry/catchして空リストを返すため、
+            // ここでは「IDmが一致しない」「全く読み取れなかった」場合をエラー扱いにはしない
+            // （既存挙動の維持を優先）。実装の主目的はインターフェース遵守。
+            CardReaderException capturedError = null;
+            EventHandler<System.Exception> handler = (s, e) =>
+            {
+                if (e is CardReaderException cre) capturedError = cre;
+            };
+            Error += handler;
+            try
+            {
+                var details = (await ReadHistoryAsync(idm)).ToList();
+                if (capturedError != null)
+                {
+                    return CardReadResult<IReadOnlyList<LedgerDetail>>.Fail(capturedError);
+                }
+                return CardReadResult<IReadOnlyList<LedgerDetail>>.Ok(details);
+            }
+            finally
+            {
+                Error -= handler;
+            }
+        }
+
         /// <summary>
         /// カードの残高を読み取ります。
         /// </summary>

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/HybridCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/HybridCardReader.cs
@@ -1,6 +1,7 @@
 #if DEBUG
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ICCardManager.Models;
 
@@ -62,6 +63,18 @@ namespace ICCardManager.Infrastructure.CardReader
 
             // カスタムデータがなければ実カードリーダーに委譲
             return await _realReader.ReadHistoryAsync(idm);
+        }
+
+        /// <inheritdoc/>
+        public async Task<CardReadResult<IReadOnlyList<LedgerDetail>>> TryReadHistoryAsync(string idm)
+        {
+            // Issue #1169: カスタム履歴データがあれば成功として返す
+            if (_settings.CustomHistory.TryGetValue(idm, out var customHistory))
+            {
+                return CardReadResult<IReadOnlyList<LedgerDetail>>.Ok(customHistory.ToList());
+            }
+
+            return await _realReader.TryReadHistoryAsync(idm);
         }
 
         /// <inheritdoc/>

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/ICardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/ICardReader.cs
@@ -112,11 +112,25 @@ namespace ICCardManager.Infrastructure.CardReader
         CardReaderConnectionState ConnectionState { get; }
 
         /// <summary>
-        /// カードから履歴を読み取る
+        /// カードから履歴を読み取る（後方互換用）
+        /// </summary>
+        /// <remarks>
+        /// Issue #1169: このメソッドは例外を飲み込んで空リストを返すため、
+        /// リーダーエラーと「履歴ゼロ件」を区別できない。
+        /// 区別が必要な場合は <see cref="TryReadHistoryAsync"/> を使用すること。
+        /// </remarks>
+        /// <param name="idm">カードのIDm</param>
+        /// <returns>利用履歴詳細のリスト（エラー時は空リスト）</returns>
+        Task<IEnumerable<LedgerDetail>> ReadHistoryAsync(string idm);
+
+        /// <summary>
+        /// Issue #1169: カードから履歴を読み取る（Result型版）。
+        /// リーダーエラー発生時はFailを返し、呼び出し元でリーダーエラーと
+        /// 「履歴ゼロ件（正常）」を明確に区別できる。
         /// </summary>
         /// <param name="idm">カードのIDm</param>
-        /// <returns>利用履歴詳細のリスト</returns>
-        Task<IEnumerable<LedgerDetail>> ReadHistoryAsync(string idm);
+        /// <returns>成功時は利用履歴詳細のリスト、失敗時はエラー情報</returns>
+        Task<CardReadResult<IReadOnlyList<LedgerDetail>>> TryReadHistoryAsync(string idm);
 
         /// <summary>
         /// カードの残高を読み取る

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/MockCardReader.cs
@@ -114,6 +114,19 @@ namespace ICCardManager.Infrastructure.CardReader
             return Task.FromResult<IEnumerable<LedgerDetail>>(details);
         }
 
+        /// <inheritdoc/>
+        public Task<CardReadResult<IReadOnlyList<LedgerDetail>>> TryReadHistoryAsync(string idm)
+        {
+            // Issue #1169: モック実装は常に成功を返す
+            if (HistorySettings.CustomHistory.TryGetValue(idm, out var customHistory))
+            {
+                return Task.FromResult(CardReadResult<IReadOnlyList<LedgerDetail>>.Ok((IReadOnlyList<LedgerDetail>)customHistory.ToList()));
+            }
+
+            var details = GenerateMockHistory(HistorySettings.Days, HistorySettings.IncludeBus, HistorySettings.IncludeCharge);
+            return Task.FromResult(CardReadResult<IReadOnlyList<LedgerDetail>>.Ok((IReadOnlyList<LedgerDetail>)details));
+        }
+
         /// <summary>
         /// モック履歴データを生成
         /// </summary>

--- a/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/CardReader/PcScCardReader.cs
@@ -279,10 +279,18 @@ namespace ICCardManager.Infrastructure.CardReader
         /// </remarks>
         public async Task<IEnumerable<LedgerDetail>> ReadHistoryAsync(string idm)
         {
-            var details = new List<LedgerDetail>();
+            // Issue #1169: 後方互換のため、Result型版を呼び出して値を取り出す。
+            // エラー時は空リストを返す（既存の挙動を維持）
+            var result = await TryReadHistoryAsync(idm);
+            return result.Success ? (IEnumerable<LedgerDetail>)result.Value : new List<LedgerDetail>();
+        }
 
-            await Task.Run(() =>
+        /// <inheritdoc/>
+        public async Task<CardReadResult<IReadOnlyList<LedgerDetail>>> TryReadHistoryAsync(string idm)
+        {
+            return await Task.Run<CardReadResult<IReadOnlyList<LedgerDetail>>>(() =>
             {
+                var details = new List<LedgerDetail>();
                 try
                 {
                     var readerNames = _provider.GetReaders();
@@ -291,7 +299,10 @@ namespace ICCardManager.Infrastructure.CardReader
 #if DEBUG
                         System.Diagnostics.Debug.WriteLine("履歴読み取り: カードリーダーが見つかりません");
 #endif
-                        return;
+                        // Issue #1169: リーダー未接続は明確なエラーとして返す
+                        var notConnectedException = CardReaderException.NotConnected();
+                        Error?.Invoke(this, notConnectedException);
+                        return CardReadResult<IReadOnlyList<LedgerDetail>>.Fail(notConnectedException);
                     }
 
                     using var reader = _provider.ConnectReader(readerNames[0], SCardShareMode.Shared, SCardProtocol.Any);
@@ -318,9 +329,6 @@ namespace ICCardManager.Infrastructure.CardReader
 #endif
 
                     // 駅名解決にはCardType.Unknownを使用
-                    // 注: IDmの先頭2バイトは製造者コードであり、カード種別ではないため、
-                    //     CardTypeDetector.DetectFromIdmは信頼できない
-                    //     StationMasterServiceのUnknown優先順位（九州優先）が使用される
                     var cardType = CardType.Unknown;
 
                     // 履歴データをパースして金額を計算
@@ -335,6 +343,9 @@ namespace ICCardManager.Infrastructure.CardReader
                             details.Add(detail);
                         }
                     }
+
+                    // Issue #1169: 成功（履歴ゼロ件も成功として扱う）
+                    return CardReadResult<IReadOnlyList<LedgerDetail>>.Ok(details);
                 }
                 catch (PCSCException ex)
                 {
@@ -347,6 +358,7 @@ namespace ICCardManager.Infrastructure.CardReader
                         _ => CardReaderException.HistoryReadFailed(ex.Message, ex)
                     };
                     Error?.Invoke(this, cardReaderException);
+                    return CardReadResult<IReadOnlyList<LedgerDetail>>.Fail(cardReaderException);
                 }
                 catch (Exception ex)
                 {
@@ -355,10 +367,9 @@ namespace ICCardManager.Infrastructure.CardReader
 #endif
                     var cardReaderException = CardReaderException.HistoryReadFailed(ex.Message, ex);
                     Error?.Invoke(this, cardReaderException);
+                    return CardReadResult<IReadOnlyList<LedgerDetail>>.Fail(cardReaderException);
                 }
             });
-
-            return details;
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1173,9 +1173,19 @@ public partial class MainViewModel : ViewModelBase
         // メイン画面は変更せず、内部状態のみ更新（Issue #186）
         SetInternalState(AppState.Processing);
 
-        // カードから履歴を読み取る
-        var usageDetails = await _cardReader.ReadHistoryAsync(card.CardIdm);
-        var usageDetailsList = usageDetails.ToList();
+        // Issue #1169: カードから履歴を読み取る（リーダーエラーと履歴ゼロ件を区別）
+        var historyResult = await _cardReader.TryReadHistoryAsync(card.CardIdm);
+        if (!historyResult.Success)
+        {
+            // リーダーエラー: 不正確なデータをDBに記録しないため返却処理を中断
+            _soundPlayer.Play(SoundType.Error);
+            _toastNotificationService.ShowError(
+                "カードリーダーエラー",
+                "履歴の読み取りに失敗しました。カードを再度タッチしてください。");
+            ResetState();
+            return;
+        }
+        var usageDetailsList = historyResult.Value.ToList();
 
         var result = await _lendingService.ReturnAsync(_currentStaffIdm!, card.CardIdm, usageDetailsList);
 

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/PcScCardReaderTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using ICCardManager.Common.Exceptions;
 using ICCardManager.Infrastructure.CardReader;
+using ICCardManager.Models;
 using ICCardManager.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -707,6 +708,108 @@ public class PcScCardReaderTests : IDisposable
 
         // Assert
         _monitorMock.Verify(m => m.Cancel(), Times.Once);
+    }
+
+    #endregion
+
+    #region Issue #1169: TryReadHistoryAsync テスト
+
+    /// <summary>
+    /// Issue #1169: リーダー未接続時はFailを返すこと
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TryReadHistoryAsync_WhenNoReaderAvailable_ReturnsFail()
+    {
+        // Arrange
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
+        var reader = CreateReader();
+
+        // Act
+        var result = await reader.TryReadHistoryAsync("0123456789ABCDEF");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeFalse("リーダー未接続はFailであるべき");
+        result.Error.Should().NotBeNull("エラー情報が設定されるべき");
+    }
+
+    /// <summary>
+    /// Issue #1169: リーダー未接続時にErrorイベントが発火すること
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TryReadHistoryAsync_WhenNoReaderAvailable_FiresErrorEvent()
+    {
+        // Arrange
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
+        var reader = CreateReader();
+        Exception? capturedError = null;
+        reader.Error += (s, e) => capturedError = e;
+
+        // Act
+        await reader.TryReadHistoryAsync("0123456789ABCDEF");
+
+        // Assert
+        capturedError.Should().NotBeNull();
+        capturedError.Should().BeOfType<CardReaderException>();
+    }
+
+    /// <summary>
+    /// Issue #1169: 旧APIのReadHistoryAsyncはエラー時に空リストを返すこと（後方互換）
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadHistoryAsync_WhenNoReaderAvailable_ReturnsEmptyList()
+    {
+        // Arrange
+        _providerMock.Setup(p => p.GetReaders()).Returns((string[]?)null!);
+        var reader = CreateReader();
+
+        // Act
+        var result = await reader.ReadHistoryAsync("0123456789ABCDEF");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("後方互換のため、エラー時は空リストを返すべき");
+    }
+
+    /// <summary>
+    /// Issue #1169: CardReadResult.Okの基本動作
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CardReadResult_Ok_HasSuccessTrueAndValue()
+    {
+        // Arrange
+        var details = new List<LedgerDetail> { new LedgerDetail() };
+
+        // Act
+        var result = CardReadResult<IReadOnlyList<LedgerDetail>>.Ok(details);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Value.Should().BeSameAs(details);
+        result.Error.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Issue #1169: CardReadResult.Failの基本動作
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CardReadResult_Fail_HasSuccessFalseAndError()
+    {
+        // Arrange
+        var error = CardReaderException.NotConnected();
+
+        // Act
+        var result = CardReadResult<IReadOnlyList<LedgerDetail>>.Fail(error);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Value.Should().BeNull();
+        result.Error.Should().BeSameAs(error);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- `CardReadResult<T>`型を新規追加し、成功/失敗を明示的に区別
- `ICardReader`に`TryReadHistoryAsync`メソッドを追加（Result型版）
- 全実装クラス（PcScCardReader / HybridCardReader / MockCardReader / FelicaCardReader）に実装
- 既存`ReadHistoryAsync`は内部で新メソッドを呼び出して後方互換を維持
- `MainViewModel.ProcessReturnAsync`でリーダーエラー時に返却処理を中断し、不正確なデータがDBに記録されることを防止

## Problem
`PcScCardReader.ReadHistoryAsync`は`PCSCException`等の例外を飲み込んで空リストを返すため、呼び出し元の`MainViewModel`は「履歴ゼロ件（正常）」と「リーダーエラーで読み取れなかった」を判別できなかった。エラー時も無音で返却処理が続行され、不正確なデータ（履歴なし扱い）がDBに記録される可能性があった。

## Solution
**Result型による明示的なエラーハンドリング**:
1. `CardReadResult<T>`は`Success`/`Value`/`Error`を持つシンプルなResult型
2. `TryReadHistoryAsync`がエラー時は`Fail`、履歴ゼロ件は`Ok([])`を返す
3. 既存`ReadHistoryAsync`は新メソッドに委譲し、後方互換を維持
4. `ProcessReturnAsync`でリーダーエラーを検知したら、エラー音＋トースト通知＋状態リセットで返却処理を中断

## Test plan
- [x] `TryReadHistoryAsync_WhenNoReaderAvailable_ReturnsFail` — リーダー未接続でFail
- [x] `TryReadHistoryAsync_WhenNoReaderAvailable_FiresErrorEvent` — Errorイベント発火確認
- [x] `ReadHistoryAsync_WhenNoReaderAvailable_ReturnsEmptyList` — 後方互換性確認
- [x] `CardReadResult_Ok_HasSuccessTrueAndValue` — Result型の基本動作
- [x] `CardReadResult_Fail_HasSuccessFalseAndError` — Result型の基本動作
- [x] 既存テスト全2277件パス（回帰なし）

## Note
カード登録時の事前読み取り（`MainViewModel.ProcessUnregisteredCardAsync`の`preReadHistory`）はエラーを許容する設計なので、引き続き旧API（`ReadHistoryAsync`）を使用しています。

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)