### PR TITLE
feat: インストーラーが既存設定をデフォルト表示＆帳票出力先ページ追加

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -146,6 +146,34 @@ var
   DatabaseUseSharedFolder: Boolean;
   DatabaseSharedPath: string;
 
+// 帳票出力先選択ページ
+var
+  ReportOutputPage: TWizardPage;
+  ReportOutputPathEdit: TNewEdit;
+  ReportOutputPathLabel: TNewStaticText;
+  ReportOutputNoteLabel: TNewStaticText;
+  ReportOutputBrowseButton: TNewButton;
+
+// 既存の設定ファイルを読み込む（アップグレード時のデフォルト値として使用）
+// LoadStringsFromFile（TArrayOfString版）は内部でTStringList.LoadFromFileを使い、
+// UTF-8 BOM を自動検出してUnicodeにデコードする。BOMなしはANSI（Shift_JIS）として読む。
+function ReadConfigFile(FileName: string): string;
+var
+  ConfigPath: string;
+  Lines: TArrayOfString;
+begin
+  Result := '';
+  ConfigPath := ExpandConstant('{commonappdata}\ICCardManager\') + FileName;
+  if FileExists(ConfigPath) then
+  begin
+    if LoadStringsFromFile(ConfigPath, Lines) then
+    begin
+      if GetArrayLength(Lines) > 0 then
+        Result := Trim(Lines[0]);
+    end;
+  end;
+end;
+
 // パス入力時に自動的に「共有フォルダ」ラジオボタンを選択
 procedure DatabasePathEditChange(Sender: TObject);
 begin
@@ -171,10 +199,28 @@ begin
   end;
 end;
 
+// 帳票出力先の「参照」ボタンクリック
+procedure ReportOutputBrowseButtonClick(Sender: TObject);
+var
+  Dir: string;
+begin
+  Dir := ReportOutputPathEdit.Text;
+  if BrowseForFolder('帳票出力先フォルダを選択してください。', Dir, False) then
+  begin
+    ReportOutputPathEdit.Text := Dir;
+  end;
+end;
+
 // インストールウィザードにページを追加
 procedure InitializeWizard();
+var
+  ExistingDepartment: string;
+  ExistingDbPath: string;
+  ExistingReportOutput: string;
 begin
+  // =============================================
   // 部署選択ページ（Issue #742）
+  // =============================================
   DepartmentPage := CreateInputOptionPage(wpSelectTasks,
     '部署の選択',
     '使用する部署及び支出科目を選択してください。',
@@ -186,7 +232,14 @@ begin
   DepartmentPage.Add('企業会計部局（水道局、交通局等）：旅費 - 乗車券購入費');
   DepartmentPage.SelectedValueIndex := 0;
 
+  // 既存の部署設定を読み込んでデフォルト値として表示（アップグレード時）
+  ExistingDepartment := ReadConfigFile('department_config.txt');
+  if ExistingDepartment = 'enterprise_account' then
+    DepartmentPage.SelectedValueIndex := 1;
+
+  // =============================================
   // DB保存先選択ページ（部署選択の次に表示）
+  // =============================================
   DatabasePage := CreateCustomPage(DepartmentPage.ID,
     'データベースの保存先',
     '複数のPCから同時に利用する場合は、共有フォルダを指定してください。' + #13#10 +
@@ -238,6 +291,59 @@ begin
   DatabaseNoteLabel.Top := DatabasePathEdit.Top + DatabasePathEdit.Height + 4;
   DatabaseNoteLabel.Left := 20;
   DatabaseNoteLabel.Font.Color := clGray;
+
+  // 既存のDB設定を読み込んでデフォルト値として表示（アップグレード時）
+  ExistingDbPath := ReadConfigFile('database_config.txt');
+  if ExistingDbPath <> '' then
+  begin
+    DatabasePathEdit.Text := ExtractFileDir(ExistingDbPath);
+    DatabaseSharedRadio.Checked := True;
+    DatabaseLocalRadio.Checked := False;
+  end;
+
+  // =============================================
+  // 帳票出力先選択ページ（DB保存先の次に表示）
+  // =============================================
+  ReportOutputPage := CreateCustomPage(DatabasePage.ID,
+    '帳票出力先フォルダ',
+    '帳票（Excel）の出力先フォルダを指定してください。' + #13#10 +
+    'この設定は後から帳票作成画面で変更できます。');
+
+  ReportOutputPathLabel := TNewStaticText.Create(ReportOutputPage);
+  ReportOutputPathLabel.Parent := ReportOutputPage.Surface;
+  ReportOutputPathLabel.Caption := '出力先フォルダ:';
+  ReportOutputPathLabel.Top := 0;
+  ReportOutputPathLabel.Left := 0;
+
+  ReportOutputPathEdit := TNewEdit.Create(ReportOutputPage);
+  ReportOutputPathEdit.Parent := ReportOutputPage.Surface;
+  ReportOutputPathEdit.Top := ReportOutputPathLabel.Top + ReportOutputPathLabel.Height + 4;
+  ReportOutputPathEdit.Left := 0;
+  ReportOutputPathEdit.Width := ReportOutputPage.SurfaceWidth - 100;
+
+  ReportOutputBrowseButton := TNewButton.Create(ReportOutputPage);
+  ReportOutputBrowseButton.Parent := ReportOutputPage.Surface;
+  ReportOutputBrowseButton.Caption := '参照...';
+  ReportOutputBrowseButton.Top := ReportOutputPathEdit.Top - 1;
+  ReportOutputBrowseButton.Left := ReportOutputPathEdit.Left + ReportOutputPathEdit.Width + 8;
+  ReportOutputBrowseButton.Width := 70;
+  ReportOutputBrowseButton.Height := ReportOutputPathEdit.Height + 2;
+  ReportOutputBrowseButton.OnClick := @ReportOutputBrowseButtonClick;
+
+  ReportOutputNoteLabel := TNewStaticText.Create(ReportOutputPage);
+  ReportOutputNoteLabel.Parent := ReportOutputPage.Surface;
+  ReportOutputNoteLabel.Caption := '例: C:\Users\username\Documents';
+  ReportOutputNoteLabel.Top := ReportOutputPathEdit.Top + ReportOutputPathEdit.Height + 4;
+  ReportOutputNoteLabel.Left := 0;
+  ReportOutputNoteLabel.Font.Color := clGray;
+
+  // 既存の帳票出力先設定を読み込んでデフォルト値として表示（アップグレード時）
+  // 設定がなければマイドキュメントをデフォルトにする
+  ExistingReportOutput := ReadConfigFile('report_output_config.txt');
+  if ExistingReportOutput <> '' then
+    ReportOutputPathEdit.Text := ExistingReportOutput
+  else
+    ReportOutputPathEdit.Text := ExpandConstant('{userdocs}');
 end;
 
 // 部署選択結果を設定ファイルに書き出す（Issue #742）
@@ -293,6 +399,27 @@ begin
   ConfigFile := ConfigDir + '\database_config.txt';
 
   SaveStringToFile(ConfigFile, FullDbPath, False);
+end;
+
+// 帳票出力先選択結果を設定ファイルに書き出す
+procedure WriteReportOutputConfig();
+var
+  ConfigDir: string;
+  ConfigFile: string;
+  OutputPath: string;
+begin
+  if ReportOutputPathEdit = nil then
+    Exit;
+
+  OutputPath := Trim(ReportOutputPathEdit.Text);
+  if OutputPath = '' then
+    Exit;
+
+  ConfigDir := ExpandConstant('{commonappdata}\ICCardManager');
+  ForceDirectories(ConfigDir);
+  ConfigFile := ConfigDir + '\report_output_config.txt';
+
+  SaveStringToFile(ConfigFile, OutputPath, False);
 end;
 
 // DB保存先ページのバリデーション（「次へ」ボタン押下時に呼ばれる）
@@ -397,6 +524,7 @@ begin
       end;
     end;
     WriteDatabaseConfig();
+    WriteReportOutputConfig();
   end;
 end;
 

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -389,8 +389,9 @@ namespace ICCardManager
             Task.Run(() => RegisterTestDataAsync()).GetAwaiter().GetResult();
     #endif
 
-            // インストーラーからの部署設定を適用（Issue #742）
-            ApplyDepartmentConfigFromInstaller();
+            // 設定ファイルからの設定を適用（Issue #742）
+            ApplyDepartmentConfigFromFile();
+            ApplyReportOutputConfigFromFile();
 
             // 保存済み設定を適用
             ApplySavedSettings();
@@ -400,33 +401,20 @@ namespace ICCardManager
         }
 
         /// <summary>
-        /// インストーラーが書き出した部署設定ファイルを読み取り、DBに適用する（Issue #742）
+        /// 部署設定ファイルを読み取り、DBに適用する（Issue #742）
         /// </summary>
         /// <remarks>
-        /// インストーラーは %PROGRAMDATA%\ICCardManager\department_config.txt に
-        /// 選択された部署種別（"mayor_office" or "enterprise_account"）を書き出す。
-        /// アプリ初回起動時にこのファイルを読み取り、DB設定を上書きしてからファイルを削除する。
+        /// インストーラーまたはアプリの設定画面が %PROGRAMDATA%\ICCardManager\department_config.txt に
+        /// 部署種別（"mayor_office" or "enterprise_account"）を書き出す。
+        /// 起動時にこのファイルを読み取り、DB設定に適用する。
+        /// ファイルは削除せず永続的に保持する（インストーラーがアップグレード時にデフォルト値として使用）。
         /// ファイルが存在しない場合（手動インストール等）はschema.sqlのデフォルト値が使用される。
         /// </remarks>
-        private void ApplyDepartmentConfigFromInstaller()
+        private void ApplyDepartmentConfigFromFile()
         {
             try
             {
-                var configPath = System.IO.Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                    "ICCardManager", "department_config.txt");
-
-                if (!System.IO.File.Exists(configPath))
-                {
-                    return; // 設定ファイルなし（アップグレードまたは手動インストール）
-                }
-
-                var departmentValue = System.IO.File.ReadAllText(configPath).Trim();
-
-                // ファイルを削除（次回起動時に再適用しない）
-                // インストーラー（管理者権限）が作成したファイルのため、
-                // 一般ユーザーでは削除できない場合がある（Issue #1080）
-                DeleteOrClearFile(configPath, _logger);
+                var departmentValue = ViewModels.SettingsViewModel.LoadDepartmentConfigFromFile();
 
                 if (string.IsNullOrEmpty(departmentValue))
                 {
@@ -444,12 +432,50 @@ namespace ICCardManager
                 cacheService.Invalidate(CacheKeys.AppSettings);
 
                 var departmentType = SettingsRepository.ParseDepartmentType(departmentValue);
-                _logger?.LogInformation("インストーラー設定: 部署種別を適用 DepartmentType={DepartmentType}", departmentType);
+                _logger?.LogInformation("設定ファイル: 部署種別を適用 DepartmentType={DepartmentType}", departmentType);
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "インストーラーからの部署設定の適用でエラー");
+                _logger?.LogWarning(ex, "部署設定ファイルの適用でエラー");
                 // エラーが発生してもアプリは起動させる（schema.sqlのデフォルト値が使用される）
+            }
+        }
+
+        /// <summary>
+        /// 帳票出力先設定ファイルを読み取り、DBに適用する
+        /// </summary>
+        /// <remarks>
+        /// インストーラーまたは帳票作成画面が %PROGRAMDATA%\ICCardManager\report_output_config.txt に
+        /// 帳票出力先フォルダパスを書き出す。
+        /// 起動時にこのファイルを読み取り、DB設定に適用する。
+        /// ファイルが存在しない場合は何もしない。
+        /// </remarks>
+        private void ApplyReportOutputConfigFromFile()
+        {
+            try
+            {
+                var outputFolder = ViewModels.SettingsViewModel.LoadReportOutputConfigFromFile();
+
+                if (string.IsNullOrEmpty(outputFolder))
+                {
+                    return;
+                }
+
+                var settingsRepository = ServiceProvider.GetRequiredService<ISettingsRepository>();
+                Task.Run(() => settingsRepository.SetAsync(
+                    SettingsRepository.KeyReportOutputFolder,
+                    outputFolder
+                )).GetAwaiter().GetResult();
+
+                // キャッシュを無効化して再取得を強制
+                var cacheService = ServiceProvider.GetRequiredService<ICacheService>();
+                cacheService.Invalidate(CacheKeys.AppSettings);
+
+                _logger?.LogInformation("設定ファイル: 帳票出力先を適用 OutputFolder={OutputFolder}", outputFolder);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "帳票出力先設定ファイルの適用でエラー");
             }
         }
 

--- a/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/ReportViewModel.cs
@@ -143,6 +143,16 @@ public partial class ReportViewModel : ViewModelBase
         var settings = await _settingsRepository.GetAppSettingsAsync();
         settings.ReportOutputFolder = OutputFolder;
         await _settingsRepository.SaveAppSettingsAsync(settings);
+
+        // 設定ファイルにも保存（インストーラーがアップグレード時に読み込む）
+        try
+        {
+            SettingsViewModel.SaveReportOutputConfigToFile(OutputFolder);
+        }
+        catch
+        {
+            // 非致命的: DBが正なので設定ファイルの書き込み失敗は無視
+        }
     }
 
     /// <summary>

--- a/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/SettingsViewModel.cs
@@ -269,6 +269,17 @@ public partial class SettingsViewModel : ViewModelBase
                 // トースト位置の変更を反映
                 App.ApplyToastPosition(settings.ToastPosition);
 
+                // 部署種別を設定ファイルに保存（インストーラーがアップグレード時に読み込む）
+                try
+                {
+                    SaveDepartmentConfigToFile(
+                        SettingsRepository.DepartmentTypeToString(settings.DepartmentType));
+                }
+                catch
+                {
+                    // 非致命的: DBが正なので設定ファイルの書き込み失敗は無視
+                }
+
                 // DBパスが変更された場合、appsettings.jsonに保存
                 if (IsDatabasePathChanged)
                 {
@@ -371,31 +382,103 @@ public partial class SettingsViewModel : ViewModelBase
         }
     }
 
+    // =========================================================================
+    // 設定ファイル共通ヘルパー
+    // =========================================================================
+    // C:\ProgramData\ICCardManager\ 配下のテキストファイルを読み書きする共通処理。
+    // インストーラー（Inno Setup）はShift_JIS、アプリはUTF-8 BOMで書き込むため、
+    // 読み取り時はBOMで自動判定する。
+
+    /// <summary>
+    /// ProgramData配下の設定ファイルのフルパスを取得
+    /// </summary>
+    private static string GetConfigFilePath(string fileName)
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "ICCardManager", fileName);
+    }
+
+    /// <summary>
+    /// 設定ファイルからテキストを読み込む（BOM自動判定）
+    /// </summary>
+    /// <remarks>
+    /// Inno SetupのSaveStringToFileはShift_JIS（ANSI）で書き込むが、
+    /// アプリのFile.WriteAllTextはUTF-8 BOM付きで書き込む。
+    /// どちらでも正しく読めるよう、BOMで判定する。
+    /// </remarks>
+    private static string LoadConfigFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var bytes = File.ReadAllBytes(filePath);
+            string value;
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            {
+                // UTF-8 BOM
+                value = System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+            }
+            else if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+            {
+                // UTF-16 LE BOM
+                value = System.Text.Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+            }
+            else
+            {
+                // BOMなし: Shift_JIS（Inno Setupが書いた場合）として読む
+                value = System.Text.Encoding.GetEncoding(932).GetString(bytes);
+            }
+            return value.Trim();
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// 設定ファイルにテキストを書き込む（アトミック書き込み）
+    /// </summary>
+    /// <remarks>
+    /// 一時ファイルに書き出してからリネームすることで、書き込み途中のクラッシュによる
+    /// ファイル破損を防止する。
+    /// </remarks>
+    private static void SaveConfigFile(string filePath, string value)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var tempPath = filePath + ".tmp";
+        File.WriteAllText(tempPath, value ?? string.Empty, System.Text.Encoding.UTF8);
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+        File.Move(tempPath, filePath);
+    }
+
+    // =========================================================================
+    // データベース設定ファイル
+    // =========================================================================
+
     /// <summary>
     /// データベースパスを設定ファイルに保存
     /// </summary>
     /// <remarks>
     /// appsettings.jsonはProgram Files内にあり一般ユーザーには書き込めないため、
     /// C:\ProgramData\ICCardManager\database_config.txt に保存する。
-    /// department_config.txt と同じパターン。
     /// </remarks>
     internal static void SaveDatabasePathToConfigFile(string databasePath)
     {
-        var configPath = GetDatabaseConfigPath();
-        var directory = Path.GetDirectoryName(configPath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        // アトミック書き込み: 一時ファイルに書き出してからリネーム（破損防止）
-        var tempPath = configPath + ".tmp";
-        File.WriteAllText(tempPath, databasePath ?? string.Empty, System.Text.Encoding.UTF8);
-        if (File.Exists(configPath))
-        {
-            File.Delete(configPath);
-        }
-        File.Move(tempPath, configPath);
+        SaveConfigFile(GetDatabaseConfigPath(), databasePath);
     }
 
     /// <summary>
@@ -403,9 +486,7 @@ public partial class SettingsViewModel : ViewModelBase
     /// </summary>
     internal static string GetDatabaseConfigPath()
     {
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "ICCardManager", "database_config.txt");
+        return GetConfigFilePath("database_config.txt");
     }
 
     /// <summary>
@@ -413,40 +494,63 @@ public partial class SettingsViewModel : ViewModelBase
     /// </summary>
     internal static string LoadDatabasePathFromConfigFile()
     {
-        var configPath = GetDatabaseConfigPath();
-        if (!File.Exists(configPath))
-        {
-            return string.Empty;
-        }
+        return LoadConfigFile(GetDatabaseConfigPath());
+    }
 
-        try
-        {
-            // Inno SetupのSaveStringToFileはShift_JIS（ANSI）で書き込むが、
-            // 設定画面のFile.WriteAllTextはUTF-8 BOM付きで書き込む。
-            // どちらでも正しく読めるよう、BOMで判定する。
-            var bytes = File.ReadAllBytes(configPath);
-            string path;
-            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
-            {
-                // UTF-8 BOM
-                path = System.Text.Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
-            }
-            else if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
-            {
-                // UTF-16 LE BOM
-                path = System.Text.Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
-            }
-            else
-            {
-                // BOMなし: Shift_JIS（Inno Setupが書いた場合）として読む
-                path = System.Text.Encoding.GetEncoding(932).GetString(bytes);
-            }
-            return path.Trim();
-        }
-        catch
-        {
-            return string.Empty;
-        }
+    // =========================================================================
+    // 部署種別設定ファイル
+    // =========================================================================
+
+    /// <summary>
+    /// 部署種別設定ファイルのパスを取得
+    /// </summary>
+    internal static string GetDepartmentConfigPath()
+    {
+        return GetConfigFilePath("department_config.txt");
+    }
+
+    /// <summary>
+    /// 部署種別設定ファイルから値を読み込み
+    /// </summary>
+    internal static string LoadDepartmentConfigFromFile()
+    {
+        return LoadConfigFile(GetDepartmentConfigPath());
+    }
+
+    /// <summary>
+    /// 部署種別を設定ファイルに保存（インストーラーがアップグレード時に読み込む）
+    /// </summary>
+    internal static void SaveDepartmentConfigToFile(string departmentValue)
+    {
+        SaveConfigFile(GetDepartmentConfigPath(), departmentValue);
+    }
+
+    // =========================================================================
+    // 帳票出力先設定ファイル
+    // =========================================================================
+
+    /// <summary>
+    /// 帳票出力先設定ファイルのパスを取得
+    /// </summary>
+    internal static string GetReportOutputConfigPath()
+    {
+        return GetConfigFilePath("report_output_config.txt");
+    }
+
+    /// <summary>
+    /// 帳票出力先設定ファイルから値を読み込み
+    /// </summary>
+    internal static string LoadReportOutputConfigFromFile()
+    {
+        return LoadConfigFile(GetReportOutputConfigPath());
+    }
+
+    /// <summary>
+    /// 帳票出力先を設定ファイルに保存（インストーラーがアップグレード時に読み込む）
+    /// </summary>
+    internal static void SaveReportOutputConfigToFile(string outputFolder)
+    {
+        SaveConfigFile(GetReportOutputConfigPath(), outputFolder);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- アップグレードインストール時に、既存の設定ファイル（部局種別・DB保存先・帳票出力先）を読み込んでデフォルト値として表示
- `department_config.txt`を永続化し、アプリと双方向同期するよう変更
- `report_output_config.txt`を新規追加し、帳票出力先フォルダをインストール時に設定可能に
- `SettingsViewModel`のconfig file I/Oを共通ヘルパーに抽出してリファクタリング

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `ICCardManager.iss` | `ReadConfigFile()`追加、帳票出力先ページ追加、既存config読み込み |
| `SettingsViewModel.cs` | `LoadConfigFile()`/`SaveConfigFile()`共通化、department/report output用メソッド追加 |
| `App.xaml.cs` | `department_config.txt`削除廃止、`report_output_config.txt`読み込み追加 |
| `ReportViewModel.cs` | 出力先変更時に`report_output_config.txt`も更新 |

## Test plan
- [x] ビルド成功（0エラー）
- [x] 全テスト合格（2510件）
- [x] インストーラーコンパイル成功（InnoSetup 6）
- [x] インストーラーV999.999.999で動作確認済み（文字化け修正含む）
- [x] 新規インストール → 3つの設定ページがデフォルト値で表示される
- [ ] アプリで設定変更 → config fileが更新される
- [x] アップグレードインストール → 各ページに既存設定が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)