### PR TITLE
fix: CsvImportServiceのXMLドキュメントコメント警告を修正

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/CsvImportService.cs
@@ -192,14 +192,12 @@ namespace ICCardManager.Services
             _cacheService = cacheService;
         }
 
-        /// <summary>
-        /// カードCSVをインポート
-        /// </summary>
-        /// <param name="filePath">CSVファイルパス</param>
-        /// <param name="skipExisting">既存データをスキップするか（falseの場合は更新）</param>
-
         // === 共通ユーティリティ ===
 
+        /// <summary>
+        /// CSVファイルを読み込み、行のリストとして返す
+        /// </summary>
+        /// <param name="filePath">CSVファイルパス</param>
         internal static async Task<List<string>> ReadCsvFileAsync(string filePath)
         {
             // UTF-8 with BOMに対応
@@ -454,13 +452,9 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
-        /// カードデータの変更点を検出
+        /// CSV行をパースし、フィールドのリストとして返す（ダブルクォート対応）
         /// </summary>
-        /// <param name="existingCard">既存のカード</param>
-        /// <param name="newCardType">新しいカード種別</param>
-        /// <param name="newCardNumber">新しい管理番号</param>
-        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
-
+        /// <param name="line">CSV行文字列</param>
         private static List<string> ParseCsvLine(string line)
         {
             var fields = new List<string>();

--- a/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Card.cs
+++ b/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Card.cs
@@ -364,11 +364,12 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
-        /// 職員CSVのインポートプレビューを取得
+        /// カードデータの変更点を検出
         /// </summary>
-        /// <param name="filePath">CSVファイルパス</param>
-        /// <param name="skipExisting">既存データをスキップするか（falseの場合は更新）</param>
-
+        /// <param name="existingCard">既存のカード</param>
+        /// <param name="newCardType">新しいカード種別</param>
+        /// <param name="newCardNumber">新しい管理番号</param>
+        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
         private static void DetectCardChanges(
             IcCard existingCard,
             string newCardType,
@@ -395,13 +396,5 @@ namespace ICCardManager.Services
                 });
             }
         }
-
-        /// <summary>
-        /// 職員データの変更点を検出
-        /// </summary>
-        /// <param name="existingStaff">既存の職員</param>
-        /// <param name="newName">新しい氏名</param>
-        /// <param name="newNumber">新しい職員番号</param>
-        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
     }
 }

--- a/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Detail.cs
+++ b/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Detail.cs
@@ -1036,15 +1036,5 @@ namespace ICCardManager.Services
 
             return string.Join(" ", parts);
         }
-
-        /// <summary>
-        /// 残高整合性チェック（プレビュー用）
-        /// カードごとに日時順で残高の連続性を検証します。
-        /// 計算式: 前の残高 + 受入金額 - 払出金額 = 今回の残高
-        /// Issue #907: 最初の行もDB上の直前残高と照合します。
-        /// </summary>
-        /// <param name="records">検証対象レコード（LineNumber, LedgerId, CardIdm, Date, Summary, Income, Expense, Balance, StaffName, Note）</param>
-        /// <param name="errors">エラーリスト</param>
-        /// <param name="previousBalanceByCard">カードIDmごとのDB上の直前残高（存在しない場合はキーなし）</param>
     }
 }

--- a/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Ledger.cs
+++ b/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Ledger.cs
@@ -774,14 +774,17 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
-        /// 利用履歴詳細CSVのインポートプレビューを取得
+        /// 出納記録の変更点を検出
         /// </summary>
-        /// <remarks>
-        /// Issue #751対応: ledger_detailのCSVインポート。
-        /// ledger_idごとにグループ化し、全置換（ReplaceDetailsAsync）で復元する。
-        /// </remarks>
-        /// <param name="filePath">CSVファイルパス</param>
-
+        /// <param name="existingLedger">既存の出納記録</param>
+        /// <param name="newDate">新しい日付</param>
+        /// <param name="newSummary">新しい摘要</param>
+        /// <param name="newIncome">新しい受入金額</param>
+        /// <param name="newExpense">新しい払出金額</param>
+        /// <param name="newBalance">新しい残額</param>
+        /// <param name="newStaffName">新しい利用者名</param>
+        /// <param name="newNote">新しい備考</param>
+        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
         private static void DetectLedgerChanges(
             Ledger existingLedger,
             DateTime newDate,

--- a/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Staff.cs
+++ b/ICCardManager/src/ICCardManager/Services/Import/CsvImportService.Staff.cs
@@ -360,19 +360,12 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
-        /// 履歴CSVをインポート
+        /// 職員データの変更点を検出
         /// </summary>
-        /// <param name="filePath">CSVファイルパス</param>
-        /// <param name="skipExisting">既存データをスキップするか（falseの場合は更新）</param>
-        /// <param name="targetCardIdm">CSV内のIDmが空の場合に使用するカードIDm（オプション）</param>
-        /// <remarks>
-        /// 新フォーマット: ID,日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
-        /// 旧フォーマット: 日時,カードIDm,管理番号,摘要,受入金額,払出金額,残額,利用者,備考
-        /// 注意: LedgerDetailはインポートされません（エクスポート時に含まれないため）
-        /// 注意: 管理番号は参照用で、実際のデータ識別はカードIDmで行います
-        /// Issue #511: CSVのIDm列が空の場合、targetCardIdmが指定されていればそのIDmを使用
-        /// </remarks>
-
+        /// <param name="existingStaff">既存の職員</param>
+        /// <param name="newName">新しい氏名</param>
+        /// <param name="newNumber">新しい職員番号</param>
+        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
         private static void DetectStaffChanges(
             Staff existingStaff,
             string newName,
@@ -399,18 +392,5 @@ namespace ICCardManager.Services
                 });
             }
         }
-
-        /// <summary>
-        /// 履歴データの変更点を検出
-        /// </summary>
-        /// <param name="existingLedger">既存の履歴</param>
-        /// <param name="newDate">新しい日付</param>
-        /// <param name="newSummary">新しい摘要</param>
-        /// <param name="newIncome">新しい受入金額</param>
-        /// <param name="newExpense">新しい払出金額</param>
-        /// <param name="newBalance">新しい残高</param>
-        /// <param name="newStaffName">新しい利用者名</param>
-        /// <param name="newNote">新しい備考</param>
-        /// <param name="changes">変更点リスト（検出結果が追加される）</param>
     }
 }


### PR DESCRIPTION
## Summary
- `dotnet build -c Release` 時に発生していたCS1572/CS1573/CS1587警告（計30件超）をすべて解消
- #1223 の partial class 分割時に、XMLドキュメントコメントが元のメソッドから分離して浮遊状態になっていたのが原因
- 各メソッドに正しい `<param>` タグを付与し、孤立コメントを削除

### 修正ファイル（5ファイル）
| ファイル | 修正内容 |
|----------|----------|
| `CsvImportService.cs` | `ReadCsvFileAsync`・`ParseCsvLine` に正しいドキュメントコメントを付与 |
| `CsvImportService.Card.cs` | `DetectCardChanges` のparamタグ修正、末尾の孤立コメント削除 |
| `CsvImportService.Ledger.cs` | `DetectLedgerChanges` のparamタグ修正 |
| `CsvImportService.Staff.cs` | `DetectStaffChanges` のparamタグ修正、末尾の孤立コメント削除 |
| `CsvImportService.Detail.cs` | 末尾の孤立コメント削除 |

## Test plan
- [x] `dotnet build -c Release` で **0個の警告** を確認済み
- [x] 全2510テスト合格を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)