### PR TITLE
fix(OperationLogger): LogLedgerDeleteAsync の operatorIdm を nullable に統一 (#1188)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
@@ -330,14 +330,22 @@ namespace ICCardManager.Services
         /// <summary>
         /// 履歴削除のログを記録
         /// </summary>
-        public async Task LogLedgerDeleteAsync(string operatorIdm, Ledger ledger)
+        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
+        /// <param name="ledger">削除する履歴データ</param>
+        /// <remarks>
+        /// Issue #1188: 他の Log 系メソッドとシグネチャを統一し、operatorIdm を nullable に変更。
+        /// nullまたは空文字列が渡された場合は GUI 操作としてフォールバックする。
+        /// </remarks>
+        public async Task LogLedgerDeleteAsync(string? operatorIdm, Ledger ledger)
         {
-            var operatorName = await GetOperatorNameAsync(operatorIdm);
+            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
+            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
+            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
 
             var log = new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = operatorIdm,
+                OperatorIdm = actualIdm,
                 OperatorName = operatorName,
                 TargetTable = Tables.Ledger,
                 TargetId = ledger.Id.ToString(),

--- a/ICCardManager/tests/ICCardManager.Tests/Services/OperationLoggerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/OperationLoggerTests.cs
@@ -385,8 +385,13 @@ public class OperationLoggerTests : IDisposable
 
     /// <summary>
     /// LogLedgerDeleteAsync: 有効な operatorIdm を渡すと正しく記録される。
-    /// （他のメソッドと異なり null は許容されないシグネチャ）
     /// </summary>
+    /// <remarks>
+    /// Issue #1188 で他の Log 系メソッドとシグネチャが統一され、operatorIdm が
+    /// nullable になった。本テストは「有効な operatorIdm を渡した場合の振る舞い」を固定する。
+    /// null / 空文字列ケースは別途下記の <c>LogLedgerDeleteAsync_WithNullOperatorIdm_*</c>
+    /// および <c>LogLedgerDeleteAsync_WithEmptyOperatorIdm_*</c> で検証する。
+    /// </remarks>
     [Fact]
     public async Task LogLedgerDeleteAsync_WithValidOperator_RecordsBeforeOnly()
     {
@@ -407,6 +412,54 @@ public class OperationLoggerTests : IDisposable
         log.OperatorName.Should().Be("削除者");
         log.BeforeData.Should().Contain("削除対象");
         log.AfterData.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Issue #1188: LogLedgerDeleteAsync に null operatorIdm を渡すと
+    /// GUI 操作識別子（Idm/Name）にフォールバックして記録される
+    /// </summary>
+    [Fact]
+    public async Task LogLedgerDeleteAsync_WithNullOperatorIdm_UsesGuiIdentifier()
+    {
+        var ledger = CreateTestLedger(id: 77, summary: "GUI削除対象");
+
+        await _logger.LogLedgerDeleteAsync(null, ledger);
+
+        var logs = await _operationLogRepository.GetByTargetAsync(
+            OperationLogger.Tables.Ledger, "77");
+        logs.Should().HaveCount(1);
+        var log = logs.First();
+        log.Action.Should().Be(OperationLogger.Actions.Delete);
+        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
+        log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
+        log.BeforeData.Should().Contain("GUI削除対象");
+        log.AfterData.Should().BeNull();
+        // null が渡された場合、StaffRepository は照会されない
+        _staffRepositoryMock.Verify(
+            x => x.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Issue #1188: LogLedgerDeleteAsync に空文字列の operatorIdm を渡すと
+    /// GUI 操作識別子にフォールバックする（他の Log 系メソッドと同等の振る舞い）
+    /// </summary>
+    [Fact]
+    public async Task LogLedgerDeleteAsync_WithEmptyOperatorIdm_UsesGuiIdentifier()
+    {
+        var ledger = CreateTestLedger(id: 78, summary: "空文字列削除対象");
+
+        await _logger.LogLedgerDeleteAsync(string.Empty, ledger);
+
+        var logs = await _operationLogRepository.GetByTargetAsync(
+            OperationLogger.Tables.Ledger, "78");
+        logs.Should().HaveCount(1);
+        var log = logs.First();
+        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
+        log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
+        _staffRepositoryMock.Verify(
+            x => x.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Fixes #1188

`OperationLogger.LogLedgerDeleteAsync` だけ `operatorIdm` が `string`（null 非許容）型で宣言されており、他の Log 系メソッド（`LogStaffDeleteAsync`、`LogCardDeleteAsync` 等）の `string?` と一貫性がなかった。本 PR でシグネチャを統一する。

## 変更内容
- `LogLedgerDeleteAsync` のシグネチャを `string? operatorIdm` に変更
- null または空文字列の場合は GUI 操作識別子（`GuiOperator.Idm` / `GuiOperator.Name`）にフォールバック
- GUI 操作時は `StaffRepository` を照会しない（無駄なクエリを抑制）
- XMLドキュメントコメントに Issue #1188 の経緯を記載

## 呼び出し元への影響
`MainViewModel.cs:1777, 1831` の 2 箇所はいずれも非null の `string`（`authResult.Idm` / `operatorIdm`）を渡しているため、**後方互換性あり**。既存呼び出し元の修正は不要。

## テスト追加（2ケース）
- `LogLedgerDeleteAsync_WithNullOperatorIdm_UsesGuiIdentifier`: null → GuiOperator にフォールバック、StaffRepository 未照会
- `LogLedgerDeleteAsync_WithEmptyOperatorIdm_UsesGuiIdentifier`: 空文字列 → 同上

既存テスト `LogLedgerDeleteAsync_WithValidOperator_RecordsBeforeOnly` のXMLコメントを更新し、本 Issue 解決後の位置づけ（「有効な operatorIdm を渡した場合の振る舞い」）を明示。

## Test plan
- [x] `dotnet test --filter OperationLoggerTests` → 22/22 passed（既存20 + 新規2）
- [x] `dotnet test`（フル実行） → 2453/2453 passed（回帰なし）
- [ ] CI でフル回帰テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)