### PR TITLE
chore: .claude/agents/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ __pycache__/
 
 # Claude Code（個人設定）
 .claude/settings.local.json
+.claude/agents/
 
 # 一時ファイル
 タイトルなし.txt


### PR DESCRIPTION
## Summary
- `.claude/agents/` ディレクトリを `.gitignore` に追加
- 個人のClaude Codeカスタムエージェント設定がリポジトリに混入するのを防止（`.claude/settings.local.json` と同様の扱い）

## Test plan
- [ ] `.claude/agents/` 配下のファイルが `git status` に表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)