### PR TITLE
docs: サードパーティライセンス一覧のバージョン同期とVOICEVOX追記

### DIFF
--- a/ICCardManager/docs/THIRD_PARTY_LICENSES.md
+++ b/ICCardManager/docs/THIRD_PARTY_LICENSES.md
@@ -10,16 +10,16 @@
 
 | ライブラリ名 | バージョン | ライセンス | 用途 |
 |---|---|---|---|
-| [System.Data.SQLite.Core](https://system.data.sqlite.org/) | 1.0.118 | Public Domain | SQLiteデータベースアクセス |
-| [ClosedXML](https://github.com/ClosedXML/ClosedXML) | 0.102.2 | MIT | Excel帳票（物品出納簿）の生成 |
+| [System.Data.SQLite.Core](https://system.data.sqlite.org/) | 1.0.119 | Public Domain | SQLiteデータベースアクセス |
+| [ClosedXML](https://github.com/ClosedXML/ClosedXML) | 0.105.0 | MIT | Excel帳票（物品出納簿）の生成 |
 | [CommunityToolkit.Mvvm](https://github.com/CommunityToolkit/dotnet) | 8.2.2 | MIT | MVVMパターン実装（ObservableProperty、RelayCommand等） |
 | [FelicaLib.DotNet](https://github.com/sakapon/felicalib-remodeled) | 1.2.67 | MIT + BSD-3-Clause | FeliCa（Sony PaSoRi）カード読み取り ※1 |
-| [Microsoft.Extensions.DependencyInjection](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | 依存性注入（DIコンテナ） |
-| [Microsoft.Extensions.Hosting](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | アプリケーションホスティング |
-| [Microsoft.Extensions.Logging](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | ログ記録フレームワーク |
-| [Microsoft.Extensions.Logging.Debug](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | デバッグ出力へのログ記録 |
-| [Microsoft.Extensions.Configuration.Json](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | JSON設定ファイル読み込み |
-| [Microsoft.Extensions.Caching.Memory](https://github.com/dotnet/runtime) | 3.1.32 | Apache-2.0 | インメモリキャッシュ |
+| [Microsoft.Extensions.DependencyInjection](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | 依存性注入（DIコンテナ） |
+| [Microsoft.Extensions.Hosting](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | アプリケーションホスティング |
+| [Microsoft.Extensions.Logging](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | ログ記録フレームワーク |
+| [Microsoft.Extensions.Logging.Debug](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | デバッグ出力へのログ記録 |
+| [Microsoft.Extensions.Configuration.Json](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | JSON設定ファイル読み込み |
+| [Microsoft.Extensions.Caching.Memory](https://github.com/dotnet/runtime) | 8.0.1 | Apache-2.0 | インメモリキャッシュ |
 
 > **※1** FelicaLib.DotNet は、felicalib Remodeled 部分が MIT License（Copyright © Keiho Sakapon）、オリジナルの felicalib 部分が BSD-3-Clause License（Copyright © 2007 Takuya Murakami）のデュアルライセンスです。
 
@@ -44,7 +44,18 @@
 
 アプリケーション本体と共通のライブラリ（System.Data.SQLite.Core、CommunityToolkit.Mvvm、FelicaLib.DotNet、Microsoft.Extensions.*）を使用しています。詳細は「1. アプリケーション本体の依存ライブラリ」を参照してください。
 
-## 4. ライセンス種別の概要
+## 4. 音声素材
+
+| 素材 | キャラクター | ライセンス・利用規約 | 用途 |
+|---|---|---|---|
+| [VOICEVOX](https://voicevox.hiroshiba.jp/) 生成音声 | 四国めたん | [VOICEVOX 四国めたん 利用規約](https://voicevox.hiroshiba.jp/term/) | 貸出・返却時の女性音声 |
+| [VOICEVOX](https://voicevox.hiroshiba.jp/) 生成音声 | 玄野武宏 | [VOICEVOX 玄野武宏 利用規約](https://voicevox.hiroshiba.jp/term/) | 貸出・返却時の男性音声 |
+
+> クレジット表記（VOICEVOX利用規約に基づき必須）: **VOICEVOX:四国めたん / VOICEVOX:玄野武宏**
+>
+> アプリケーション内では設定ダイアログに上記クレジットを表示しています。
+
+## 5. ライセンス種別の概要
 
 本システムで使用しているライセンスはすべて**寛容型（permissive）ライセンス**であり、商用利用・再配布が許可されています。コピーレフト型ライセンス（GPL等）は含まれていません。
 
@@ -56,10 +67,11 @@
 | BSD-3-Clause | 寛容型 | 著作権表示とライセンス文の保持、著作者名の無断使用禁止 |
 | Public Domain | パブリックドメイン | 制約なし |
 
-## 5. 更新履歴
+## 6. 更新履歴
 
 | 日付 | 内容 |
 |---|---|
+| 2026-04-16 | パッケージバージョンを最新に同期、VOICEVOX音声素材のセクションを追加 |
 | 2026-03-23 | 初版作成 |
 
 ---


### PR DESCRIPTION
## Summary
- `THIRD_PARTY_LICENSES.md` のパッケージバージョンをcsproj実態に合わせて更新
  - System.Data.SQLite.Core: 1.0.118 → 1.0.119
  - ClosedXML: 0.102.2 → 0.105.0
  - Microsoft.Extensions.*: 3.1.32 → 8.0.1
- VOICEVOX音声素材（四国めたん / 玄野武宏）のライセンス情報セクションを新設（§4）

## Test plan
- [ ] Markdown のレンダリングが正しいことを確認
- [ ] 記載バージョンが `ICCardManager.csproj` の `PackageReference` と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)