### PR TITLE
fix: 監査ログへの操作者なりすましを防止 (#1265)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 更新履歴
 
+### Unreleased
+
+**セキュリティ修正**
+- 監査ログ（operation_log）への操作者なりすましを防止。`OperationLogger` の operator_idm / operator_name は `ICurrentOperatorContext`（職員証タッチ成功時に `StaffAuthService` が自動設定）からのみ解決される。旧 API（`operatorIdm` 引数付き）は `[Obsolete]` となり、渡された引数は無視される（#1265）
+
 ### v2.7.0 (2026-04-15)
 
 **新機能**

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -250,7 +250,8 @@ graph TB
 | DebugDataService | テストデータの管理（DEBUGビルド専用） |
 | LedgerMergeService | 複数Ledgerレコードの統合・取り消し（Issue #548） |
 | CardLockManager | カードアクセスの排他制御（シングルトン） |
-| IStaffAuthService / StaffAuthService | 職員証による操作者認証 |
+| IStaffAuthService / StaffAuthService | 職員証による操作者認証。成功時に ICurrentOperatorContext を更新（Issue #1265） |
+| ICurrentOperatorContext / CurrentOperatorContext | 認証済み操作者のセッション情報保持（Issue #1265、監査ログなりすまし防止） |
 | IDialogService / DialogService | ダイアログ表示の抽象化（テスタビリティ向上） |
 | ReportDataBuilder | 月次帳票の共通データ準備（Excel/印刷で共有） |
 | LedgerSplitService | 複数明細を含むLedgerレコードの分割（Issue #634） |
@@ -917,6 +918,7 @@ classDiagram
         -IStaffRepository _staffRepository
         -ICardReader _cardReader
         -ISoundPlayer _soundPlayer
+        -ICurrentOperatorContext _operatorContext
         +RequestAuthenticationAsync(operationDescription) Task~StaffAuthResult~
     }
 
@@ -927,7 +929,48 @@ classDiagram
 
     StaffAuthService ..|> IStaffAuthService
     StaffAuthService --> StaffAuthResult
+    StaffAuthService --> ICurrentOperatorContext : BeginSession()
 ```
+
+**Issue #1265**: 認証成功時に `ICurrentOperatorContext.BeginSession(idm, name)` を呼び、後続の `OperationLogger` が操作者を一元的に解決できるようにする。
+
+### 5.17a CurrentOperatorContext
+
+```mermaid
+classDiagram
+    class ICurrentOperatorContext {
+        <<interface>>
+        +string? CurrentIdm
+        +string? CurrentName
+        +bool HasSession
+        +BeginSession(idm, name) void
+        +ClearSession() void
+    }
+
+    class CurrentOperatorContext {
+        -ISystemClock _clock
+        -TimeSpan _sessionDuration
+        -string? _idm
+        -string? _name
+        -DateTime _expiresAt
+        +static TimeSpan DefaultSessionDuration
+    }
+
+    CurrentOperatorContext ..|> ICurrentOperatorContext
+    CurrentOperatorContext --> ISystemClock
+```
+
+**責務**:
+- 認証済み操作者の IDm / 氏名を一元的に保持（Singleton）
+- 指定時間（既定 5 分）で自動失効
+- 監査ログ（`operation_log`）への操作者なりすましを防止
+
+**使用フロー**:
+1. `StaffAuthService.RequestAuthenticationAsync()` が職員証タッチ成功時に `BeginSession()` を呼ぶ
+2. `OperationLogger.LogXxxAsync()` が `CurrentIdm` / `CurrentName` を参照してログを記録
+3. セッションが失効すると `HasSession=false` となり、以降のログは `GuiOperator` へフォールバック
+
+**Issue #1265**: `OperationLogger` の旧 API（`operatorIdm` 引数付き）は `[Obsolete]` になり、渡された引数は無視される。操作者は常にこのコンテキストから解決される。
 
 ### 5.18 DialogService
 
@@ -1117,6 +1160,7 @@ services.AddSingleton<IToastNotificationService, ToastNotificationService>();
 services.AddSingleton<LedgerMergeService>();
 services.AddSingleton<CardLockManager>();
 services.AddSingleton<IStaffAuthService, StaffAuthService>();
+services.AddSingleton<ICurrentOperatorContext, CurrentOperatorContext>();  // Issue #1265
 services.AddSingleton<IDialogService, DialogService>();
 #if DEBUG
 services.AddSingleton<DebugDataService>();

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -2361,6 +2361,38 @@ Model層に追加されたドメインロジック（自身のプロパティの
 
 **テストクラス:** `BackupServiceTests`, `BackupServiceRestoreSafetyTests`
 
+#### UT-AUDIT-001: CurrentOperatorContext (Issue #1265)
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 初期状態 | BeginSession未呼び出し | HasSession=false, CurrentIdm/Name=null |
+| 2 | BeginSessionで設定 | idm="AAAA...", name="田中太郎" | HasSession=true, CurrentIdm/Nameが返る |
+| 3 | 空IDmでBeginSession | null/空文字列 | ArgumentExceptionがスロー |
+| 4 | 空氏名でBeginSession | name=空文字列 | ArgumentExceptionがスロー |
+| 5 | 有効期間内 | 失効前の時刻で問い合わせ | HasSession=true |
+| 6 | 失効後 | 有効期間+1秒経過後 | HasSession=false, CurrentIdm/Name=null |
+| 7 | BeginSession再呼び出し | 既存セッション中に再認証 | 値が更新され、失効時刻が延長される |
+| 8 | ClearSession | 有効なセッション中 | HasSession=false, CurrentIdm/Name=null |
+| 9 | 既定有効期間 | DefaultSessionDuration | 5分 |
+| 10 | ゼロ時間での生成 | sessionDuration=TimeSpan.Zero | ArgumentOutOfRangeException |
+
+**テストクラス:** `CurrentOperatorContextTests`
+
+#### UT-AUDIT-002: OperationLogger なりすまし防止 (Issue #1265)
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | Context未設定で新API呼び出し | operator引数なし | GuiOperator (Idm=000...0, Name="GUI操作") で記録 |
+| 2 | Context設定済みで新API呼び出し | BeginSession後 | Contextの値で記録 |
+| 3 | 旧API+Context未設定+偽IDm | `LogLedgerDeleteAsync("FFFF...", ledger)` | 偽IDmのログは作られず GuiOperator で記録 |
+| 4 | 旧API+Context設定済み+偽IDm | BeginSession(実操作者) → `LogLedgerDeleteAsync("FFFF...", ledger)` | 偽IDmは無視され、Contextの実操作者で記録 |
+| 5 | Context失効後の旧API呼び出し | 失効後 | GuiOperator で記録（偽IDm引数は無視） |
+| 6 | 旧API→新API委譲 | 全Log*Async旧シグネチャ | 新APIと同じ結果 |
+| 7 | JSON日本語・特殊文字保持 | staff.Name="山田 \"太郎\" & 花子" | 日本語部分はエスケープされず記録 |
+| 8 | 各テーブル+各Action | Staff/Card/Ledger × Insert/Update/Delete/Restore/Merge/Split | 13種類のログが正しい TargetTable / Action で記録 |
+
+**テストクラス:** `OperationLoggerTests`
+
 ### 7a.2 結合テスト
 
 #### IT-SHARED-001: 複数接続での貸出・返却

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -265,6 +265,8 @@ namespace ICCardManager
             services.AddSingleton<IStationMasterService, StationMasterService>();
             services.AddSingleton<IDatabaseInfo>(sp => sp.GetRequiredService<DbContext>());
             services.AddSingleton<ICCardManager.Infrastructure.Timing.ISystemClock, ICCardManager.Infrastructure.Timing.SystemClock>();
+            // Issue #1265: 監査ログなりすまし防止のため、操作者コンテキストを一元管理する
+            services.AddSingleton<ICurrentOperatorContext, CurrentOperatorContext>();
             services.AddSingleton<SharedModeMonitor>();
             services.AddSingleton<WarningService>();
             services.AddSingleton<DashboardService>();

--- a/ICCardManager/src/ICCardManager/Services/ICurrentOperatorContext.cs
+++ b/ICCardManager/src/ICCardManager/Services/ICurrentOperatorContext.cs
@@ -1,0 +1,138 @@
+using System;
+using ICCardManager.Infrastructure.Timing;
+
+namespace ICCardManager.Services
+{
+    /// <summary>
+    /// 現在認証されている操作者のセッション情報を保持するコンテキスト。
+    /// Issue #1265: 監査ログ (operation_log) の operator_idm / operator_name を
+    /// 呼び出し元引数からではなく、このコンテキストから一元的に取得することで
+    /// 内部者による監査ログなりすましを防止する。
+    /// </summary>
+    /// <remarks>
+    /// 想定ライフサイクル: Singleton。StaffAuthService が認証成功時に BeginSession を呼び、
+    /// OperationLogger が記録時に CurrentIdm / CurrentName を読む。
+    /// セッションは指定時間経過で自動失効し、次回ログ記録時には GUI 操作として扱われる。
+    /// </remarks>
+    public interface ICurrentOperatorContext
+    {
+        /// <summary>現在のセッションが有効な場合の操作者 IDm。無効な場合は null。</summary>
+        string? CurrentIdm { get; }
+
+        /// <summary>現在のセッションが有効な場合の操作者氏名。無効な場合は null。</summary>
+        string? CurrentName { get; }
+
+        /// <summary>有効なセッションが存在するか（未期限切れ）。</summary>
+        bool HasSession { get; }
+
+        /// <summary>
+        /// 認証セッションを開始する（または延長する）。StaffAuthService のみが呼び出すべき。
+        /// </summary>
+        /// <param name="idm">認証された操作者の IDm（16桁16進）</param>
+        /// <param name="name">認証された操作者の氏名</param>
+        void BeginSession(string idm, string name);
+
+        /// <summary>
+        /// 現在のセッションを明示的に終了する。
+        /// </summary>
+        void ClearSession();
+    }
+
+    /// <summary>
+    /// ICurrentOperatorContext の既定実装。シングルトンとして登録されることを前提とする。
+    /// </summary>
+    public class CurrentOperatorContext : ICurrentOperatorContext
+    {
+        private readonly object _lock = new object();
+        private readonly ISystemClock _clock;
+        private readonly TimeSpan _sessionDuration;
+        private string? _idm;
+        private string? _name;
+        private DateTime _expiresAt;
+
+        /// <summary>
+        /// セッションの既定有効期間（5分）。職員証タッチから実操作完了までの時間を想定。
+        /// </summary>
+        public static readonly TimeSpan DefaultSessionDuration = TimeSpan.FromMinutes(5);
+
+        public CurrentOperatorContext(ISystemClock clock)
+            : this(clock, DefaultSessionDuration)
+        {
+        }
+
+        /// <summary>
+        /// テスト目的でセッション長を差し替えるためのコンストラクタ。
+        /// </summary>
+        public CurrentOperatorContext(ISystemClock clock, TimeSpan sessionDuration)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+            if (sessionDuration <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sessionDuration), "セッション有効期間は正の値である必要があります。");
+            }
+            _sessionDuration = sessionDuration;
+        }
+
+        public bool HasSession
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _idm != null && _clock.Now < _expiresAt;
+                }
+            }
+        }
+
+        public string? CurrentIdm
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return (_idm != null && _clock.Now < _expiresAt) ? _idm : null;
+                }
+            }
+        }
+
+        public string? CurrentName
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return (_idm != null && _clock.Now < _expiresAt) ? _name : null;
+                }
+            }
+        }
+
+        public void BeginSession(string idm, string name)
+        {
+            if (string.IsNullOrEmpty(idm))
+            {
+                throw new ArgumentException("IDm は必須です。", nameof(idm));
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("氏名は必須です。", nameof(name));
+            }
+
+            lock (_lock)
+            {
+                _idm = idm;
+                _name = name;
+                _expiresAt = _clock.Now + _sessionDuration;
+            }
+        }
+
+        public void ClearSession()
+        {
+            lock (_lock)
+            {
+                _idm = null;
+                _name = null;
+                _expiresAt = DateTime.MinValue;
+            }
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
+++ b/ICCardManager/src/ICCardManager/Services/OperationLogger.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Text.Json;
 using ICCardManager.Data.Repositories;
@@ -11,10 +10,15 @@ namespace ICCardManager.Services
 /// <summary>
     /// 操作ログ記録サービス
     /// </summary>
+    /// <remarks>
+    /// Issue #1265: 操作者 IDm / 氏名は、呼び出し元引数ではなく
+    /// <see cref="ICurrentOperatorContext"/> からのみ解決される。
+    /// 旧シグネチャ (operatorIdm 付き) は [Obsolete] で残存するが、渡された値は無視される。
+    /// </remarks>
     public class OperationLogger
     {
         private readonly IOperationLogRepository _operationLogRepository;
-        private readonly IStaffRepository _staffRepository;
+        private readonly ICurrentOperatorContext _operatorContext;
 
         /// <summary>
         /// 操作種別
@@ -57,367 +61,340 @@ namespace ICCardManager.Services
 
         public OperationLogger(
             IOperationLogRepository operationLogRepository,
-            IStaffRepository staffRepository)
+            ICurrentOperatorContext operatorContext)
         {
             _operationLogRepository = operationLogRepository;
-            _staffRepository = staffRepository;
+            _operatorContext = operatorContext;
         }
 
-        /// <summary>
-        /// 職員登録のログを記録
-        /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="staff">登録した職員データ</param>
-        public async Task LogStaffInsertAsync(string? operatorIdm, Staff staff)
-        {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
+        #region 新 API (operatorIdm 引数なし) — Issue #1265
 
-            var log = new OperationLog
+        /// <summary>
+        /// 職員登録のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
+        /// </summary>
+        public async Task LogStaffInsertAsync(Staff staff)
+        {
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Staff,
                 TargetId = staff.StaffIdm,
                 Action = Actions.Insert,
                 BeforeData = null,
                 AfterData = SerializeToJson(staff)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 職員更新のログを記録
+        /// 職員更新のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="beforeStaff">変更前の職員データ</param>
-        /// <param name="afterStaff">変更後の職員データ</param>
-        public async Task LogStaffUpdateAsync(string? operatorIdm, Staff beforeStaff, Staff afterStaff)
+        public async Task LogStaffUpdateAsync(Staff beforeStaff, Staff afterStaff)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Staff,
                 TargetId = afterStaff.StaffIdm,
                 Action = Actions.Update,
                 BeforeData = SerializeToJson(beforeStaff),
                 AfterData = SerializeToJson(afterStaff)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 職員削除のログを記録
+        /// 職員削除のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="staff">削除する職員データ</param>
-        public async Task LogStaffDeleteAsync(string? operatorIdm, Staff staff)
+        public async Task LogStaffDeleteAsync(Staff staff)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Staff,
                 TargetId = staff.StaffIdm,
                 Action = Actions.Delete,
                 BeforeData = SerializeToJson(staff),
                 AfterData = null
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 職員復元のログを記録
+        /// 職員復元のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="staff">復元後の職員データ</param>
-        public async Task LogStaffRestoreAsync(string? operatorIdm, Staff staff)
+        public async Task LogStaffRestoreAsync(Staff staff)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Staff,
                 TargetId = staff.StaffIdm,
                 Action = Actions.Restore,
                 BeforeData = null,
                 AfterData = SerializeToJson(staff)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// ICカード登録のログを記録
+        /// ICカード登録のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="card">登録したICカードデータ</param>
-        public async Task LogCardInsertAsync(string? operatorIdm, IcCard card)
+        public async Task LogCardInsertAsync(IcCard card)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.IcCard,
                 TargetId = card.CardIdm,
                 Action = Actions.Insert,
                 BeforeData = null,
                 AfterData = SerializeToJson(card)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// ICカード更新のログを記録
+        /// ICカード更新のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="beforeCard">変更前のICカードデータ</param>
-        /// <param name="afterCard">変更後のICカードデータ</param>
-        public async Task LogCardUpdateAsync(string? operatorIdm, IcCard beforeCard, IcCard afterCard)
+        public async Task LogCardUpdateAsync(IcCard beforeCard, IcCard afterCard)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.IcCard,
                 TargetId = afterCard.CardIdm,
                 Action = Actions.Update,
                 BeforeData = SerializeToJson(beforeCard),
                 AfterData = SerializeToJson(afterCard)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// ICカード削除のログを記録
+        /// ICカード削除のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="card">削除するICカードデータ</param>
-        public async Task LogCardDeleteAsync(string? operatorIdm, IcCard card)
+        public async Task LogCardDeleteAsync(IcCard card)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.IcCard,
                 TargetId = card.CardIdm,
                 Action = Actions.Delete,
                 BeforeData = SerializeToJson(card),
                 AfterData = null
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// ICカード復元のログを記録
+        /// ICカード復元のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="card">復元後のICカードデータ</param>
-        public async Task LogCardRestoreAsync(string? operatorIdm, IcCard card)
+        public async Task LogCardRestoreAsync(IcCard card)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.IcCard,
                 TargetId = card.CardIdm,
                 Action = Actions.Restore,
                 BeforeData = null,
                 AfterData = SerializeToJson(card)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 履歴更新のログを記録
+        /// 履歴更新のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="beforeLedger">変更前の履歴データ</param>
-        /// <param name="afterLedger">変更後の履歴データ</param>
-        public async Task LogLedgerUpdateAsync(string? operatorIdm, Ledger beforeLedger, Ledger afterLedger)
+        public async Task LogLedgerUpdateAsync(Ledger beforeLedger, Ledger afterLedger)
         {
-            // GUI操作（operatorIdmがnullまたは空）の場合はGUI用識別子を使用
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Ledger,
                 TargetId = afterLedger.Id.ToString(),
                 Action = Actions.Update,
                 BeforeData = SerializeToJson(beforeLedger),
                 AfterData = SerializeToJson(afterLedger)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 履歴挿入のログを記録（Issue #635: 行の追加）
+        /// 履歴挿入のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="ledger">挿入した履歴データ</param>
-        public async Task LogLedgerInsertAsync(string? operatorIdm, Ledger ledger)
+        public async Task LogLedgerInsertAsync(Ledger ledger)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Ledger,
                 TargetId = ledger.Id.ToString(),
                 Action = Actions.Insert,
                 BeforeData = null,
                 AfterData = SerializeToJson(ledger)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 履歴削除のログを記録
+        /// 履歴削除のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="ledger">削除する履歴データ</param>
-        /// <remarks>
-        /// Issue #1188: 他の Log 系メソッドとシグネチャを統一し、operatorIdm を nullable に変更。
-        /// nullまたは空文字列が渡された場合は GUI 操作としてフォールバックする。
-        /// </remarks>
-        public async Task LogLedgerDeleteAsync(string? operatorIdm, Ledger ledger)
+        public async Task LogLedgerDeleteAsync(Ledger ledger)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Ledger,
                 TargetId = ledger.Id.ToString(),
                 Action = Actions.Delete,
                 BeforeData = SerializeToJson(ledger),
                 AfterData = null
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 履歴統合のログを記録
+        /// 履歴統合のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="sourceLedgers">統合元の履歴データリスト</param>
-        /// <param name="mergedLedger">統合後の履歴データ</param>
-        public async Task LogLedgerMergeAsync(string? operatorIdm, IReadOnlyList<Ledger> sourceLedgers, Ledger mergedLedger)
+        public async Task LogLedgerMergeAsync(IReadOnlyList<Ledger> sourceLedgers, Ledger mergedLedger)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Ledger,
                 TargetId = mergedLedger.Id.ToString(),
                 Action = Actions.Merge,
                 BeforeData = SerializeToJson(sourceLedgers),
                 AfterData = SerializeToJson(mergedLedger)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
         /// <summary>
-        /// 履歴分割のログを記録（Issue #634）
+        /// 履歴分割のログを記録。操作者情報は <see cref="ICurrentOperatorContext"/> から自動取得する。
         /// </summary>
-        /// <param name="operatorIdm">操作者IDm（nullまたは空文字列の場合はGUI操作として記録）</param>
-        /// <param name="originalLedger">分割前の履歴データ</param>
-        /// <param name="splitLedgers">分割後の履歴データリスト</param>
-        public async Task LogLedgerSplitAsync(string? operatorIdm, Ledger originalLedger, IReadOnlyList<Ledger> splitLedgers)
+        public async Task LogLedgerSplitAsync(Ledger originalLedger, IReadOnlyList<Ledger> splitLedgers)
         {
-            var isGuiOperation = string.IsNullOrEmpty(operatorIdm);
-            var actualIdm = isGuiOperation ? GuiOperator.Idm : operatorIdm;
-            var operatorName = isGuiOperation ? GuiOperator.Name : await GetOperatorNameAsync(operatorIdm!);
-
-            var log = new OperationLog
+            var (idm, name) = ResolveOperator();
+            await _operationLogRepository.InsertAsync(new OperationLog
             {
                 Timestamp = DateTime.Now,
-                OperatorIdm = actualIdm,
-                OperatorName = operatorName,
+                OperatorIdm = idm,
+                OperatorName = name,
                 TargetTable = Tables.Ledger,
                 TargetId = originalLedger.Id.ToString(),
                 Action = Actions.Split,
                 BeforeData = SerializeToJson(originalLedger),
                 AfterData = SerializeToJson(splitLedgers)
-            };
-
-            await _operationLogRepository.InsertAsync(log);
+            });
         }
 
+        #endregion
+
+        #region 旧 API (operatorIdm 引数付き) — 後方互換のため残存。引数は無視される (Issue #1265)
+
+        private const string ObsoleteMessage =
+            "Issue #1265: operatorIdm パラメータは監査ログなりすまし防止のため無視されます。" +
+            " ICurrentOperatorContext（StaffAuthService が職員証タッチ成功時に自動設定）経由で操作者を解決します。" +
+            " operatorIdm 引数を取らないオーバーロードに移行してください。";
+
+        /// <inheritdoc cref="LogStaffInsertAsync(Staff)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogStaffInsertAsync(string? operatorIdm, Staff staff) => LogStaffInsertAsync(staff);
+
+        /// <inheritdoc cref="LogStaffUpdateAsync(Staff, Staff)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogStaffUpdateAsync(string? operatorIdm, Staff beforeStaff, Staff afterStaff) =>
+            LogStaffUpdateAsync(beforeStaff, afterStaff);
+
+        /// <inheritdoc cref="LogStaffDeleteAsync(Staff)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogStaffDeleteAsync(string? operatorIdm, Staff staff) => LogStaffDeleteAsync(staff);
+
+        /// <inheritdoc cref="LogStaffRestoreAsync(Staff)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogStaffRestoreAsync(string? operatorIdm, Staff staff) => LogStaffRestoreAsync(staff);
+
+        /// <inheritdoc cref="LogCardInsertAsync(IcCard)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogCardInsertAsync(string? operatorIdm, IcCard card) => LogCardInsertAsync(card);
+
+        /// <inheritdoc cref="LogCardUpdateAsync(IcCard, IcCard)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogCardUpdateAsync(string? operatorIdm, IcCard beforeCard, IcCard afterCard) =>
+            LogCardUpdateAsync(beforeCard, afterCard);
+
+        /// <inheritdoc cref="LogCardDeleteAsync(IcCard)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogCardDeleteAsync(string? operatorIdm, IcCard card) => LogCardDeleteAsync(card);
+
+        /// <inheritdoc cref="LogCardRestoreAsync(IcCard)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogCardRestoreAsync(string? operatorIdm, IcCard card) => LogCardRestoreAsync(card);
+
+        /// <inheritdoc cref="LogLedgerUpdateAsync(Ledger, Ledger)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogLedgerUpdateAsync(string? operatorIdm, Ledger beforeLedger, Ledger afterLedger) =>
+            LogLedgerUpdateAsync(beforeLedger, afterLedger);
+
+        /// <inheritdoc cref="LogLedgerInsertAsync(Ledger)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogLedgerInsertAsync(string? operatorIdm, Ledger ledger) => LogLedgerInsertAsync(ledger);
+
+        /// <inheritdoc cref="LogLedgerDeleteAsync(Ledger)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogLedgerDeleteAsync(string? operatorIdm, Ledger ledger) => LogLedgerDeleteAsync(ledger);
+
+        /// <inheritdoc cref="LogLedgerMergeAsync(IReadOnlyList{Ledger}, Ledger)"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogLedgerMergeAsync(string? operatorIdm, IReadOnlyList<Ledger> sourceLedgers, Ledger mergedLedger) =>
+            LogLedgerMergeAsync(sourceLedgers, mergedLedger);
+
+        /// <inheritdoc cref="LogLedgerSplitAsync(Ledger, IReadOnlyList{Ledger})"/>
+        [Obsolete(ObsoleteMessage)]
+        public Task LogLedgerSplitAsync(string? operatorIdm, Ledger originalLedger, IReadOnlyList<Ledger> splitLedgers) =>
+            LogLedgerSplitAsync(originalLedger, splitLedgers);
+
+        #endregion
+
         /// <summary>
-        /// 操作者の氏名を取得
+        /// <see cref="ICurrentOperatorContext"/> から現在の操作者を解決する。
+        /// セッション無効時は GUI 操作として扱う。
         /// </summary>
-        private async Task<string> GetOperatorNameAsync(string operatorIdm)
+        private (string idm, string name) ResolveOperator()
         {
-            var staff = await _staffRepository.GetByIdmAsync(operatorIdm, includeDeleted: true);
-            return staff?.Name ?? "不明";
+            if (_operatorContext.HasSession)
+            {
+                return (_operatorContext.CurrentIdm!, _operatorContext.CurrentName!);
+            }
+            return (GuiOperator.Idm, GuiOperator.Name);
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/StaffAuthService.cs
+++ b/ICCardManager/src/ICCardManager/Services/StaffAuthService.cs
@@ -22,19 +22,22 @@ namespace ICCardManager.Services
         private readonly ISoundPlayer _soundPlayer;
         private readonly IMessenger _messenger;
         private readonly IOptions<AppOptions> _appOptions;
+        private readonly ICurrentOperatorContext _operatorContext;
 
         public StaffAuthService(
             IStaffRepository staffRepository,
             ICardReader cardReader,
             ISoundPlayer soundPlayer,
             IMessenger messenger,
-            IOptions<AppOptions> appOptions)
+            IOptions<AppOptions> appOptions,
+            ICurrentOperatorContext operatorContext)
         {
             _staffRepository = staffRepository;
             _cardReader = cardReader;
             _soundPlayer = soundPlayer;
             _messenger = messenger;
             _appOptions = appOptions;
+            _operatorContext = operatorContext;
         }
 
         /// <inheritdoc/>
@@ -48,6 +51,10 @@ namespace ICCardManager.Services
 
             if (dialog.ShowDialog() == true && dialog.IsAuthenticated)
             {
+                // Issue #1265: 認証成功時に操作者コンテキストを更新し、
+                // 後続の OperationLogger によるログ記録で使用する。
+                _operatorContext.BeginSession(dialog.AuthenticatedIdm!, dialog.AuthenticatedStaffName!);
+
                 return Task.FromResult<StaffAuthResult?>(new StaffAuthResult
                 {
                     Idm = dialog.AuthenticatedIdm!,

--- a/ICCardManager/tests/ICCardManager.Tests/Services/CurrentOperatorContextTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/CurrentOperatorContextTests.cs
@@ -1,0 +1,152 @@
+using System;
+using FluentAssertions;
+using ICCardManager.Infrastructure.Timing;
+using ICCardManager.Services;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// <see cref="CurrentOperatorContext"/> の単体テスト。
+/// Issue #1265: 操作者コンテキストの失効判定・排他制御・nullハンドリングを検証。
+/// </summary>
+public class CurrentOperatorContextTests
+{
+    private readonly Mock<ISystemClock> _clockMock;
+    private DateTime _now;
+
+    public CurrentOperatorContextTests()
+    {
+        _now = new DateTime(2026, 4, 17, 10, 0, 0);
+        _clockMock = new Mock<ISystemClock>();
+        _clockMock.Setup(c => c.Now).Returns(() => _now);
+    }
+
+    [Fact]
+    public void NewInstance_HasNoSession()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object);
+
+        context.HasSession.Should().BeFalse();
+        context.CurrentIdm.Should().BeNull();
+        context.CurrentName.Should().BeNull();
+    }
+
+    [Fact]
+    public void BeginSession_SetsOperatorValues()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object);
+
+        context.BeginSession("AAAA000000000001", "田中太郎");
+
+        context.HasSession.Should().BeTrue();
+        context.CurrentIdm.Should().Be("AAAA000000000001");
+        context.CurrentName.Should().Be("田中太郎");
+    }
+
+    [Fact]
+    public void BeginSession_WithNullIdm_Throws()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object);
+
+        Action act = () => context.BeginSession(null!, "氏名");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BeginSession_WithEmptyName_Throws()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object);
+
+        Action act = () => context.BeginSession("AAAA000000000001", string.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_WithZeroDuration_Throws()
+    {
+        Action act = () => new CurrentOperatorContext(_clockMock.Object, TimeSpan.Zero);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullClock_Throws()
+    {
+        Action act = () => new CurrentOperatorContext(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Session_ExpiresAfterDuration()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object, TimeSpan.FromMinutes(5));
+        context.BeginSession("AAAA000000000001", "田中太郎");
+
+        // 経過前: セッション有効
+        _now = _now.AddMinutes(4).AddSeconds(59);
+        context.HasSession.Should().BeTrue();
+        context.CurrentIdm.Should().Be("AAAA000000000001");
+
+        // 経過後: セッション無効（失効）
+        _now = _now.AddSeconds(2); // 計 5 分 1 秒経過
+        context.HasSession.Should().BeFalse();
+        context.CurrentIdm.Should().BeNull();
+        context.CurrentName.Should().BeNull();
+    }
+
+    [Fact]
+    public void BeginSession_RenewsExpiration()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object, TimeSpan.FromMinutes(5));
+        context.BeginSession("AAAA000000000001", "田中太郎");
+
+        _now = _now.AddMinutes(4);
+        // 再認証で有効期限を更新
+        context.BeginSession("BBBB000000000002", "山田花子");
+
+        _now = _now.AddMinutes(4); // 元の BeginSession から 8 分経過しているが、再認証は 4 分前なので有効
+        context.HasSession.Should().BeTrue();
+        context.CurrentIdm.Should().Be("BBBB000000000002");
+        context.CurrentName.Should().Be("山田花子");
+    }
+
+    [Fact]
+    public void ClearSession_InvalidatesSession()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object);
+        context.BeginSession("AAAA000000000001", "田中太郎");
+
+        context.ClearSession();
+
+        context.HasSession.Should().BeFalse();
+        context.CurrentIdm.Should().BeNull();
+        context.CurrentName.Should().BeNull();
+    }
+
+    [Fact]
+    public void DefaultSessionDuration_IsFiveMinutes()
+    {
+        CurrentOperatorContext.DefaultSessionDuration.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    /// <summary>
+    /// セッション中にクロックが1ms巻き戻されても、期限前ならセッションは有効でなければならない。
+    /// </summary>
+    [Fact]
+    public void CurrentIdm_ReflectsClockAtQueryTime()
+    {
+        var context = new CurrentOperatorContext(_clockMock.Object, TimeSpan.FromSeconds(30));
+        context.BeginSession("AAAA000000000001", "田中太郎");
+
+        _now = _now.AddSeconds(29);
+        context.CurrentIdm.Should().Be("AAAA000000000001");
+
+        _now = _now.AddSeconds(2); // 31秒経過 → 失効
+        context.CurrentIdm.Should().BeNull();
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerMergeServiceTests.cs
@@ -48,7 +48,7 @@ public class LedgerMergeServiceTests
         // OperationLoggerは実物を使用（メソッドがvirtualでないため）
         _operationLogger = new OperationLogger(
             _operationLogRepositoryMock.Object,
-            _staffRepositoryMock.Object);
+            Mock.Of<ICurrentOperatorContext>());
 
         _service = new LedgerMergeService(
             _ledgerRepositoryMock.Object,

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LedgerSplitServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LedgerSplitServiceTests.cs
@@ -40,7 +40,7 @@ public class LedgerSplitServiceTests
 
         _operationLogger = new OperationLogger(
             _operationLogRepositoryMock.Object,
-            _staffRepositoryMock.Object);
+            Mock.Of<ICurrentOperatorContext>());
 
         _service = new LedgerSplitService(
             _ledgerRepositoryMock.Object,

--- a/ICCardManager/tests/ICCardManager.Tests/Services/OperationLoggerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/OperationLoggerTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using ICCardManager.Data;
 using ICCardManager.Data.Repositories;
+using ICCardManager.Infrastructure.Timing;
 using ICCardManager.Models;
 using ICCardManager.Services;
 using Moq;
@@ -16,22 +17,30 @@ namespace ICCardManager.Tests.Services;
 
 /// <summary>
 /// OperationLoggerの単体テスト
+/// Issue #1265: 操作者情報は ICurrentOperatorContext から一元的に解決される。
+/// 旧シグネチャに渡された operatorIdm は無視される（監査ログなりすまし防止）。
 /// </summary>
 public class OperationLoggerTests : IDisposable
 {
     private readonly DbContext _dbContext;
     private readonly OperationLogRepository _operationLogRepository;
-    private readonly Mock<IStaffRepository> _staffRepositoryMock;
+    private readonly Mock<ISystemClock> _clockMock;
+    private readonly CurrentOperatorContext _operatorContext;
     private readonly OperationLogger _logger;
+    private DateTime _now;
 
     public OperationLoggerTests()
     {
         _dbContext = new DbContext(":memory:");
         _dbContext.InitializeDatabase();
         _operationLogRepository = new OperationLogRepository(_dbContext);
-        _staffRepositoryMock = new Mock<IStaffRepository>();
 
-        _logger = new OperationLogger(_operationLogRepository, _staffRepositoryMock.Object);
+        _now = new DateTime(2026, 4, 17, 10, 0, 0);
+        _clockMock = new Mock<ISystemClock>();
+        _clockMock.Setup(c => c.Now).Returns(() => _now);
+        _operatorContext = new CurrentOperatorContext(_clockMock.Object);
+
+        _logger = new OperationLogger(_operationLogRepository, _operatorContext);
     }
 
     public void Dispose()
@@ -40,25 +49,34 @@ public class OperationLoggerTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    #region LogLedgerUpdateAsync GUI操作テスト
+    #region GuiOperator 定数テスト
 
-    /// <summary>
-    /// operatorIdmがnullの場合、GUI操作用識別子が使用されること
-    /// </summary>
+    /// <summary>GUI操作用識別子の値が正しいことを確認</summary>
     [Fact]
-    public async Task LogLedgerUpdateAsync_WithNullOperatorIdm_UsesGuiIdentifier()
+    public void GuiOperator_HasCorrectValues()
     {
-        // Arrange
+        OperationLogger.GuiOperator.Idm.Should().Be("0000000000000000");
+        OperationLogger.GuiOperator.Idm.Should().HaveLength(16);
+        OperationLogger.GuiOperator.Name.Should().Be("GUI操作");
+    }
+
+    #endregion
+
+    #region 新API: context なし → GuiOperator フォールバック
+
+    [Fact]
+    public async Task LogLedgerUpdateAsync_WithoutContext_UsesGuiIdentifier()
+    {
+        // Arrange: context 未設定
         var beforeLedger = CreateTestLedger(summary: "変更前");
         var afterLedger = CreateTestLedger(summary: "変更後");
 
-        // Act
-        await _logger.LogLedgerUpdateAsync(null, beforeLedger, afterLedger);
+        // Act: 新 API（operator 引数なし）
+        await _logger.LogLedgerUpdateAsync(beforeLedger, afterLedger);
 
         // Assert
         var logs = await _operationLogRepository.GetByOperatorAsync(OperationLogger.GuiOperator.Idm);
         logs.Should().HaveCount(1);
-
         var log = logs.First();
         log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
         log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
@@ -66,405 +84,308 @@ public class OperationLoggerTests : IDisposable
         log.Action.Should().Be(OperationLogger.Actions.Update);
     }
 
-    /// <summary>
-    /// operatorIdmが空文字列の場合、GUI操作用識別子が使用されること
-    /// </summary>
     [Fact]
-    public async Task LogLedgerUpdateAsync_WithEmptyOperatorIdm_UsesGuiIdentifier()
+    public async Task LogStaffInsertAsync_WithoutContext_UsesGuiIdentifier()
     {
-        // Arrange
-        var beforeLedger = CreateTestLedger(summary: "変更前");
-        var afterLedger = CreateTestLedger(summary: "変更後");
+        var staff = CreateTestStaff();
 
-        // Act
-        await _logger.LogLedgerUpdateAsync(string.Empty, beforeLedger, afterLedger);
+        await _logger.LogStaffInsertAsync(staff);
 
-        // Assert
-        var logs = await _operationLogRepository.GetByOperatorAsync(OperationLogger.GuiOperator.Idm);
+        var logs = await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm);
         logs.Should().HaveCount(1);
-
         var log = logs.First();
         log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
         log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
-    }
-
-    /// <summary>
-    /// 有効なoperatorIdmが渡された場合、そのIDmが使用されること
-    /// </summary>
-    [Fact]
-    public async Task LogLedgerUpdateAsync_WithValidOperatorIdm_UsesProvidedIdm()
-    {
-        // Arrange
-        const string operatorIdm = "FFFF000000000001";
-        const string operatorName = "テスト職員";
-        var staff = new Staff { StaffIdm = operatorIdm, Name = operatorName };
-
-        _staffRepositoryMock
-            .Setup(x => x.GetByIdmAsync(operatorIdm, true))
-            .ReturnsAsync(staff);
-
-        var beforeLedger = CreateTestLedger(summary: "変更前");
-        var afterLedger = CreateTestLedger(summary: "変更後");
-
-        // Act
-        await _logger.LogLedgerUpdateAsync(operatorIdm, beforeLedger, afterLedger);
-
-        // Assert
-        var logs = await _operationLogRepository.GetByOperatorAsync(operatorIdm);
-        logs.Should().HaveCount(1);
-
-        var log = logs.First();
-        log.OperatorIdm.Should().Be(operatorIdm);
-        log.OperatorName.Should().Be(operatorName);
-    }
-
-    /// <summary>
-    /// GUI操作用識別子の値が正しいことを確認
-    /// </summary>
-    [Fact]
-    public void GuiOperator_HasCorrectValues()
-    {
-        // Assert
-        OperationLogger.GuiOperator.Idm.Should().Be("0000000000000000");
-        OperationLogger.GuiOperator.Idm.Should().HaveLength(16);
-        OperationLogger.GuiOperator.Name.Should().Be("GUI操作");
-    }
-
-    /// <summary>
-    /// GUI操作のログに変更前・変更後のデータが正しく記録されること
-    /// </summary>
-    [Fact]
-    public async Task LogLedgerUpdateAsync_WithGuiOperation_RecordsBeforeAndAfterData()
-    {
-        // Arrange
-        var beforeLedger = CreateTestLedger(id: 1, summary: "バス（★）");
-        var afterLedger = CreateTestLedger(id: 1, summary: "バス（天神～博多）");
-
-        // Act
-        await _logger.LogLedgerUpdateAsync(null, beforeLedger, afterLedger);
-
-        // Assert
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger,
-            afterLedger.Id.ToString());
-        logs.Should().HaveCount(1);
-
-        var log = logs.First();
-        log.BeforeData.Should().Contain("バス（★）");
-        log.AfterData.Should().Contain("バス（天神～博多）");
+        log.Action.Should().Be(OperationLogger.Actions.Insert);
     }
 
     #endregion
 
-    #region Staff ログ
+    #region 新API: context あり → context 値を使用
+
+    [Fact]
+    public async Task LogLedgerDeleteAsync_WithContext_RecordsContextOperator()
+    {
+        // Arrange: 認証済み operator を context に設定
+        const string authIdm = "AAAA000000000001";
+        const string authName = "認証済み職員";
+        _operatorContext.BeginSession(authIdm, authName);
+
+        var ledger = CreateTestLedger(id: 99, summary: "削除対象");
+
+        // Act
+        await _logger.LogLedgerDeleteAsync(ledger);
+
+        // Assert
+        var logs = await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "99");
+        var log = logs.Single();
+        log.OperatorIdm.Should().Be(authIdm);
+        log.OperatorName.Should().Be(authName);
+        log.Action.Should().Be(OperationLogger.Actions.Delete);
+    }
+
+    [Fact]
+    public async Task LogStaffInsertAsync_WithContext_RecordsContextOperator()
+    {
+        _operatorContext.BeginSession("BBBB000000000002", "山田 花子");
+
+        var staff = CreateTestStaff();
+        await _logger.LogStaffInsertAsync(staff);
+
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm)).Single();
+        log.OperatorIdm.Should().Be("BBBB000000000002");
+        log.OperatorName.Should().Be("山田 花子");
+    }
+
+    #endregion
+
+    #region Issue #1265: 監査ログなりすまし防止
 
     /// <summary>
-    /// LogStaffInsertAsync: GUI操作で staff テーブル・INSERT・After のみが記録される
+    /// 旧 API に操作者 IDm を渡しても、context が設定されている場合は
+    /// context の値が優先される（呼び出し側は他人の IDm でなりすますことができない）。
     /// </summary>
     [Fact]
-    public async Task LogStaffInsertAsync_GuiOperation_RecordsCorrectly()
+    public async Task ObsoleteApi_WithContext_IgnoresPassedOperatorIdm_AntiSpoofing()
     {
-        var staff = CreateTestStaff();
+        // Arrange: 実際の認証操作者は AAAA...
+        const string authenticatedIdm = "AAAA000000000001";
+        const string authenticatedName = "認証済み職員";
+        _operatorContext.BeginSession(authenticatedIdm, authenticatedName);
 
-        await _logger.LogStaffInsertAsync(null, staff);
+        // 攻撃者が悪意を持って他の職員の IDm を渡す
+        const string spoofedIdm = "FFFF000000000002";
+        var ledger = CreateTestLedger(id: 50, summary: "なりすましターゲット");
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Staff, staff.StaffIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
-        log.Action.Should().Be(OperationLogger.Actions.Insert);
-        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
-        log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
-        log.BeforeData.Should().BeNull();
-        log.AfterData.Should().NotBeNullOrEmpty();
-        log.AfterData.Should().Contain(staff.Name);
+        // Act: [Obsolete] な旧 API に偽の IDm を渡す
+#pragma warning disable CS0618 // Obsolete 警告を抑制（このテストこそが非推奨 API の振る舞いを検証）
+        await _logger.LogLedgerDeleteAsync(spoofedIdm, ledger);
+#pragma warning restore CS0618
+
+        // Assert: 記録は context の認証済み操作者で行われ、偽IDm は記録されない
+        var spoofedLogs = await _operationLogRepository.GetByOperatorAsync(spoofedIdm);
+        spoofedLogs.Should().BeEmpty("なりすまし IDm でのログは一切記録されてはならない");
+
+        var authenticatedLogs = await _operationLogRepository.GetByOperatorAsync(authenticatedIdm);
+        authenticatedLogs.Should().HaveCount(1);
+        authenticatedLogs.Single().OperatorName.Should().Be(authenticatedName);
     }
 
     /// <summary>
-    /// LogStaffUpdateAsync: Before/After 両方が記録される
+    /// context が未設定のときに旧 API に操作者 IDm を渡しても、
+    /// それは無視され GUI 操作としてフォールバックする（引数経由でのなりすましを防ぐ）。
     /// </summary>
+    [Fact]
+    public async Task ObsoleteApi_WithoutContext_IgnoresPassedOperatorIdm_FallsBackToGui()
+    {
+        // Arrange: context 未設定
+        const string spoofedIdm = "FFFF000000000003";
+        var ledger = CreateTestLedger(id: 51, summary: "context未設定の偽称ターゲット");
+
+        // Act: 悪意ある呼び出し側が他の職員の IDm を渡す
+#pragma warning disable CS0618
+        await _logger.LogLedgerDeleteAsync(spoofedIdm, ledger);
+#pragma warning restore CS0618
+
+        // Assert: 偽 IDm のログは一切作られず、GUI 操作として記録される
+        var spoofedLogs = await _operationLogRepository.GetByOperatorAsync(spoofedIdm);
+        spoofedLogs.Should().BeEmpty();
+
+        var guiLogs = await _operationLogRepository.GetByOperatorAsync(OperationLogger.GuiOperator.Idm);
+        guiLogs.Should().HaveCount(1);
+        guiLogs.Single().OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
+    }
+
+    /// <summary>
+    /// セッション失効後は、旧 API 経由の操作者 IDm も context も使われず GUI 操作扱い。
+    /// </summary>
+    [Fact]
+    public async Task ObsoleteApi_AfterContextExpiration_UsesGuiIdentifier()
+    {
+        // Arrange: 短い有効期間の context
+        var shortLived = new CurrentOperatorContext(_clockMock.Object, TimeSpan.FromSeconds(10));
+        shortLived.BeginSession("CCCC000000000003", "期限切れ予定職員");
+        var logger = new OperationLogger(_operationLogRepository, shortLived);
+
+        // 11 秒経過 → セッション失効
+        _now = _now.AddSeconds(11);
+
+        var ledger = CreateTestLedger(id: 52, summary: "失効後ターゲット");
+
+        // Act
+#pragma warning disable CS0618
+        await logger.LogLedgerDeleteAsync("FFFF000000000004", ledger);
+#pragma warning restore CS0618
+
+        // Assert: GUI 操作としてフォールバック
+        var logs = await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "52");
+        var log = logs.Single();
+        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
+        log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
+    }
+
+    #endregion
+
+    #region 後方互換: 旧 API は新 API と同じ結果を返す
+
+    [Fact]
+    public async Task ObsoleteLogStaffInsertAsync_DelegatesToNewApi()
+    {
+        var staff = CreateTestStaff();
+
+#pragma warning disable CS0618
+        await _logger.LogStaffInsertAsync(null, staff);
+#pragma warning restore CS0618
+
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm)).Single();
+        log.Action.Should().Be(OperationLogger.Actions.Insert);
+        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
+        log.BeforeData.Should().BeNull();
+        log.AfterData.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ObsoleteLogLedgerMergeAsync_DelegatesToNewApi()
+    {
+        var src1 = CreateTestLedger(id: 1, summary: "元1");
+        var src2 = CreateTestLedger(id: 2, summary: "元2");
+        var merged = CreateTestLedger(id: 3, summary: "統合後");
+
+#pragma warning disable CS0618
+        await _logger.LogLedgerMergeAsync(null, new List<Ledger> { src1, src2 }, merged);
+#pragma warning restore CS0618
+
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "3")).Single();
+        log.Action.Should().Be(OperationLogger.Actions.Merge);
+        log.BeforeData.Should().Contain("元1").And.Contain("元2");
+        log.AfterData.Should().Contain("統合後");
+    }
+
+    #endregion
+
+    #region 各テーブルのログ記録 (新 API)
+
     [Fact]
     public async Task LogStaffUpdateAsync_RecordsBeforeAndAfter()
     {
         var before = CreateTestStaff(name: "旧氏名");
         var after = CreateTestStaff(name: "新氏名");
 
-        await _logger.LogStaffUpdateAsync(null, before, after);
+        await _logger.LogStaffUpdateAsync(before, after);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Staff, after.StaffIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, after.StaffIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Update);
         log.BeforeData.Should().Contain("旧氏名");
         log.AfterData.Should().Contain("新氏名");
     }
 
-    /// <summary>
-    /// LogStaffDeleteAsync: Before のみ記録、After は null
-    /// </summary>
     [Fact]
     public async Task LogStaffDeleteAsync_RecordsBeforeOnly()
     {
         var staff = CreateTestStaff();
 
-        await _logger.LogStaffDeleteAsync(null, staff);
+        await _logger.LogStaffDeleteAsync(staff);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Staff, staff.StaffIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Delete);
         log.BeforeData.Should().NotBeNullOrEmpty();
         log.AfterData.Should().BeNull();
     }
 
-    /// <summary>
-    /// LogStaffRestoreAsync: After のみ記録、Before は null
-    /// </summary>
     [Fact]
     public async Task LogStaffRestoreAsync_RecordsAfterOnly()
     {
         var staff = CreateTestStaff();
 
-        await _logger.LogStaffRestoreAsync(null, staff);
+        await _logger.LogStaffRestoreAsync(staff);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Staff, staff.StaffIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Restore);
         log.BeforeData.Should().BeNull();
         log.AfterData.Should().NotBeNullOrEmpty();
     }
 
-    /// <summary>
-    /// 有効な操作者IDmが渡された場合、StaffRepositoryから氏名を取得して記録する
-    /// </summary>
-    [Fact]
-    public async Task LogStaffInsertAsync_WithValidOperator_LooksUpName()
-    {
-        const string operatorIdm = "0102030405060708";
-        _staffRepositoryMock
-            .Setup(x => x.GetByIdmAsync(operatorIdm, true))
-            .ReturnsAsync(new Staff { StaffIdm = operatorIdm, Name = "操作者A" });
-
-        var target = CreateTestStaff(idm: "AAAA000000000001", name: "対象者");
-
-        await _logger.LogStaffInsertAsync(operatorIdm, target);
-
-        var logs = await _operationLogRepository.GetByOperatorAsync(operatorIdm);
-        logs.Should().HaveCount(1);
-        logs.First().OperatorName.Should().Be("操作者A");
-    }
-
-    /// <summary>
-    /// 操作者がStaffRepositoryに存在しない場合は「不明」と記録される
-    /// </summary>
-    [Fact]
-    public async Task LogStaffInsertAsync_WithUnknownOperator_RecordsAsUnknown()
-    {
-        const string operatorIdm = "DEADBEEF00000001";
-        _staffRepositoryMock
-            .Setup(x => x.GetByIdmAsync(operatorIdm, true))
-            .ReturnsAsync((Staff)null);
-
-        var target = CreateTestStaff();
-
-        await _logger.LogStaffInsertAsync(operatorIdm, target);
-
-        var logs = await _operationLogRepository.GetByOperatorAsync(operatorIdm);
-        logs.Should().HaveCount(1);
-        logs.First().OperatorName.Should().Be("不明");
-    }
-
-    #endregion
-
-    #region IcCard ログ
-
-    /// <summary>
-    /// LogCardInsertAsync: ic_card テーブル・INSERT・After のみ
-    /// </summary>
     [Fact]
     public async Task LogCardInsertAsync_RecordsCorrectly()
     {
         var card = CreateTestCard();
 
-        await _logger.LogCardInsertAsync(null, card);
+        await _logger.LogCardInsertAsync(card);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.IcCard, card.CardIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.IcCard, card.CardIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Insert);
-        log.TargetTable.Should().Be(OperationLogger.Tables.IcCard);
         log.BeforeData.Should().BeNull();
         log.AfterData.Should().NotBeNullOrEmpty();
     }
 
-    /// <summary>
-    /// LogCardUpdateAsync: Before/After 両方
-    /// </summary>
     [Fact]
     public async Task LogCardUpdateAsync_RecordsBeforeAndAfter()
     {
         var before = CreateTestCard(cardNumber: "OLD-001");
         var after = CreateTestCard(cardNumber: "NEW-001");
 
-        await _logger.LogCardUpdateAsync(null, before, after);
+        await _logger.LogCardUpdateAsync(before, after);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.IcCard, after.CardIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.IcCard, after.CardIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Update);
         log.BeforeData.Should().Contain("OLD-001");
         log.AfterData.Should().Contain("NEW-001");
     }
 
-    /// <summary>
-    /// LogCardDeleteAsync: Before のみ
-    /// </summary>
     [Fact]
     public async Task LogCardDeleteAsync_RecordsBeforeOnly()
     {
         var card = CreateTestCard();
 
-        await _logger.LogCardDeleteAsync(null, card);
+        await _logger.LogCardDeleteAsync(card);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.IcCard, card.CardIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.IcCard, card.CardIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Delete);
         log.BeforeData.Should().NotBeNullOrEmpty();
         log.AfterData.Should().BeNull();
     }
 
-    /// <summary>
-    /// LogCardRestoreAsync: After のみ
-    /// </summary>
     [Fact]
     public async Task LogCardRestoreAsync_RecordsAfterOnly()
     {
         var card = CreateTestCard();
 
-        await _logger.LogCardRestoreAsync(null, card);
+        await _logger.LogCardRestoreAsync(card);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.IcCard, card.CardIdm);
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.IcCard, card.CardIdm)).Single();
         log.Action.Should().Be(OperationLogger.Actions.Restore);
         log.BeforeData.Should().BeNull();
         log.AfterData.Should().NotBeNullOrEmpty();
     }
 
-    #endregion
-
-    #region Ledger ログ（Insert/Delete/Merge/Split）
-
-    /// <summary>
-    /// LogLedgerInsertAsync: ledger テーブル・INSERT・After のみ
-    /// </summary>
     [Fact]
     public async Task LogLedgerInsertAsync_RecordsCorrectly()
     {
         var ledger = CreateTestLedger(id: 42, summary: "新規行");
 
-        await _logger.LogLedgerInsertAsync(null, ledger);
+        await _logger.LogLedgerInsertAsync(ledger);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "42");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "42")).Single();
         log.Action.Should().Be(OperationLogger.Actions.Insert);
         log.BeforeData.Should().BeNull();
         log.AfterData.Should().Contain("新規行");
     }
 
-    /// <summary>
-    /// LogLedgerDeleteAsync: 有効な operatorIdm を渡すと正しく記録される。
-    /// </summary>
-    /// <remarks>
-    /// Issue #1188 で他の Log 系メソッドとシグネチャが統一され、operatorIdm が
-    /// nullable になった。本テストは「有効な operatorIdm を渡した場合の振る舞い」を固定する。
-    /// null / 空文字列ケースは別途下記の <c>LogLedgerDeleteAsync_WithNullOperatorIdm_*</c>
-    /// および <c>LogLedgerDeleteAsync_WithEmptyOperatorIdm_*</c> で検証する。
-    /// </remarks>
     [Fact]
-    public async Task LogLedgerDeleteAsync_WithValidOperator_RecordsBeforeOnly()
-    {
-        const string operatorIdm = "BEEF000000000001";
-        _staffRepositoryMock
-            .Setup(x => x.GetByIdmAsync(operatorIdm, true))
-            .ReturnsAsync(new Staff { StaffIdm = operatorIdm, Name = "削除者" });
-
-        var ledger = CreateTestLedger(id: 99, summary: "削除対象");
-
-        await _logger.LogLedgerDeleteAsync(operatorIdm, ledger);
-
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "99");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
-        log.Action.Should().Be(OperationLogger.Actions.Delete);
-        log.OperatorName.Should().Be("削除者");
-        log.BeforeData.Should().Contain("削除対象");
-        log.AfterData.Should().BeNull();
-    }
-
-    /// <summary>
-    /// Issue #1188: LogLedgerDeleteAsync に null operatorIdm を渡すと
-    /// GUI 操作識別子（Idm/Name）にフォールバックして記録される
-    /// </summary>
-    [Fact]
-    public async Task LogLedgerDeleteAsync_WithNullOperatorIdm_UsesGuiIdentifier()
+    public async Task LogLedgerDeleteAsync_WithoutContext_RecordsBeforeOnlyAsGui()
     {
         var ledger = CreateTestLedger(id: 77, summary: "GUI削除対象");
 
-        await _logger.LogLedgerDeleteAsync(null, ledger);
+        await _logger.LogLedgerDeleteAsync(ledger);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "77");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "77")).Single();
         log.Action.Should().Be(OperationLogger.Actions.Delete);
         log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
         log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
         log.BeforeData.Should().Contain("GUI削除対象");
         log.AfterData.Should().BeNull();
-        // null が渡された場合、StaffRepository は照会されない
-        _staffRepositoryMock.Verify(
-            x => x.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()),
-            Times.Never);
     }
 
-    /// <summary>
-    /// Issue #1188: LogLedgerDeleteAsync に空文字列の operatorIdm を渡すと
-    /// GUI 操作識別子にフォールバックする（他の Log 系メソッドと同等の振る舞い）
-    /// </summary>
-    [Fact]
-    public async Task LogLedgerDeleteAsync_WithEmptyOperatorIdm_UsesGuiIdentifier()
-    {
-        var ledger = CreateTestLedger(id: 78, summary: "空文字列削除対象");
-
-        await _logger.LogLedgerDeleteAsync(string.Empty, ledger);
-
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "78");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
-        log.OperatorIdm.Should().Be(OperationLogger.GuiOperator.Idm);
-        log.OperatorName.Should().Be(OperationLogger.GuiOperator.Name);
-        _staffRepositoryMock.Verify(
-            x => x.GetByIdmAsync(It.IsAny<string>(), It.IsAny<bool>()),
-            Times.Never);
-    }
-
-    /// <summary>
-    /// LogLedgerMergeAsync: BeforeData に元レコード配列、AfterData に統合後レコードが入る
-    /// </summary>
     [Fact]
     public async Task LogLedgerMergeAsync_RecordsSourcesAndMerged()
     {
@@ -472,20 +393,14 @@ public class OperationLoggerTests : IDisposable
         var src2 = CreateTestLedger(id: 2, summary: "元2");
         var merged = CreateTestLedger(id: 3, summary: "統合後");
 
-        await _logger.LogLedgerMergeAsync(null, new List<Ledger> { src1, src2 }, merged);
+        await _logger.LogLedgerMergeAsync(new List<Ledger> { src1, src2 }, merged);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "3");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "3")).Single();
         log.Action.Should().Be(OperationLogger.Actions.Merge);
         log.BeforeData.Should().Contain("元1").And.Contain("元2");
         log.AfterData.Should().Contain("統合後");
     }
 
-    /// <summary>
-    /// LogLedgerSplitAsync: BeforeData に元レコード、AfterData に分割後配列が入る。TargetId は元レコードの ID
-    /// </summary>
     [Fact]
     public async Task LogLedgerSplitAsync_RecordsOriginalAndSplits()
     {
@@ -493,12 +408,9 @@ public class OperationLoggerTests : IDisposable
         var split1 = CreateTestLedger(id: 11, summary: "分割1");
         var split2 = CreateTestLedger(id: 12, summary: "分割2");
 
-        await _logger.LogLedgerSplitAsync(null, original, new List<Ledger> { split1, split2 });
+        await _logger.LogLedgerSplitAsync(original, new List<Ledger> { split1, split2 });
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Ledger, "10");
-        logs.Should().HaveCount(1);
-        var log = logs.First();
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Ledger, "10")).Single();
         log.Action.Should().Be(OperationLogger.Actions.Split);
         log.BeforeData.Should().Contain("元");
         log.AfterData.Should().Contain("分割1").And.Contain("分割2");
@@ -508,21 +420,15 @@ public class OperationLoggerTests : IDisposable
 
     #region JSONシリアライズ
 
-    /// <summary>
-    /// 日本語・特殊文字（&, ", '）を含むデータがエスケープを最小限にして読みやすく記録される
-    /// （JavaScriptEncoder.UnsafeRelaxedJsonEscaping の振る舞い）
-    /// </summary>
+    /// <summary>日本語・特殊文字を含むデータが読みやすく記録される</summary>
     [Fact]
     public async Task LogStaffInsertAsync_PreservesJapaneseAndSpecialChars()
     {
         var staff = CreateTestStaff(name: "山田 \"太郎\" & 花子");
 
-        await _logger.LogStaffInsertAsync(null, staff);
+        await _logger.LogStaffInsertAsync(staff);
 
-        var logs = await _operationLogRepository.GetByTargetAsync(
-            OperationLogger.Tables.Staff, staff.StaffIdm);
-        var log = logs.First();
-        // 日本語はエスケープされず生のまま記録される
+        var log = (await _operationLogRepository.GetByTargetAsync(OperationLogger.Tables.Staff, staff.StaffIdm)).Single();
         log.AfterData.Should().Contain("山田");
         log.AfterData.Should().Contain("花子");
     }

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelMessagingTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelMessagingTests.cs
@@ -42,7 +42,7 @@ public class CardManageViewModelMessagingTests
         _staffAuthServiceMock = new Mock<IStaffAuthService>();
 
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
-        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, Mock.Of<ICurrentOperatorContext>());
 
         var settingsRepositoryMock = new Mock<ISettingsRepository>();
         var summaryGenerator = new SummaryGenerator();

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/CardManageViewModelTests.cs
@@ -50,7 +50,7 @@ public class CardManageViewModelTests
 
         // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
-        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, Mock.Of<ICurrentOperatorContext>());
 
         // LendingServiceの作成（Issue #596対応）
         var settingsRepositoryMock = new Mock<ISettingsRepository>();

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerDetailViewModelTests.cs
@@ -33,7 +33,7 @@ public class LedgerDetailViewModelTests
         var staffRepoMock = new Mock<IStaffRepository>();
         var operationLogger = new OperationLogger(
             operationLogRepoMock.Object,
-            staffRepoMock.Object);
+            Mock.Of<ICurrentOperatorContext>());
         var splitServiceLogger = NullLogger<LedgerSplitService>.Instance;
         var ledgerSplitService = new LedgerSplitService(
             _ledgerRepoMock.Object,

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerRowEditViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/LedgerRowEditViewModelTests.cs
@@ -38,7 +38,7 @@ public class LedgerRowEditViewModelTests
         _operationLogRepoMock = new Mock<IOperationLogRepository>();
         _operationLogger = new OperationLogger(
             _operationLogRepoMock.Object,
-            _staffRepoMock.Object);
+            Mock.Of<ICurrentOperatorContext>());
 
         _staffRepoMock.Setup(r => r.GetAllAsync())
             .ReturnsAsync(new List<Staff> { _staffA, _staffB });

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelSyncDisplayTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelSyncDisplayTests.cs
@@ -208,7 +208,7 @@ public class MainViewModelSyncDisplayTests
         var summaryGenerator = new SummaryGenerator();
         var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);
         var operationLoggerMock = new Mock<OperationLogger>(
-            new Mock<IOperationLogRepository>().Object, staffRepositoryMock.Object);
+            new Mock<IOperationLogRepository>().Object, Mock.Of<ICurrentOperatorContext>());
         var lendingService = new LendingService(
             dbContext,
             cardRepositoryMock.Object,

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/MainViewModelTests.cs
@@ -69,7 +69,7 @@ public class MainViewModelTests
 
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
         _operationLoggerMock = new Mock<OperationLogger>(
-            operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+            operationLogRepositoryMock.Object, Mock.Of<ICurrentOperatorContext>());
 
         var summaryGenerator = new SummaryGenerator();
         var lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelMessagingTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelMessagingTests.cs
@@ -34,7 +34,7 @@ public class StaffManageViewModelMessagingTests
         _staffAuthServiceMock = new Mock<IStaffAuthService>();
 
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
-        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, Mock.Of<ICurrentOperatorContext>());
 
         _messenger = new WeakReferenceMessenger();
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
@@ -41,7 +41,7 @@ public class StaffManageViewModelTests
 
         // OperationLoggerのモック（コンストラクタ引数が必要なためMock.Ofで作成）
         var operationLogRepositoryMock = new Mock<IOperationLogRepository>();
-        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, _staffRepositoryMock.Object);
+        _operationLoggerMock = new Mock<OperationLogger>(operationLogRepositoryMock.Object, Mock.Of<ICurrentOperatorContext>());
 
         // バリデーションはデフォルトで成功を返す
         _validationServiceMock.Setup(v => v.ValidateStaffIdm(It.IsAny<string>())).Returns(ValidationResult.Success());


### PR DESCRIPTION
## 概要

Issue #1265 の対応。監査ログ（`operation_log`）の `operator_idm` / `operator_name` がアプリケーション層から直接指定可能だったため、内部者が他職員の名義で監査ログを捏造できる状態だった。6 年保存が義務の監査要件と矛盾するため最優先（critical）で修正。

## 変更内容

### コア実装
- **`Services/ICurrentOperatorContext.cs`** (新規): 操作者セッション情報を保持する Singleton コンテキスト
  - 既定 5 分で自動失効（`ISystemClock` 連携でテスト容易化）
  - `BeginSession(idm, name)` / `ClearSession()` / `HasSession` / `CurrentIdm` / `CurrentName`
- **`Services/StaffAuthService.cs`**: 認証成功時に `_operatorContext.BeginSession()` を呼び出すよう変更
- **`Services/OperationLogger.cs`** (全面改訂):
  - Context から操作者を一元解決する **新 API**（operator 引数なし）を追加
  - **旧 API**（operatorIdm 引数付き）は `[Obsolete]` で残存し、渡された引数は **無視される**
    → 後方互換を維持しつつ、呼び出し側からのなりすまし経路を即座に遮断
  - `IStaffRepository` 依存を削除（操作者は Context のみから解決）

### DI 登録
- `App.xaml.cs` に `ICurrentOperatorContext` を Singleton 登録

### テスト
- **`CurrentOperatorContextTests`** (新規、10 ケース): 失効判定、排他制御、null ハンドリング
- **`OperationLoggerTests`** (全面改訂):
  - 新 API: Context なし → GuiOperator フォールバック
  - 新 API: Context あり → Context 値を使用
  - **なりすまし防止 3 ケース** (Issue #1265 の核心):
    - Context 設定中に偽 IDm を旧 API で渡しても Context が優先
    - Context 未設定で偽 IDm を渡しても GuiOperator フォールバック（引数は無視）
    - Context 失効後も偽 IDm 引数は無視
  - 旧 API → 新 API 委譲の後方互換
  - 13 種類のログ記録（Staff / Card / Ledger × Insert / Update / Delete / Restore / Merge / Split）
- **既存テスト 8 ファイル**: `Mock<OperationLogger>` のコンストラクタ引数を `Mock.Of<ICurrentOperatorContext>()` に差し替え

### ドキュメント
- `docs/design/05_クラス設計書.md`:
  - §5.17a `CurrentOperatorContext` を新設
  - `StaffAuthService` に `ICurrentOperatorContext` 依存と `BeginSession()` 連携を追記
  - サービス一覧表と DI 登録セクションに `ICurrentOperatorContext` を追記
- `docs/design/07_テスト設計書.md`:
  - `UT-AUDIT-001: CurrentOperatorContext`（10 ケース）を追加
  - `UT-AUDIT-002: OperationLogger なりすまし防止`（8 ケース）を追加
- `CHANGELOG.md`: Unreleased セキュリティ修正として記載

## 検証

- `dotnet build`: **0 警告、0 エラー**
- `dotnet test`: **全 2521 テスト合格、失敗なし**

## 後方互換性

呼び出し側の 20+ callsite（ViewModels / Services）は変更不要。旧 API が `[Obsolete]` 警告で移行を促しつつ、引数を無視して Context から解決する。

Follow-up PR として、callsite 側で新 API への段階的移行（`_operatorIdm` フィールド削除、Service 層の `operatorIdm` パラメータ削除）を予定。

## セキュリティ影響

本修正により以下の攻撃シナリオが遮断される:
1. ✅ 内部者が他職員の IDm を偽って監査ログを記録（引数経由）
2. ✅ 認証をスキップして任意の操作者名でログ挿入
3. ✅ 認証済みセッション失効後の継続利用

Closes #1265

## 既知の範囲外（本 PR 対象外）

現在 `operation_log` はレコード単位の INSERT/UPDATE/DELETE/RESTORE/MERGE/SPLIT のみを記録しており、**CSV インポート/エクスポート/バックアップ/リストアは記録対象外**。本 PR のなりすまし防止とは独立した監査証跡の抜け漏れのため、別 Issue #1302 で対応予定。

## Test plan
- [x] `dotnet build` で 0 エラー
- [x] `dotnet test` で 2521 テスト全 Green
- [x] 手動確認: 職員管理画面での削除操作（認証ダイアログ → 削除 → 操作ログが認証操作者で記録されること）
- [x] 手動確認: 職員・カードの新規登録・編集・復元、および帳簿行の追加・編集（いずれも認証不要の GUI 操作）の操作ログが「GUI操作」で記録されること
- [x] 手動確認: 認証後に Ledger 削除を実行し、操作ログに認証した職員の IDm/氏名が記録されること
- [x] 手動確認: 認証から 5 分以上経過後の操作ログが「GUI操作」にフォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
