### PR TITLE
refactor: IntToVisibilityConverter の重複クラスを統合

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1872,22 +1872,17 @@ Model層に追加されたドメインロジック（自身のプロパティの
 
 #### UT-053: Views/Converters の値コンバーター
 
-`Common/Converters.cs` の同名クラスとは振る舞いが異なる点に注意：
-- `Common.IntToVisibilityConverter`: `intValue > 0` でVisible
-- `Views.Converters.IntToVisibilityConverter`: `intValue != 0` でVisible（負も含む）
+※ `IntToVisibilityConverter` は Issue #1227 で `Common/Converters.cs` に統合済み。テストは `Common/ConvertersTests.cs` の `IntToVisibilityConverterTests` を参照。
 
 | No | テストケース | 入力 | 期待結果 |
 |----|-------------|------|---------|
-| 1-5 | 整数→Visibility | 1/100/-1/-100/0 | 非ゼロはVisible、ゼロはCollapsed |
-| 6 | null入力 | null | Collapsed |
-| 7 | 整数以外 | "hello" | Collapsed |
-| 8-9 | InverseBoolConverter | true/false | 反転 |
-| 10-11 | InverseBoolConverter ConvertBack | true/false | 反転 |
-| 12 | 非bool型 | "not a bool" | false |
-| 13 | null | null | false |
-| 14-17 | NotNullToBoolConverter | object/string/空文字/null | nullのみfalse |
+| 1-2 | InverseBoolConverter | true/false | 反転 |
+| 3-4 | InverseBoolConverter ConvertBack | true/false | 反転 |
+| 5 | 非bool型 | "not a bool" | false |
+| 6 | null | null | false |
+| 7-10 | NotNullToBoolConverter | object/string/空文字/null | nullのみfalse |
 
-**テストクラス:** `ViewsIntToVisibilityConverterTests` / `InverseBoolConverterTests` / `NotNullToBoolConverterTests`
+**テストクラス:** `InverseBoolConverterTests` / `NotNullToBoolConverterTests`
 
 ---
 

--- a/ICCardManager/src/ICCardManager/Views/Converters/VisibilityConverters.cs
+++ b/ICCardManager/src/ICCardManager/Views/Converters/VisibilityConverters.cs
@@ -1,33 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Globalization;
-using System.Windows;
 using System.Windows.Data;
 
 namespace ICCardManager.Views.Converters
 {
-/// <summary>
-    /// 整数値をVisibilityに変換（0以外でVisible）
-    /// </summary>
-    public class IntToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value is int intValue)
-            {
-                return intValue != 0 ? Visibility.Visible : Visibility.Collapsed;
-            }
-            return Visibility.Collapsed;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     /// <summary>
     /// 逆Bool変換
     /// </summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Views/Converters/VisibilityConvertersTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Views/Converters/VisibilityConvertersTests.cs
@@ -9,43 +9,9 @@ namespace ICCardManager.Tests.Views.Converters;
 /// <summary>
 /// Views/Converters/VisibilityConverters.cs に定義された WPF 値コンバーターの単体テスト
 ///
-/// 注: Common/Converters.cs にも同名のクラスが存在するが振る舞いが異なる：
-///  - Common.IntToVisibilityConverter: intValue > 0 のときVisible（正の値のみ）
-///  - Views.Converters.IntToVisibilityConverter: intValue != 0 のときVisible（負も含む非ゼロ）
+/// 注: IntToVisibilityConverter は Issue #1227 で Common/Converters.cs に統合済み。
+/// テストは Common/ConvertersTests.cs の IntToVisibilityConverterTests を参照。
 /// </summary>
-public class ViewsIntToVisibilityConverterTests
-{
-    private readonly IntToVisibilityConverter _converter = new();
-
-    [Theory]
-    [InlineData(1, "Visible")]
-    [InlineData(100, "Visible")]
-    [InlineData(-1, "Visible")]   // Common版とは異なり、負の値もVisible
-    [InlineData(-100, "Visible")]
-    [InlineData(0, "Collapsed")]
-    public void Convert_整数値に対して非ゼロならVisible_ゼロならCollapsedを返すこと(int input, string expected)
-    {
-        var result = _converter.Convert(input, typeof(Visibility), null, CultureInfo.InvariantCulture);
-
-        var expectedVisibility = expected == "Visible" ? Visibility.Visible : Visibility.Collapsed;
-        result.Should().Be(expectedVisibility);
-    }
-
-    [Fact]
-    public void Convert_nullの場合はCollapsedを返すこと()
-    {
-        var result = _converter.Convert(null, typeof(Visibility), null, CultureInfo.InvariantCulture);
-        result.Should().Be(Visibility.Collapsed);
-    }
-
-    [Fact]
-    public void Convert_整数以外の型はCollapsedを返すこと()
-    {
-        var result = _converter.Convert("hello", typeof(Visibility), null, CultureInfo.InvariantCulture);
-        result.Should().Be(Visibility.Collapsed);
-    }
-}
-
 public class InverseBoolConverterTests
 {
     private readonly InverseBoolConverter _converter = new();


### PR DESCRIPTION
## Summary

Closes #1227

- `Views.Converters.IntToVisibilityConverter`（`!= 0`判定）を削除し、`Common.IntToVisibilityConverter`（`> 0`判定）に統合
- 両XAMLとも既に`Common`版を参照していたため、XAML変更は不要
- テスト設計書（UT-053）を更新し、削除したテストクラスへの参照を整理

## 変更内容

| ファイル | 変更 |
|---------|------|
| `Views/Converters/VisibilityConverters.cs` | `IntToVisibilityConverter`クラスを削除、不要なusingを整理 |
| `Tests/Views/Converters/VisibilityConvertersTests.cs` | `ViewsIntToVisibilityConverterTests`クラスを削除、コメントを更新 |
| `docs/design/07_テスト設計書.md` | UT-053セクションからIntToVisibilityConverter関連を削除し、統合先への参照を追記 |

## 判断根拠

- `MainWindow.xaml`: `xmlns:conv="clr-namespace:ICCardManager.Common"` → **Common版を使用**
- `DataExportImportDialog.xaml`: `xmlns:common="clr-namespace:ICCardManager.Common"` → **Common版を使用**
- Views.Converters版はどのXAMLからも参照されておらず、デッドコードだった
- 両方の利用箇所（`WarningMessages.Count`、`ImportErrors.Count`）はコレクションの`Count`プロパティで常に0以上のため、`> 0`判定で正しい

## Test plan

- [x] ビルド成功（0エラー）
- [x] 全2510テスト合格
- [ ] MainWindow: 警告メッセージがある場合にバッジが表示されること
- [ ] DataExportImportDialog: インポートエラーがある場合にエラー一覧が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)