### PR TITLE
refactor(PrintService): ページネーション計算を internal static に変更

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/PrintService.cs
+++ b/ICCardManager/src/ICCardManager/Services/PrintService.cs
@@ -246,7 +246,10 @@ namespace ICCardManager.Services
         /// <summary>
         /// ヘッダー部分の合計高さを取得（タイトル + カード情報 + 列ヘッダー + テーブル罫線）
         /// </summary>
-        private double GetHeaderTotalHeight()
+        /// <remarks>
+        /// 純粋関数（インスタンス状態に依存しない）。テスト容易性のため internal static として公開。
+        /// </remarks>
+        internal static double GetHeaderTotalHeight()
         {
             return TitleHeight + CardInfoTableHeight + ColumnHeaderHeight + TableBorderHeight;
         }
@@ -254,7 +257,11 @@ namespace ICCardManager.Services
         /// <summary>
         /// データ行の高さを取得（摘要欄の文字数に基づく）
         /// </summary>
-        private double GetDataRowHeight(ReportRow row, bool isLandscape)
+        /// <remarks>
+        /// 純粋関数。摘要が空または1行に収まる場合は <see cref="DataRowHeight"/>、
+        /// 折り返す場合は <see cref="DataRowHeightDouble"/> を返す。
+        /// </remarks>
+        internal static double GetDataRowHeight(ReportRow row, bool isLandscape)
         {
             if (string.IsNullOrEmpty(row.Summary))
                 return DataRowHeight;
@@ -266,7 +273,8 @@ namespace ICCardManager.Services
         /// <summary>
         /// データ領域の利用可能な高さを計算
         /// </summary>
-        private double GetAvailableDataHeight(double pageHeight)
+        /// <remarks>純粋関数。</remarks>
+        internal static double GetAvailableDataHeight(double pageHeight)
         {
             // ページ高さ - 上下余白 - ヘッダー部分
             return pageHeight - (PagePaddingSize * 2) - GetHeaderTotalHeight();
@@ -275,7 +283,11 @@ namespace ICCardManager.Services
         /// <summary>
         /// 行をページごとにグループ化（高さを積み上げて改ページ位置を決定）
         /// </summary>
-        private List<List<ReportRow>> GroupRowsByPage(
+        /// <remarks>
+        /// 純粋関数。ページ寸法・行データ・合計行数を入力として、改ページ位置を確定する。
+        /// インスタンス状態に依存しない。
+        /// </remarks>
+        internal static List<List<ReportRow>> GroupRowsByPage(
             List<ReportRow> rows,
             double pageWidth,
             double pageHeight,


### PR DESCRIPTION
## Summary
- `PrintService.GroupRowsByPage` および補助メソッド（`GetHeaderTotalHeight`、`GetDataRowHeight`、`GetAvailableDataHeight`）はすべてインスタンス状態に依存しない純粋関数だったが、`private` インスタンスメソッドとして宣言されていたため、テストから直接呼べなかった
- これら4メソッドを `internal static` に変更し、テスト容易性を向上させる
- **振る舞いは完全に同一**（メソッド本体は1行も変更していない）
- 既存テスト 2,413 件すべて合格

## 変更内容
| メソッド | 変更前 | 変更後 |
|---|---|---|
| `GetHeaderTotalHeight` | `private double` | `internal static double` |
| `GetDataRowHeight` | `private double` | `internal static double` |
| `GetAvailableDataHeight` | `private double` | `internal static double` |
| `GroupRowsByPage` | `private List<List<ReportRow>>` | `internal static List<List<ReportRow>>` |

## 設計上の意義
- `InternalsVisibleTo` は既に設定済みのため、別クラスへの抽出は不要
- アクセシビリティと `static` 修飾子のみの変更で、メソッド本体は1行も触っていない（最小変更リファクタ）
- 後続PRで4メソッドに対する直接単体テストを追加予定

## Test plan
- [x] `dotnet test`（フル実行） → 2413/2413 passed
- [x] CI でフル回帰テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)