### PR TITLE
fix(ReportService): GetStartingPageNumberForMonth の L2 空シートスキップを明示化 (#1197)

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -730,8 +730,15 @@ namespace ICCardManager.Services
         /// ワークシート内の最終ページ番号を取得（Issue #809）
         /// </summary>
         /// <remarks>
+        /// <para>
         /// CheckAndInsertPageBreak は改ページごとに AddHorizontalPageBreak と SetPageNumber を呼ぶため、
         /// 「1ページ目のページ番号 + 改ページ数 = 最終ページ番号」が成り立つ。
+        /// </para>
+        /// <para>
+        /// L2 セル（1ページ目のページ番号）が空または整数として読めない場合は <c>0</c> を返す。
+        /// 0 は「ページ情報を持たない（無効な）シート」を示すセンチネル値であり、呼び出し側
+        /// （<see cref="FindNearestPreviousMonthLastPage"/>）はこの 0 を見て当該シートをスキップする。
+        /// </para>
         /// </remarks>
         internal static int GetLastPageNumberFromWorksheet(IXLWorksheet worksheet)
         {
@@ -750,9 +757,16 @@ namespace ICCardManager.Services
         /// 月の開始ページ番号を算出（Issue #809）
         /// </summary>
         /// <remarks>
-        /// 前月のシートが存在する場合はその最終ページ番号+1、
-        /// 存在しない場合は card.StartingPageNumber を使用する。
-        /// 年度内の月順序に従い、直近で存在するシートまで遡って検索する。
+        /// <para>
+        /// 直近の前月シートが存在し、かつそのシートが有効なページ番号情報を持つ場合は
+        /// その最終ページ番号+1 を返す。それ以外（前月シートなし、もしくはあっても L2 が
+        /// 空/非整数）の場合は <see cref="IcCard.StartingPageNumber"/> を使用する。
+        /// </para>
+        /// <para>
+        /// 「直近の前月シートを探す」処理は <see cref="FindNearestPreviousMonthLastPage"/> に
+        /// 委譲しており、L2 が空/非整数のシートはスキップしてさらに過去のシートを探索する
+        /// 振る舞いはそちらに集約されている。
+        /// </para>
         /// </remarks>
         internal static int GetStartingPageNumberForMonth(XLWorkbook workbook, IcCard card, int month)
         {
@@ -764,7 +778,38 @@ namespace ICCardManager.Services
             if (currentIndex <= 0)
                 return card.StartingPageNumber;
 
-            // 直前の月から逆順に、存在するシートを探す
+            var nearestPreviousLastPage = FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex);
+            return nearestPreviousLastPage > 0
+                ? nearestPreviousLastPage + 1
+                : card.StartingPageNumber;
+        }
+
+        /// <summary>
+        /// 直近で「有効なページ情報を持つ前月シート」を逆順検索し、その最終ページ番号を返す。
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// 年度内の月順序（4月→5月→…→3月）を基準に、現在月の1つ前から先頭（4月）に向かって
+        /// シートを探索する。シートが存在しても <see cref="GetLastPageNumberFromWorksheet"/> が
+        /// 0 を返す場合（L2 が空または非整数の異常状態）はそのシートをスキップしてさらに過去の
+        /// シートを探索する。
+        /// </para>
+        /// <para>
+        /// この「L2 空シートのスキップ」は本メソッドの中核的な責務であり、メソッド名と本コメントで
+        /// 明示している。Issue #1197: 以前は <see cref="GetStartingPageNumberForMonth"/> 内に
+        /// 直接ループが書かれており、L2 空シートをスキップする動作が暗黙の前提として埋もれていた。
+        /// </para>
+        /// </remarks>
+        /// <param name="workbook">対象ワークブック</param>
+        /// <param name="fiscalMonthOrder">年度内の月順序配列（4月始まり3月終わり）</param>
+        /// <param name="currentIndex">現在月の <paramref name="fiscalMonthOrder"/> 内インデックス</param>
+        /// <returns>
+        /// 直近の有効な前月シートの最終ページ番号。
+        /// どの前月シートも存在しないか、すべて L2 が空/非整数の場合は 0。
+        /// </returns>
+        internal static int FindNearestPreviousMonthLastPage(
+            XLWorkbook workbook, int[] fiscalMonthOrder, int currentIndex)
+        {
             for (int i = currentIndex - 1; i >= 0; i--)
             {
                 var prevMonthName = $"{fiscalMonthOrder[i]}月";
@@ -772,12 +817,10 @@ namespace ICCardManager.Services
                 {
                     var lastPage = GetLastPageNumberFromWorksheet(prevSheet);
                     if (lastPage > 0)
-                        return lastPage + 1;
+                        return lastPage;
                 }
             }
-
-            // どの月のシートも存在しない → StartingPageNumber を使用
-            return card.StartingPageNumber;
+            return 0;
         }
 
         /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServicePageNumberTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServicePageNumberTests.cs
@@ -298,4 +298,74 @@ public class ReportServicePageNumberTests
     }
 
     #endregion
+
+    #region FindNearestPreviousMonthLastPage（Issue #1197）
+
+    /// <summary>
+    /// Issue #1197: 抽出されたヘルパーメソッドに対する直接単体テスト。
+    /// 4月始まり3月終わりの月順序配列を渡し、直近の有効前月シートが見つかれば
+    /// その最終ページ番号を返すこと。
+    /// </summary>
+    [Fact]
+    public void FindNearestPreviousMonthLastPage_PreviousSheetExists_ReturnsLastPage()
+    {
+        using var workbook = new XLWorkbook();
+        CreateSheetWithPageInfo(workbook, "4月", firstPageNumber: 5, pageBreakCount: 2);
+        var fiscalMonthOrder = new[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3 };
+        // 5月（インデックス1）から直前を探す
+        var result = ReportService.FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex: 1);
+
+        // 4月の最終ページ = 5+2 = 7
+        result.Should().Be(7);
+    }
+
+    /// <summary>
+    /// Issue #1197: ヘルパーは L2 空のシートをスキップしてさらに過去を探索する
+    /// （これが本ヘルパーの中核責務）。
+    /// </summary>
+    [Fact]
+    public void FindNearestPreviousMonthLastPage_SkipsEmptyL2AndFindsOlder()
+    {
+        using var workbook = new XLWorkbook();
+        // 4月: 有効
+        CreateSheetWithPageInfo(workbook, "4月", firstPageNumber: 10);
+        // 5月: シートはあるが L2 空 → スキップ対象
+        workbook.AddWorksheet("5月");
+        var fiscalMonthOrder = new[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3 };
+        // 6月（インデックス2）から探索 → 5月スキップ → 4月に到達
+        var result = ReportService.FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex: 2);
+
+        result.Should().Be(10);
+    }
+
+    /// <summary>
+    /// Issue #1197: どの前月シートも存在しない場合は 0 を返す
+    /// </summary>
+    [Fact]
+    public void FindNearestPreviousMonthLastPage_NoPreviousSheets_ReturnsZero()
+    {
+        using var workbook = new XLWorkbook();
+        var fiscalMonthOrder = new[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3 };
+        var result = ReportService.FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex: 5);
+
+        result.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Issue #1197: 前月シートはあるが全て L2 空の場合は 0 を返す
+    /// （フォールバック判定の境界）
+    /// </summary>
+    [Fact]
+    public void FindNearestPreviousMonthLastPage_AllPreviousSheetsHaveEmptyL2_ReturnsZero()
+    {
+        using var workbook = new XLWorkbook();
+        workbook.AddWorksheet("4月");
+        workbook.AddWorksheet("5月");
+        var fiscalMonthOrder = new[] { 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3 };
+        var result = ReportService.FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex: 2);
+
+        result.Should().Be(0);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Fixes #1197

`GetStartingPageNumberForMonth` の前月逆順探索ループには、L2 セルが空または非整数のシートを自動的にスキップしてさらに過去を探索する暗黙の振る舞いがあった。`GetLastPageNumberFromWorksheet` が 0 を返すケースに依存する設計だが、XML コメントには記載されておらず、将来戻り値仕様を変える人が破壊するリスクがあった。

本 PR では Issue #1197 の **案A（XML コメント明示）** と **案B（メソッド抽出）** を **両方適用** し、ドキュメントとコード両面から契約を明示する。

## 変更内容
### 1. ループを `FindNearestPreviousMonthLastPage` に抽出（案B）
```csharp
internal static int FindNearestPreviousMonthLastPage(
    XLWorkbook workbook, int[] fiscalMonthOrder, int currentIndex)
{
    for (int i = currentIndex - 1; i >= 0; i--)
    {
        var prevMonthName = $"{fiscalMonthOrder[i]}月";
        if (workbook.Worksheets.TryGetWorksheet(prevMonthName, out var prevSheet))
        {
            var lastPage = GetLastPageNumberFromWorksheet(prevSheet);
            if (lastPage > 0)
                return lastPage;
        }
    }
    return 0;
}
```
メソッド名で「**直近の有効な前月シートを探す**」という意図を表現する。

### 2. XML コメントで契約を明示（案A）
- `FindNearestPreviousMonthLastPage`: 「L2 空シートのスキップ」を中核責務として明記
- `GetLastPageNumberFromWorksheet`: 戻り値 0 が「ページ情報を持たない無効シート」のセンチネル値である契約を明示
- `GetStartingPageNumberForMonth`: ヘルパー委譲の構造を `<remarks>` で記述

### 3. `GetStartingPageNumberForMonth` の簡素化
ループを抽出した結果、本体はヘルパー呼び出しと三項演算子のみの薄い実装に:
```csharp
var nearestPreviousLastPage = FindNearestPreviousMonthLastPage(workbook, fiscalMonthOrder, currentIndex);
return nearestPreviousLastPage > 0
    ? nearestPreviousLastPage + 1
    : card.StartingPageNumber;
```

## テスト追加（4ケース）
新規ヘルパー `FindNearestPreviousMonthLastPage` に対する直接単体テスト:
| テスト | 検証内容 |
|---|---|
| `PreviousSheetExists_ReturnsLastPage` | 通常ケース（4月L2=5+改ページ2 → 7） |
| `SkipsEmptyL2AndFindsOlder` | **本ヘルパーの中核責務**: 5月L2空 → 4月まで遡る |
| `NoPreviousSheets_ReturnsZero` | フォールバック（前月シートなし）|
| `AllPreviousSheetsHaveEmptyL2_ReturnsZero` | フォールバック（全L2空）|

## 既存テストの役割
PR #1191 で追加した `ReportServicePageNumberTests` の **既存16ケース** が、`GetStartingPageNumberForMonth` 経由でリファクタの回帰検出器として機能する。これらは抽出前後で完全にパスし、振る舞い変更ゼロを担保している。

## 設計書/マニュアル更新
**不要**: 内部リファクタのみで挙動変化なし。クラス設計書・テスト設計書ともに該当メソッドの内部ロジックレベルの記述はない。

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ReportServicePageNumberTests"` → 20/20 passed（既存16 + 新規4）
- [x] `dotnet test`（フル実行） → 2458/2458 passed（回帰なし）
- [x] CI でフル回帰テスト

## 手動テストの要否
**不要**: 純粋なリファクタ（メソッド抽出 + コメント追加）で、振る舞い変化なし。月次帳票生成のページ番号連続性は既存テスト（PR #1191 + 統合テスト）で完全に担保される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)