### PR TITLE
fix: CardLockManagerのクリーンアップ競合によるObjectDisposedExceptionを修正 (#1171)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -875,6 +875,10 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 3 | 同一カード同時返却 | 2スレッドで同時ReturnAsync | 1件成功 |
 | 4 | ロックタイムアウト | 1スレッドがロック保持中に2スレッド目 | "処理が実行中" |
 | 5 | 連続10操作 | 10回連続LendAsync | デッドロックなし、全完了 |
+| 6 | クリーンアップ後のGetLock (#1171) | Cleanup→GetLock | ObjectDisposedException発生せず |
+| 7 | クリーンアップとGetLockの並行実行 (#1171) | 5×Cleanup × 5×GetLock並行 | ObjectDisposedException発生せず |
+| 8 | クリーンアップ後の新インスタンス (#1171) | Cleanup→GetLock | 別インスタンスのSemaphoreが返る |
+| 9 | 参照中エントリの保護 (#1171) | 参照カウント>0で期限経過 | 削除されない |
 
 #### UT-017g: 履歴完全性チェック
 

--- a/ICCardManager/src/ICCardManager/Services/CardLockManager.cs
+++ b/ICCardManager/src/ICCardManager/Services/CardLockManager.cs
@@ -25,6 +25,13 @@ namespace ICCardManager.Services
             public DateTime LastUsed { get; set; }
             public int ReferenceCount { get; set; }
 
+            /// <summary>
+            /// Issue #1171: クリーンアップによりDispose済みかどうか。
+            /// GetLockがこのフラグをチェックし、true の場合は辞書から取り除いて再試行する。
+            /// 必ず lock(this) 内で読み書きすること。
+            /// </summary>
+            public bool IsDisposed { get; set; }
+
             public LockEntry()
             {
                 Semaphore = new SemaphoreSlim(1, 1);
@@ -74,18 +81,33 @@ namespace ICCardManager.Services
         /// </summary>
         /// <param name="cardIdm">カードIDm</param>
         /// <returns>SemaphoreSlim</returns>
+        /// <remarks>
+        /// Issue #1171: GetLockとCleanupExpiredLocksのTOCTOU競合を回避するため、
+        /// 取得したエントリがクリーンアップによってDispose済みの場合はリトライする。
+        /// </remarks>
         public SemaphoreSlim GetLock(string cardIdm)
         {
-            var entry = _locks.GetOrAdd(cardIdm, _ => new LockEntry());
-
-            // 最終使用時刻を更新し、参照カウントをインクリメント
-            lock (entry)
+            while (true)
             {
-                entry.LastUsed = DateTime.UtcNow;
-                entry.ReferenceCount++;
-            }
+                var entry = _locks.GetOrAdd(cardIdm, _ => new LockEntry());
 
-            return entry.Semaphore;
+                // 最終使用時刻を更新し、参照カウントをインクリメント
+                lock (entry)
+                {
+                    // Issue #1171: クリーンアップによりDispose済みなら、辞書から取り除いて再試行
+                    // TryRemove(KVP)は値が一致する場合のみ削除する原子操作のため、
+                    // 別スレッドが同じキーで新エントリを既に登録していた場合に誤削除されない
+                    if (entry.IsDisposed)
+                    {
+                        ((ICollection<KeyValuePair<string, LockEntry>>)_locks).Remove(new KeyValuePair<string, LockEntry>(cardIdm, entry));
+                        continue;
+                    }
+
+                    entry.LastUsed = DateTime.UtcNow;
+                    entry.ReferenceCount++;
+                    return entry.Semaphore;
+                }
+            }
         }
 
         /// <summary>
@@ -124,55 +146,65 @@ namespace ICCardManager.Services
         /// <summary>
         /// 期限切れのロックをクリーンアップ
         /// </summary>
+        /// <remarks>
+        /// Issue #1171: マーク・削除・Dispose を単一の lock(entry) クリティカルセクション内で実行する。
+        /// これにより GetLock との TOCTOU 競合を排除し、ObjectDisposedException を防止する。
+        /// </remarks>
         public void CleanupExpiredLocks()
         {
             lock (_cleanupLock)
             {
                 var cutoffTime = DateTime.UtcNow - LockExpiration;
-                var keysToRemove = new List<string>();
+                var removedCount = 0;
 
-                foreach (var kvp in _locks)
+                // 列挙中の変更を避けるためスナップショットを取る
+                foreach (var kvp in _locks.ToArray())
                 {
                     var cardIdm = kvp.Key;
                     var entry = kvp.Value;
 
-                    // ロックされた状態でチェック
+                    // Issue #1171: 単一クリティカルセクションでチェック→マーク→削除を実行
                     lock (entry)
                     {
-                        // 参照カウントが0で、最終使用時刻が期限切れの場合のみ削除
-                        if (entry.ReferenceCount == 0 && entry.LastUsed < cutoffTime)
+                        // 参照カウントが0で、最終使用時刻が期限切れで、Semaphoreが使用中でない場合のみ削除
+                        if (entry.ReferenceCount != 0 ||
+                            entry.LastUsed >= cutoffTime ||
+                            entry.Semaphore.CurrentCount != 1)
                         {
-                            // SemaphoreSlimが使用中でないことを確認
-                            if (entry.Semaphore.CurrentCount == 1)
+                            continue;
+                        }
+
+                        // Dispose済みフラグを立て、辞書から原子的に削除
+                        // TryRemove(KVP)は値が一致する場合のみ削除するため、
+                        // 別スレッドが同じキーで既に置き換えていた場合は誤削除されない
+                        entry.IsDisposed = true;
+                        var removed = ((ICollection<KeyValuePair<string, LockEntry>>)_locks).Remove(new KeyValuePair<string, LockEntry>(cardIdm, entry));
+                        if (removed)
+                        {
+                            try
                             {
-                                keysToRemove.Add(cardIdm);
+                                entry.Semaphore.Dispose();
                             }
+                            catch (ObjectDisposedException)
+                            {
+                                // 既にDisposeされている場合は無視
+                            }
+                            removedCount++;
+                        }
+                        else
+                        {
+                            // 別スレッドが既に置き換えていた場合は IsDisposed を取り消す
+                            // （新エントリは別インスタンスなので副作用なし）
+                            entry.IsDisposed = false;
                         }
                     }
                 }
 
-                // 削除対象のロックを削除
-                foreach (var key in keysToRemove)
-                {
-                    if (_locks.TryRemove(key, out var removedEntry))
-                    {
-                        // SemaphoreSlimをDispose
-                        try
-                        {
-                            removedEntry.Semaphore.Dispose();
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // 既にDisposeされている場合は無視
-                        }
-                    }
-                }
-
-                if (keysToRemove.Count > 0)
+                if (removedCount > 0)
                 {
                     _logger.LogDebug(
                         "未使用のロックをクリーンアップしました: {Count}件削除、残り{Remaining}件",
-                        keysToRemove.Count,
+                        removedCount,
                         _locks.Count);
                 }
             }

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CardLockManagerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CardLockManagerTests.cs
@@ -543,4 +543,174 @@ public class CardLockManagerTests : IDisposable
     }
 
     #endregion
+
+    #region Issue #1171: TOCTOU競合テスト
+
+    /// <summary>
+    /// Issue #1171: クリーンアップ直後にGetLockを呼んでもObjectDisposedExceptionが発生しないこと
+    /// </summary>
+    [Fact]
+    public async Task GetLock_AfterCleanup_DoesNotThrowObjectDisposedException()
+    {
+        // Arrange: 非常に短い有効期限でクリーンアップ可能にする
+        var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance)
+        {
+            LockExpiration = TimeSpan.FromMilliseconds(1)
+        };
+        try
+        {
+            // 1. ロックを取得して解放（参照カウント0、すぐ期限切れ）
+            var sem = lockManager.GetLock("card1");
+            lockManager.ReleaseLockReference("card1");
+            await Task.Delay(50); // 期限を経過させる
+
+            // 2. クリーンアップ実行（card1のセマフォはDisposeされる）
+            lockManager.CleanupExpiredLocks();
+
+            // 3. 同じキーでGetLock → 新しいエントリが返るべき
+            var newSem = lockManager.GetLock("card1");
+
+            // Assert: 取得した新セマフォは有効（WaitAsyncが例外を投げない）
+            var act = async () => await newSem.WaitAsync(100);
+            await act.Should().NotThrowAsync();
+            newSem.Release();
+        }
+        finally
+        {
+            lockManager.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Issue #1171: クリーンアップとGetLockの並行実行でObjectDisposedExceptionが発生しないこと
+    /// </summary>
+    [Fact]
+    public async Task GetLockAndCleanup_Concurrent_DoesNotThrowObjectDisposedException()
+    {
+        // Arrange
+        var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance)
+        {
+            LockExpiration = TimeSpan.FromMilliseconds(1)
+        };
+        try
+        {
+            // 大量の使用済みロックを準備
+            for (int i = 0; i < 100; i++)
+            {
+                lockManager.GetLock($"card{i}");
+                lockManager.ReleaseLockReference($"card{i}");
+            }
+            await Task.Delay(20); // 期限切れにする
+
+            var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+            // Act: クリーンアップとGetLockを並行実行
+            var cleanupTasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() =>
+            {
+                try
+                {
+                    for (int j = 0; j < 20; j++)
+                    {
+                        lockManager.CleanupExpiredLocks();
+                    }
+                }
+                catch (Exception ex) { exceptions.Add(ex); }
+            }));
+
+            var getLockTasks = Enumerable.Range(0, 5).Select(workerIdx => Task.Run(async () =>
+            {
+                try
+                {
+                    for (int j = 0; j < 100; j++)
+                    {
+                        var key = $"card{j % 100}";
+                        var sem = lockManager.GetLock(key);
+                        // セマフォを実際に使う（ObjectDisposedExceptionが出ないこと）
+                        await sem.WaitAsync(50);
+                        sem.Release();
+                        lockManager.ReleaseLockReference(key);
+                    }
+                }
+                catch (Exception ex) { exceptions.Add(ex); }
+            }));
+
+            await Task.WhenAll(cleanupTasks.Concat(getLockTasks));
+
+            // Assert: ObjectDisposedExceptionが一度も発生していないこと
+            exceptions.OfType<ObjectDisposedException>().Should().BeEmpty(
+                "TOCTOU修正によりObjectDisposedExceptionは発生しないべき");
+        }
+        finally
+        {
+            lockManager.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Issue #1171: クリーンアップ後の同一キー再取得で新しいセマフォインスタンスが返ること
+    /// </summary>
+    [Fact]
+    public async Task GetLock_AfterCleanup_ReturnsNewSemaphoreInstance()
+    {
+        // Arrange
+        var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance)
+        {
+            LockExpiration = TimeSpan.FromMilliseconds(1)
+        };
+        try
+        {
+            var oldSem = lockManager.GetLock("card1");
+            lockManager.ReleaseLockReference("card1");
+            await Task.Delay(50);
+
+            lockManager.CleanupExpiredLocks();
+
+            // Act
+            var newSem = lockManager.GetLock("card1");
+
+            // Assert: 新しいインスタンスのはず
+            ReferenceEquals(oldSem, newSem).Should().BeFalse(
+                "クリーンアップ後の取得は新インスタンスを返すべき");
+        }
+        finally
+        {
+            lockManager.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Issue #1171: 参照カウントが残っているエントリはクリーンアップ対象外
+    /// </summary>
+    [Fact]
+    public async Task CleanupExpiredLocks_WithActiveReferences_DoesNotRemove()
+    {
+        // Arrange
+        var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance)
+        {
+            LockExpiration = TimeSpan.FromMilliseconds(1)
+        };
+        try
+        {
+            var sem = lockManager.GetLock("card1");
+            // ReleaseLockReference を呼ばない → 参照カウント=1のまま
+
+            await Task.Delay(50); // 期限経過
+
+            // Act
+            lockManager.CleanupExpiredLocks();
+
+            // Assert: 残っていること
+            lockManager.HasLock("card1").Should().BeTrue("参照カウント>0なら削除されないべき");
+
+            // 同じセマフォインスタンスが返ること
+            var sem2 = lockManager.GetLock("card1");
+            ReferenceEquals(sem, sem2).Should().BeTrue();
+        }
+        finally
+        {
+            lockManager.Dispose();
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- `LockEntry`に`IsDisposed`フラグを追加し、クリーンアップ済みであることをマーク
- `CleanupExpiredLocks`でチェック・マーク・削除・Disposeを単一の`lock(entry)`クリティカルセクション内で原子的に実行
- `GetLock`をループ化し、`IsDisposed`検出時は辞書から取り除いて再試行
- `ICollection<KVP>.Remove`を使い、値が一致する場合のみ削除する原子操作で誤削除を防止

## Problem
**TOCTOU（Time-of-check-to-time-of-use）競合**:
1. クリーンアップスレッドが`keysToRemove`にエントリを追加（`lock(entry)`は解放済み）
2. **その隙間に**別スレッドが`GetLock`で同じエントリを取得し、参照カウントを増やして`Semaphore`を返す
3. クリーンアップスレッドが`TryRemove`+`Dispose()`を実行
4. 別スレッドが`Semaphore.WaitAsync()`を呼ぶ → `ObjectDisposedException`発生
5. catchで握りつぶされるが、Semaphoreは解放済みのため排他制御が機能しなくなる

## Solution
**単一クリティカルセクションでの原子的処理**:
- クリーンアップ条件チェック→`IsDisposed=true`マーク→辞書からの削除→Disposeを全て`lock(entry)`内で実行
- `GetLock`は`lock(entry)`内で`IsDisposed`を確認し、trueなら辞書から取り除いてループ先頭に戻る
- `ICollection<KeyValuePair>.Remove`は値が完全一致する場合のみ削除する原子操作なので、別スレッドが新エントリで置換していても誤削除されない

## Test plan
- [x] `GetLock_AfterCleanup_DoesNotThrowObjectDisposedException` — クリーンアップ後の単純な再取得
- [x] `GetLockAndCleanup_Concurrent_DoesNotThrowObjectDisposedException` — 5×Cleanup×5×GetLock並行実行
- [x] `GetLock_AfterCleanup_ReturnsNewSemaphoreInstance` — 新インスタンスが返ることの確認
- [x] `CleanupExpiredLocks_WithActiveReferences_DoesNotRemove` — 参照中エントリの保護
- [x] 既存テスト全2285件パス（回帰なし）

## Note
.NET Framework 4.8では`ConcurrentDictionary.TryRemove(KeyValuePair)`オーバーロードが存在しないため、`((ICollection<KeyValuePair<,>>)dict).Remove(KVP)`を使用しました。これは値が一致する場合のみ削除する原子操作で同等の挙動です。

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)