### PR TITLE
fix: FileLoggerProviderのログキュー溢れによるサイレントドロップを修正 (#1173)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1526,6 +1526,11 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 10 | Dispose（Enabled） | Enabled=trueでDispose | 例外なく終了 |
 | 11 | Dispose（Disabled） | Enabled=falseでDispose | 例外なく終了 |
 | 12 | ローテーション | ログ書き込み後のファイル確認 | ファイルが存在する |
+| 13 | キャパシティ定数 (#1173) | LogQueueCapacity | 5000（1000から増加） |
+| 14 | 通常使用でのドロップ件数 (#1173) | 少量WriteLog | DroppedLogCount=0 |
+| 15 | 無効状態のドロップカウント (#1173) | Enabled=false | カウント増えず |
+| 16 | キュー閉鎖後のWriteLog (#1173) | Dispose後にWriteLog×10 | DroppedLogCount=10 |
+| 17 | 並行ドロップカウント (#1173) | 10スレッド×100メッセージ | アトミックに1000件カウント |
 
 **テストクラス:** `FileLoggerProviderTests`
 

--- a/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/Logging/FileLoggerProvider.cs
@@ -20,7 +20,13 @@ namespace ICCardManager.Infrastructure.Logging
     public class FileLoggerProvider : ILoggerProvider
     {
         private readonly ConcurrentDictionary<string, FileLogger> _loggers = new();
-        private readonly BlockingCollection<string> _logQueue = new(1000);
+
+        /// <summary>
+        /// Issue #1173: ログキューのキャパシティ。1000→5000に増加し、高負荷時のドロップを軽減。
+        /// </summary>
+        internal const int LogQueueCapacity = 5000;
+
+        private readonly BlockingCollection<string> _logQueue = new(LogQueueCapacity);
         private readonly Task _outputTask;
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
@@ -28,6 +34,30 @@ namespace ICCardManager.Infrastructure.Logging
         private string _currentLogFilePath = string.Empty;
         private DateTime _currentLogDate;
         private readonly object _fileLock = new();
+
+        /// <summary>
+        /// Issue #1173: キュー溢れによりドロップされたログメッセージの累積件数
+        /// </summary>
+        private long _droppedLogCount;
+
+        /// <summary>
+        /// Issue #1173: 最後にドロップ件数を自己ログ出力した時点での累積件数。
+        /// 増分の検出と「直近Nミリ秒のドロップ件数」のレポートに使用。
+        /// </summary>
+        private long _lastReportedDroppedCount;
+
+        /// <summary>
+        /// Issue #1173: ドロップ発生レポートの最小間隔（ミリ秒）。
+        /// この間隔より頻繁にレポートしないことで、自己ログ自体がキューを溢れさせる事態を防止。
+        /// </summary>
+        internal const int DropReportMinIntervalMs = 5000;
+
+        private DateTime _lastDropReportTime = DateTime.MinValue;
+
+        /// <summary>
+        /// Issue #1173: キュー溢れによりドロップされたログメッセージの累積件数（テスト・診断用）
+        /// </summary>
+        public long DroppedLogCount => Interlocked.Read(ref _droppedLogCount);
 
         public FileLoggerOptions Options { get; }
 
@@ -73,13 +103,29 @@ namespace ICCardManager.Infrastructure.Logging
                 return;
             }
 
-            // キューがいっぱいの場合は古いエントリを破棄
-            if (!_logQueue.TryAdd(message))
+            // キューがいっぱいの場合はメッセージを破棄してドロップカウンタをインクリメント
+            try
             {
-                // キューがいっぱい - ログを破棄
+                if (!_logQueue.TryAdd(message))
+                {
+                    // Issue #1173: ドロップカウンタを原子的にインクリメント
+                    Interlocked.Increment(ref _droppedLogCount);
 #if DEBUG
-                System.Diagnostics.Debug.WriteLine("[FileLogger] Log queue full, message dropped");
+                    System.Diagnostics.Debug.WriteLine("[FileLogger] Log queue full, message dropped");
 #endif
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Issue #1173: Dispose後の呼び出しもドロップとしてカウント
+                // (ObjectDisposedExceptionはInvalidOperationExceptionの派生型なので先に捕捉)
+                Interlocked.Increment(ref _droppedLogCount);
+            }
+            catch (InvalidOperationException)
+            {
+                // Issue #1173: CompleteAddingが呼ばれた後（シャットダウン中）はTryAddがスローする
+                // この場合もドロップとしてカウントし、例外を呑み込む
+                Interlocked.Increment(ref _droppedLogCount);
             }
         }
 
@@ -90,12 +136,44 @@ namespace ICCardManager.Infrastructure.Logging
                 foreach (var message in _logQueue.GetConsumingEnumerable(_cancellationTokenSource.Token))
                 {
                     WriteToFile(message);
+
+                    // Issue #1173: 各書き込み後にドロップ発生をチェックし、必要なら自己ログを書き込む
+                    ReportDroppedLogsIfNeeded();
                 }
             }
             catch (OperationCanceledException)
             {
                 // 正常終了
             }
+        }
+
+        /// <summary>
+        /// Issue #1173: 前回レポート以降にドロップが発生していれば、ログファイルに自己レポートを書き込む。
+        /// 最小間隔（DropReportMinIntervalMs）より頻繁にはレポートしない。
+        /// </summary>
+        private void ReportDroppedLogsIfNeeded()
+        {
+            var currentDropped = Interlocked.Read(ref _droppedLogCount);
+            var increment = currentDropped - _lastReportedDroppedCount;
+            if (increment <= 0)
+            {
+                return;
+            }
+
+            var now = DateTime.UtcNow;
+            if ((now - _lastDropReportTime).TotalMilliseconds < DropReportMinIntervalMs)
+            {
+                return;
+            }
+
+            _lastReportedDroppedCount = currentDropped;
+            _lastDropReportTime = now;
+
+            // 自己レポートを書き込む（このメッセージはキューを通さず直接ファイルへ）
+            var report = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [WARN] [FileLogger] " +
+                         $"Issue #1173: ログキュー溢れにより直近 {increment} 件のログメッセージが破棄されました " +
+                         $"(累計: {currentDropped} 件、キャパシティ: {LogQueueCapacity})";
+            WriteToFile(report);
         }
 
         private void WriteToFile(string message)
@@ -263,6 +341,24 @@ namespace ICCardManager.Infrastructure.Logging
             catch (AggregateException)
             {
                 // タスクがキャンセルされた
+            }
+
+            // Issue #1173: 終了時に未レポートのドロップ件数があれば最終レポートを書き込む
+            try
+            {
+                var totalDropped = Interlocked.Read(ref _droppedLogCount);
+                var unreported = totalDropped - _lastReportedDroppedCount;
+                if (unreported > 0 && Options.Enabled)
+                {
+                    var report = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [WARN] [FileLogger] " +
+                                 $"Issue #1173: シャットダウン時、未レポートだった {unreported} 件のログドロップがありました " +
+                                 $"(累計: {totalDropped} 件)";
+                    WriteToFile(report);
+                }
+            }
+            catch
+            {
+                // シャットダウン時の自己レポート失敗は無視
             }
 
             _cancellationTokenSource.Dispose();

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Logging/FileLoggerProviderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Logging/FileLoggerProviderTests.cs
@@ -272,4 +272,111 @@ public class FileLoggerProviderTests : IDisposable
     }
 
     #endregion
+
+    #region Issue #1173: キュー溢れドロップカウンタ テスト
+
+    /// <summary>
+    /// Issue #1173: キャパシティ定数が5000であること
+    /// </summary>
+    [Fact]
+    public void LogQueueCapacity_Is5000()
+    {
+        FileLoggerProvider.LogQueueCapacity.Should().Be(5000, "Issue #1173で1000→5000に増加");
+    }
+
+    /// <summary>
+    /// Issue #1173: 通常書き込みではDroppedLogCountは0であること
+    /// </summary>
+    [Fact]
+    public void DroppedLogCount_NormalUsage_IsZero()
+    {
+        // Arrange
+        using var provider = CreateProvider(enabled: true);
+
+        // Act: 少量のログを書き込み（キャパシティ未満）
+        for (int i = 0; i < 10; i++)
+        {
+            provider.WriteLog($"通常メッセージ{i}");
+        }
+        Thread.Sleep(300); // 書き込み完了を待つ
+
+        // Assert
+        provider.DroppedLogCount.Should().Be(0, "通常使用ではドロップは発生しない");
+    }
+
+    /// <summary>
+    /// Issue #1173: 無効状態のproviderはWriteLogでドロップカウントが増えないこと
+    /// </summary>
+    [Fact]
+    public void DroppedLogCount_DisabledProvider_StaysZero()
+    {
+        // Arrange
+        using var provider = CreateProvider(enabled: false);
+
+        // Act
+        for (int i = 0; i < 100; i++)
+        {
+            provider.WriteLog($"無効テスト{i}");
+        }
+
+        // Assert: 無効状態ではWriteLogが即座にreturnするためドロップは発生しない
+        provider.DroppedLogCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Issue #1173: キュー溢れ時にDroppedLogCountがインクリメントされること
+    /// </summary>
+    /// <remarks>
+    /// Disposeしたproviderの_logQueueは閉じられているためTryAddに失敗する。
+    /// この性質を利用してドロップ経路を検証する。
+    /// </remarks>
+    [Fact]
+    public void DroppedLogCount_QueueOverflow_Increments()
+    {
+        // Arrange: providerを作成してすぐDispose（_logQueue.CompleteAddingが呼ばれる）
+        var provider = CreateProvider(enabled: true);
+        provider.Dispose();
+
+        var droppedBefore = provider.DroppedLogCount;
+
+        // Act: Dispose後にWriteLogを呼ぶ → TryAddが失敗してドロップカウンタ増加
+        for (int i = 0; i < 10; i++)
+        {
+            provider.WriteLog($"溢れテスト{i}");
+        }
+
+        // Assert
+        provider.DroppedLogCount.Should().BeGreaterThan(droppedBefore,
+            "キューが受け付けない状態ではドロップカウントが増加するべき");
+        provider.DroppedLogCount.Should().Be(droppedBefore + 10);
+    }
+
+    /// <summary>
+    /// Issue #1173: DroppedLogCountは複数スレッドからインクリメントされてもアトミックに集計されること
+    /// </summary>
+    [Fact]
+    public void DroppedLogCount_MultiThreaded_AtomicIncrement()
+    {
+        // Arrange
+        var provider = CreateProvider(enabled: true);
+        provider.Dispose(); // キューを閉じてドロップ経路に誘導
+
+        const int threadCount = 10;
+        const int messagesPerThread = 100;
+
+        // Act
+        var tasks = Enumerable.Range(0, threadCount).Select(_ => System.Threading.Tasks.Task.Run(() =>
+        {
+            for (int i = 0; i < messagesPerThread; i++)
+            {
+                provider.WriteLog($"並行テスト");
+            }
+        })).ToArray();
+        System.Threading.Tasks.Task.WaitAll(tasks);
+
+        // Assert: 全ドロップが原子的にカウントされていること
+        provider.DroppedLogCount.Should().Be(threadCount * messagesPerThread);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- `LogQueueCapacity`を1000→5000に増加（高負荷時のドロップを軽減）
- `DroppedLogCount`プロパティを追加し、`Interlocked.Increment`で原子的にカウント
- `ProcessLogQueue`内で定期的にドロップ件数をログファイルに自己レポート（最小間隔5秒で「直近N件がドロップされました」と記録）
- `Dispose`時に未レポートのドロップ件数を最終出力
- `WriteLog`の`ObjectDisposedException`/`InvalidOperationException`もドロップとしてカウント（シャットダウン中のレース耐性向上）

## Problem
`FileLoggerProvider`の`BlockingCollection`キャパシティは1000件で、キューがいっぱいの場合、ログメッセージが**無音で破棄**されていた。

- 高負荷時に障害調査に必要なログが知らぬ間にドロップされる
- キュー溢れのカウンターやメトリクスが存在せず、ドロップの発生自体を検知できない

## Solution
**3層の防御**:
1. **キャパシティ拡大** (1000→5000): 通常負荷ではほぼ溢れない余裕を確保
2. **原子的カウンター** (`Interlocked.Increment`): どれだけドロップしたかを正確に追跡
3. **自己レポート機構**: バックグラウンドのライタータスク内で、前回レポート以降に増分があれば「直近N件がドロップされました」とログファイルに自動記録（最小間隔5秒で自己ログがキューを溢れさせない設計）

加えて`Dispose`時にも未レポート分の最終サマリーを出力するため、シャットダウン直前のドロップも見逃しません。

## Test plan
- [x] `LogQueueCapacity_Is5000` — キャパシティ定数
- [x] `DroppedLogCount_NormalUsage_IsZero` — 通常使用ではドロップ無し
- [x] `DroppedLogCount_DisabledProvider_StaysZero` — 無効状態
- [x] `DroppedLogCount_QueueOverflow_Increments` — Dispose後のWriteLogでドロップ経路を検証
- [x] `DroppedLogCount_MultiThreaded_AtomicIncrement` — 10スレッド×100メッセージで原子性確認
- [x] 既存テスト全2297件パス（回帰なし）

## Note
**シャットダウン中のレース耐性**: この修正で副次的に、`Dispose`後の`WriteLog`呼び出しが`ObjectDisposedException`を投げる問題も解消しました。`BlockingCollection.TryAdd`はDispose後に例外を投げる仕様ですが、今回の変更で例外を捕捉してドロップカウンタを増やすため、シャットダウン中の他スレッドからのログ呼び出しがクラッシュを引き起こさなくなります。

**ObjectDisposedException vs InvalidOperationException**: `ObjectDisposedException`は`InvalidOperationException`の派生型のため、catch句の順序を「派生型が先」にする必要がある点はC#の例外処理の典型的な落とし穴です。

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)