### PR TITLE
docs: 開発者ガイドのバージョンと構造を v2.7.0 に同期 (#1242)

### DIFF
--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -1,7 +1,7 @@
 # 交通系ICカード管理システム：ピッすい 開発者ガイド
 
-**バージョン**: 2.4.2
-**最終更新日**: 2026年4月
+**バージョン**: 2.7.0
+**最終更新日**: 2026年4月15日
 
 ---
 
@@ -59,16 +59,23 @@ graph LR
 
 ### 1.3 技術スタック
 
-| カテゴリ | 技術 | バージョン |
-|----------|------|------------|
-| 言語 | C# | 10 |
-| フレームワーク | .NET Framework | 4.8 |
-| UIフレームワーク | WPF | - |
-| MVVMツールキット | CommunityToolkit.Mvvm | 8.x |
-| データベース | SQLite (System.Data.SQLite.Core) | 3.x |
-| ICカード | FelicaLib.DotNet | 1.2.x |
-| Excel出力 | ClosedXML | 0.102.x |
-| ロギング | Microsoft.Extensions.Logging | 3.1.x |
+| カテゴリ | 技術 | バージョン | 備考 |
+|----------|------|------------|------|
+| 言語 | C# | 10 | `<LangVersion>10.0</LangVersion>` |
+| フレームワーク | .NET Framework | 4.8 | `<TargetFramework>net48</TargetFramework>` |
+| プラットフォームターゲット | x86 | - | felicalib.dll が x86 のため |
+| UIフレームワーク | WPF | - | `<UseWPF>true</UseWPF>` |
+| MVVMツールキット | CommunityToolkit.Mvvm | 8.2.2 | `[ObservableProperty]` / `[RelayCommand]` ソースジェネレータ |
+| データベース | System.Data.SQLite.Core | 1.0.119 | SQLite 3 系 |
+| ICカード | FelicaLib.DotNet | 1.2.67 | + `felicalib.dll`（ネイティブ） |
+| Excel出力 | ClosedXML | 0.105.0 | |
+| DIコンテナ | Microsoft.Extensions.DependencyInjection | 8.0.1 | |
+| ロギング | Microsoft.Extensions.Logging | 8.0.1 | |
+| メモリキャッシュ | Microsoft.Extensions.Caching.Memory | 8.0.1 | CVE-2024-43485 修正済み |
+| 設定ファイル | Microsoft.Extensions.Configuration.Json | 8.0.1 | `appsettings.json` 読み込み |
+| テストフレームワーク | xUnit + FluentAssertions + Moq | - | |
+
+> **NuGet ロックファイル**: `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` を有効化し、`packages.lock.json` で推移的依存のバージョンを固定している（サプライチェーン攻撃対策）。
 
 ---
 
@@ -125,46 +132,76 @@ graph TB
 ```
 ICCardManager/
 ├── ICCardManager.sln
+├── Directory.Build.props                # 全プロジェクト共通のビルド設定（LangVersion 等）
 ├── src/
 │   └── ICCardManager/
-│       ├── App.xaml(.cs)               # アプリケーションエントリポイント・DI設定
-│       ├── Views/                      # View層（XAML）
-│       │   ├── MainWindow.xaml         # メイン画面
-│       │   ├── Dialogs/                # ダイアログ
-│       │   └── Controls/               # カスタムコントロール
-│       ├── ViewModels/                 # ViewModel層
-│       │   ├── ViewModelBase.cs        # 基底クラス
-│       │   └── *.cs
-│       ├── Models/                     # エンティティ
-│       │   ├── Staff.cs
-│       │   ├── IcCard.cs
-│       │   └── Ledger.cs
-│       ├── Services/                   # ビジネスロジック
-│       │   ├── LendingService.cs       # 貸出・返却
-│       │   ├── ReportService.cs        # 帳票作成
-│       │   ├── ValidationService.cs    # 入力検証
-│       │   ├── InputSanitizer.cs       # 入力サニタイズ
+│       ├── App.xaml(.cs)                # アプリケーションエントリポイント・DI 設定
+│       ├── appsettings.json             # 設定（AppOptions, CacheOptions, Logging 等）
+│       ├── Views/                       # View 層（XAML）
+│       │   ├── MainWindow.xaml          # メイン画面
+│       │   ├── Dialogs/                 # ダイアログ（職員管理、カード管理、設定、帳票、履歴編集 等）
+│       │   ├── Converters/              # IValueConverter 実装（IntToVisibility など）
+│       │   └── Helpers/                 # View 専用ヘルパ
+│       ├── ViewModels/                  # ViewModel 層
+│       │   ├── ViewModelBase.cs         # 基底クラス（IsBusy / BusyMessage）
+│       │   └── *.cs                     # 画面ごとの ViewModel
+│       ├── Models/                      # エンティティ（DB テーブル対応）
+│       │   ├── Staff.cs / IcCard.cs / Ledger.cs / LedgerDetail.cs
+│       │   ├── OperationLog.cs / AppSettings.cs
 │       │   └── ...
-│       ├── Data/                       # データアクセス層
-│       │   ├── DbContext.cs            # DB接続管理
-│       │   ├── Repositories/           # リポジトリ
-│       │   ├── Migrations/             # DBマイグレーション
-│       │   └── schema.sql              # スキーマ定義
-│       ├── Infrastructure/             # インフラストラクチャ
-│       │   ├── CardReader/             # ICカードリーダー
-│       │   ├── Sound/                  # 音声再生
-│       │   ├── Caching/                # キャッシュ
-│       │   └── Logging/                # ログ
-│       ├── Common/                     # 共通ユーティリティ
-│       │   ├── Enums.cs
-│       │   └── Exceptions/
-│       └── Resources/                  # リソース
-│           ├── Sounds/
-│           └── Templates/
+│       ├── Dtos/                        # View 向け DTO / Mapper（#1222 でサービス境界を明確化）
+│       │   ├── CardDto.cs / StaffDto.cs / LedgerDto.cs / LedgerDetailDto.cs
+│       │   └── DtoMapper.cs
+│       ├── Services/                    # ビジネスロジック
+│       │   ├── LendingService.cs        # 貸出・返却・30秒ルール
+│       │   ├── ReportService.cs         # 月次帳票生成
+│       │   ├── ReportDataBuilder.cs     # 帳票共通データ構築
+│       │   ├── SummaryGenerator.cs      # 摘要文字列生成
+│       │   ├── LedgerMergeService.cs    # 履歴統合・取消（#548）
+│       │   ├── LedgerSplitService.cs    # 履歴分割（#634）
+│       │   ├── OperationLogger.cs       # 監査ログ記録
+│       │   ├── ValidationService.cs / InputSanitizer.cs
+│       │   ├── SharedModeMonitor.cs     # 共有モード監視（ヘルスチェック・同期表示）
+│       │   ├── CardLockManager.cs       # カードアクセスの排他制御
+│       │   ├── StaffAuthService.cs      # 職員証による操作者認証（#429）
+│       │   ├── NavigationService.cs     # ダイアログ解決・遷移
+│       │   ├── Import/                  # CSV インポートを責務別に partial class 分割（#1223）
+│       │   │   ├── CsvImportService.Card.cs
+│       │   │   ├── CsvImportService.Staff.cs
+│       │   │   ├── CsvImportService.Ledger.cs
+│       │   │   └── CsvImportService.Detail.cs
+│       │   └── ...
+│       ├── Data/                        # データアクセス層
+│       │   ├── DbContext.cs             # DB 接続管理・ConnectionLease / TransactionScope
+│       │   ├── Repositories/            # リポジトリ（ILedgerRepository は CQRS 分離: #1224）
+│       │   ├── Migrations/              # DB マイグレーション（#001〜#009）
+│       │   └── schema.sql               # 初期スキーマ（埋め込みリソース）
+│       ├── Infrastructure/              # インフラストラクチャ
+│       │   ├── CardReader/              # ICカードリーダー（Felica, Hybrid, Mock）
+│       │   ├── Sound/                   # 音声再生
+│       │   ├── Caching/                 # キャッシュ
+│       │   ├── Timing/                  # ISystemClock / ITimerFactory / IDispatcherService（#1228）
+│       │   └── Logging/                 # FileLogger
+│       ├── Common/                      # 共通ユーティリティ
+│       │   ├── Enums.cs / PathValidator.cs / FiscalYearHelper.cs
+│       │   ├── Exceptions/              # AppException / DatabaseException 等
+│       │   ├── Messages/                # WeakReferenceMessenger 用メッセージ（#852）
+│       │   └── ValueObjects/            # Value Objects（#1221）: CardIdm, StaffIdm, FiscalYear, Money
+│       └── Resources/                   # リソース
+│           ├── Sounds/                  # ピッ/ピピッ/エラー等の音声
+│           ├── Styles/                  # XAML スタイル（AccessibilityStyles.xaml 等）
+│           └── Templates/               # 物品出納簿 Excel テンプレート
 ├── tests/
-│   └── ICCardManager.Tests/            # ユニットテスト
-└── docs/                               # ドキュメント
+│   ├── ICCardManager.Tests/             # ユニットテスト
+│   └── ICCardManager.UITests/           # UI 統合テスト
+├── installer/                           # InnoSetup インストーラー（.iss）
+├── publish/                             # 配布ビルド出力
+└── docs/                                # ドキュメント（設計書・マニュアル）
+    ├── design/                          # 01〜08 設計書
+    └── manual/                          # ユーザー / 管理者 / 開発者ガイド
 ```
+
+> **refactor 履歴（v2.5.0〜v2.7.0）**: `MainViewModel` からのサービス抽出（#1222）、`CsvImportService` の partial class 分割（#1223）、`LedgerRepository` のインターフェース階層分離（#1224）、`ISystemClock` 導入によるテスト容易化（#1228）、Value Object 化（#1221）により、責務分離が進んでいる。詳細は §2.5 「アーキテクチャの発展」を参照。
 
 ### 2.3 依存性注入（DI）
 
@@ -228,18 +265,129 @@ private void ConfigureServices(IServiceCollection services)
 
 ### 2.4 インターフェース一覧
 
+主要なインターフェースをレイヤーごとに整理する。新規開発者はこの表から「どのレイヤに何があるか」の全体像を把握してほしい。
+
+#### Infrastructure 層
+
 | インターフェース | 実装クラス | 責務 |
 |------------------|------------|------|
-| ICardReader | FelicaCardReader, HybridCardReader(DEBUG), MockCardReader(DEBUG) | ICカード読み取り |
-| ISoundPlayer | SoundPlayer | 操作音再生 |
-| ICacheService | CacheService | データキャッシュ |
-| IValidationService | ValidationService | 入力検証 |
+| ICardReader | FelicaCardReader, HybridCardReader (DEBUG), MockCardReader (DEBUG) | ICカード読み取り |
+| ISoundPlayer | SoundPlayer | 操作音再生（ピッ / ピピッ / エラー / VOICEVOX 音声） |
+| ICacheService | CacheService | データキャッシュ（共有モードでは TTL を短縮） |
+| ISystemClock | SystemClock | 現在時刻の抽象化（#1228）。テストでは FakeClock を注入して時間依存ロジックを検証 |
+| ITimerFactory | DispatcherTimerFactory, TestTimerFactory | `DispatcherTimer` のファクトリ。WPF 文脈外テストを可能にする |
+| ITimer | DispatcherTimerAdapter, TestTimer | タイマ抽象化（Tick / Start / Stop） |
+| IDispatcherService | WpfDispatcherService, SynchronousDispatcherService | UI スレッドへのマーシャリング抽象化 |
+
+#### Data 層
+
+| インターフェース | 実装クラス | 責務 |
+|------------------|------------|------|
 | IStaffRepository | StaffRepository | 職員データアクセス |
 | ICardRepository | CardRepository | カードデータアクセス |
-| ILedgerRepository | LedgerRepository | 履歴データアクセス |
+| ILedgerRepository | LedgerRepository | 履歴データアクセス（下記 ILedgerQueryService / ILedgerMergeRepository を包含: #1224） |
+| ILedgerQueryService | LedgerRepository | 履歴の参照専用インターフェース（CQRS 風分離、#1224） |
+| ILedgerMergeRepository | LedgerRepository | 履歴統合・取消専用インターフェース（#1224） |
 | ISettingsRepository | SettingsRepository | 設定データアクセス |
 | IOperationLogRepository | OperationLogRepository | 操作ログアクセス |
-| IToastNotificationService | ToastNotificationService | トースト通知 |
+| IMigration | Migration_001〜Migration_009 | 各マイグレーションの実装契約 |
+
+#### Service 層
+
+| インターフェース | 実装クラス | 責務 |
+|------------------|------------|------|
+| IValidationService | ValidationService | 入力検証（IDm, 管理番号, 氏名 等） |
+| IStaffAuthService | StaffAuthService | 職員証タッチによる操作者認証（#429） |
+| IDialogService | NavigationService | 確認・警告・モード選択ダイアログの抽象化（テスト容易化） |
+| INavigationService | NavigationService | ダイアログ解決・ウィンドウ遷移 |
+| IStationMasterService | StationMasterService | 駅コードから駅名への解決（シングルトン） |
+| IToastNotificationService | ToastNotificationService | トースト通知の表示 |
+| IReportDataBuilder | ReportDataBuilder | 月次帳票用データ構築（Excel/印刷で共有） |
+| IDatabaseInfo | DbContext | DB 情報（共有モード判定・接続情報）の読み取り専用公開 |
+
+> **クラスのみで提供されている代表例**: `LendingService`, `ReportService`, `BackupService`, `SummaryGenerator`, `LedgerMergeService`, `LedgerSplitService`, `OperationLogger`, `CardLockManager`, `SharedModeMonitor`, `WarningService`, `DashboardService` など。これらはインターフェース未抽出だが、テストでは `Mock<ConcreteClass>` で代替できるよう `virtual` メソッドを中心に設計している。
+
+---
+
+### 2.5 アーキテクチャの発展（v2.5.0〜v2.7.0）
+
+v2.5.0〜v2.7.0 で導入された主要な構造変更は、いずれも **「テスト容易性」** と **「責務分離」** の向上を目的としている。新規開発者はこの節で現在のコード構造の背景を理解してほしい。
+
+#### 2.5.1 Value Object（#1221）
+
+`Common/ValueObjects/` に以下の不変 `readonly struct` を定義し、プリミティブ文字列・整数に型安全性を付与した。
+
+| 構造体 | 責務 | 代表的 API |
+|--------|------|------------|
+| `CardIdm` | 交通系ICカードの IDm（16進数16文字） | コンストラクタで大文字正規化 + 形式検証 / `implicit operator string` |
+| `StaffIdm` | 職員証の IDm（型レベルで CardIdm と区別） | 同上 |
+| `FiscalYear` | 日本の会計年度（4月始まり） | `Contains(DateTime)` / `StartDate` / `EndDate` / `PreviousMonth()` |
+| `Money` | 非負の金額（円） | 加算・比較演算子 / `implicit operator int` |
+
+> `FiscalYearHelper`（静的メソッド群）は互換性のため残存するが、新規コードは `FiscalYear` ValueObject を推奨。
+
+#### 2.5.2 MainViewModel からのサービス抽出（#1222）
+
+巨大化していた `MainViewModel` から以下を抽出し、DbContext への直接依存を排除した。
+
+- `SharedModeMonitor` — 共有モードの同期表示・ヘルスチェック
+- `WarningService` — 残高警告の算出
+- `DashboardService` — ダッシュボードの集計ロジック
+- `LedgerConsistencyChecker` — 残高チェーン整合性検証
+
+#### 2.5.3 CsvImportService の partial class 分割（#1223）
+
+単一ファイル 3,311 行 → 5 ファイルに分割。責務単位で読み解けるようになった。
+
+- `CsvImportService.cs`（共通ロジック）
+- `Services/Import/CsvImportService.Card.cs`
+- `Services/Import/CsvImportService.Staff.cs`
+- `Services/Import/CsvImportService.Ledger.cs`
+- `Services/Import/CsvImportService.Detail.cs`
+
+#### 2.5.4 LedgerRepository のインターフェース階層分離（#1224）
+
+巨大化していた `ILedgerRepository` を **CQRS（コマンド・クエリ分離）風** に以下へ分割した。
+
+- `ILedgerQueryService` — 参照系メソッド
+- `ILedgerMergeRepository` — 履歴統合・取消
+- `ILedgerRepository` — 上記を継承する包括インターフェース
+
+> 新しい書き込み系メソッドを追加する場合、まず `ILedgerQueryService` ではなく `ILedgerRepository` に足すこと。既存 ViewModel 側は `ILedgerRepository` を注入しているので、互換性は保たれる。
+
+#### 2.5.5 ISystemClock による時間依存テストの容易化（#1228）
+
+`DateTime.Now` を直接呼び出す代わりに、`ISystemClock` を DI 経由で注入する。
+
+```csharp
+// 本番: Singleton 登録された SystemClock が DateTime.Now を返す
+services.AddSingleton<ISystemClock, SystemClock>();
+
+// テスト: FakeClock で時刻を制御
+public class FakeClock : ISystemClock
+{
+    public DateTime Now { get; set; } = new DateTime(2026, 4, 12);
+}
+```
+
+これにより `MainViewModelSyncDisplayTests` などの時間依存テストはリフレクション不要で決定論的に書ける。
+
+#### 2.5.6 DbContext の並行アクセス保護（#1165, #1209）
+
+`GetConnection()` を非推奨（`[Obsolete]`）化し、以下のスコープベース API に統一中。
+
+```csharp
+// 非同期：推奨
+using var lease = await _dbContext.LeaseConnectionAsync();
+var connection = lease.Connection;
+
+// トランザクション：TransactionScope.Dispose() で自動ロールバック
+using var scope = await _dbContext.BeginTransactionAsync();
+// ... 処理 ...
+await scope.CommitAsync();
+```
+
+`ConnectionLease` が内部でセマフォによる排他を行い、複数スレッドから安全にアクセスできる。共有モードでも `busy_timeout=5000` と組み合わせて耐障害性を確保している。
 
 ---
 
@@ -273,6 +421,12 @@ erDiagram
         INTEGER is_lent "貸出状態"
         TEXT last_lent_at "最終貸出日時"
         TEXT last_lent_staff FK "最終貸出者"
+        INTEGER starting_page_number "帳票開始ページ(#005)"
+        INTEGER is_refunded "払戻済フラグ(#006)"
+        TEXT refunded_at "払戻日時(#006)"
+        INTEGER carryover_income_total "年度途中導入時の累計受入(#009)"
+        INTEGER carryover_expense_total "年度途中導入時の累計払出(#009)"
+        INTEGER carryover_fiscal_year "繰越起算年度(#009)"
     }
 
     ledger {
@@ -301,8 +455,11 @@ erDiagram
         INTEGER amount "金額"
         INTEGER balance "残額"
         INTEGER is_charge "チャージフラグ"
-        INTEGER is_point_redemption "ポイント還元フラグ"
+        INTEGER is_point_redemption "ポイント還元フラグ(#002)"
         INTEGER is_bus "バス利用フラグ"
+        INTEGER group_id "乗換統合グループID(#003)"
+        INTEGER sequence_number "表示順序"
+        BLOB raw_bytes "FeliCa 生バイト列(デバッグ用)"
     }
 
     operation_log {
@@ -338,17 +495,23 @@ erDiagram
 
 #### ic_cardテーブル（ICカードマスタ）
 
-| カラム | 型 | NULL | 説明 |
-|--------|-----|------|------|
-| card_idm | TEXT | × | カードIDm（PK、16進数16文字） |
-| card_type | TEXT | × | カード種別（はやかけん、nimoca等） |
-| card_number | TEXT | × | 管理番号 |
-| note | TEXT | ○ | 備考 |
-| is_deleted | INTEGER | × | 削除フラグ |
-| deleted_at | TEXT | ○ | 削除日時 |
-| is_lent | INTEGER | × | 貸出状態（0:未貸出、1:貸出中） |
-| last_lent_at | TEXT | ○ | 最終貸出日時 |
-| last_lent_staff | TEXT | ○ | 最終貸出者IDm（FK→staff） |
+| カラム | 型 | NULL | 説明 | 導入 |
+|--------|-----|------|------|------|
+| card_idm | TEXT | × | カードIDm（PK、16進数16文字） | #001 |
+| card_type | TEXT | × | カード種別（はやかけん、nimoca等） | #001 |
+| card_number | TEXT | × | 管理番号（カード種別内で一意、UNIQUE INDEX） | #001/#008 |
+| note | TEXT | ○ | 備考 | #001 |
+| is_deleted | INTEGER | × | 削除フラグ（DEFAULT 0） | #001 |
+| deleted_at | TEXT | ○ | 削除日時 | #001 |
+| is_lent | INTEGER | × | 貸出状態（0:未貸出、1:貸出中、DEFAULT 0） | #001 |
+| last_lent_at | TEXT | ○ | 最終貸出日時 | #001 |
+| last_lent_staff | TEXT | ○ | 最終貸出者IDm（FK→staff） | #001 |
+| starting_page_number | INTEGER | × | 帳票開始ページ番号（DEFAULT 1） | #005 |
+| is_refunded | INTEGER | × | 払戻済フラグ（DEFAULT 0） | #006 |
+| refunded_at | TEXT | ○ | 払戻日時 | #006 |
+| carryover_income_total | INTEGER | × | 年度途中導入時の累計受入（DEFAULT 0） | #009 |
+| carryover_expense_total | INTEGER | × | 年度途中導入時の累計払出（DEFAULT 0） | #009 |
+| carryover_fiscal_year | INTEGER | ○ | 繰越起算年度（NULL=該当なし） | #009 |
 
 #### ledgerテーブル（出納記録）
 
@@ -371,18 +534,21 @@ erDiagram
 
 #### ledger_detailテーブル（出納詳細）
 
-| カラム | 型 | NULL | 説明 |
-|--------|-----|------|------|
-| ledger_id | INTEGER | × | 親ID（FK→ledger、CASCADE DELETE） |
-| use_date | TEXT | ○ | 利用日時 |
-| entry_station | TEXT | ○ | 乗車駅 |
-| exit_station | TEXT | ○ | 降車駅 |
-| bus_stops | TEXT | ○ | バス停名（手入力） |
-| amount | INTEGER | ○ | 金額 |
-| balance | INTEGER | ○ | 残額 |
-| is_charge | INTEGER | × | チャージフラグ |
-| is_point_redemption | INTEGER | × | ポイント還元フラグ |
-| is_bus | INTEGER | × | バス利用フラグ |
+| カラム | 型 | NULL | 説明 | 導入 |
+|--------|-----|------|------|------|
+| ledger_id | INTEGER | × | 親ID（FK→ledger、CASCADE DELETE） | #001 |
+| use_date | TEXT | ○ | 利用日時 | #001 |
+| entry_station | TEXT | ○ | 乗車駅 | #001 |
+| exit_station | TEXT | ○ | 降車駅 | #001 |
+| bus_stops | TEXT | ○ | バス停名（カンマ区切り、手入力） | #001 |
+| amount | INTEGER | ○ | 金額 | #001 |
+| balance | INTEGER | ○ | 残額 | #001 |
+| is_charge | INTEGER | × | チャージフラグ（DEFAULT 0） | #001 |
+| is_point_redemption | INTEGER | × | ポイント還元フラグ（DEFAULT 0） | #002 |
+| is_bus | INTEGER | × | バス利用フラグ（DEFAULT 0） | #001 |
+| group_id | INTEGER | ○ | 乗換統合グループ ID（null=自動判定、非null=手動分割） | #003 |
+| sequence_number | INTEGER | × | 同一 ledger 内の表示順序（DEFAULT 0） | #001 |
+| raw_bytes | BLOB | ○ | FeliCa 履歴の生バイト列（デバッグ用途） | #001 |
 
 #### operation_logテーブル（操作ログ）
 
@@ -441,15 +607,17 @@ sequenceDiagram
 
 **適用済みマイグレーション一覧**:
 
-| バージョン | クラス名 | 内容 |
-|-----------|---------|------|
-| 1 | Migration_001_Initial | 初期スキーマ作成 |
-| 2 | Migration_002_AddPointRedemption | ledger_detailにis_point_redemption列追加 |
-| 3 | Migration_003_AddTripGroupId | ledger_detailにgroup_id列追加（乗換統合用） |
-| 4 | Migration_004_AddPerformanceIndexes | パフォーマンス向上のためのインデックス追加 |
-| 5 | Migration_005_AddStartingPageNumber | ic_cardにstarting_page_number列追加（帳票開始ページ） |
-| 6 | Migration_006_AddRefundedStatus | ic_cardにis_refunded, refunded_at列追加（払戻済状態） |
-| 7 | Migration_007_AddMergeHistory | ledger_merge_historyテーブル追加（統合取り消し用） |
+| バージョン | クラス名 | 内容 | 関連 Issue/PR |
+|-----------|---------|------|----------------|
+| 1 | Migration_001_Initial | 初期スキーマ作成 | - |
+| 2 | Migration_002_AddPointRedemption | ledger_detail に `is_point_redemption` 列追加 | - |
+| 3 | Migration_003_AddTripGroupId | ledger_detail に `group_id` 列追加（乗換統合用） | - |
+| 4 | Migration_004_AddPerformanceIndexes | パフォーマンス向上のためのインデックス追加 | - |
+| 5 | Migration_005_AddStartingPageNumber | ic_card に `starting_page_number` 列追加（帳票開始ページ、DEFAULT 1） | - |
+| 6 | Migration_006_AddRefundedStatus | ic_card に `is_refunded` (DEFAULT 0) / `refunded_at` 列追加（払戻済状態） | - |
+| 7 | Migration_007_AddMergeHistory | ledger_merge_history テーブル追加（統合取り消し用） | #548 |
+| 8 | Migration_008_AddCardTypeNumberUniqueIndex | `(card_type, card_number)` に UNIQUE INDEX を追加（採番競合防止） | #1106 |
+| 9 | Migration_009_AddCarryoverTotals | ic_card に `carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` 列追加（年度途中導入対応） | #1215 |
 
 **新規マイグレーションの追加手順**:
 
@@ -543,12 +711,81 @@ public partial class MyViewModel : ViewModelBase
 ```
 
 **プロパティ変更通知**:
-- `[ObservableProperty]` 属性を使用
+- `[ObservableProperty]` 属性を使用（`CommunityToolkit.Mvvm` 8.2.2 のソースジェネレータ）
 - 複雑なロジックが必要な場合は `SetProperty()` を直接使用
 
 **コマンド**:
 - `[RelayCommand]` 属性を使用
 - 非同期コマンドには `Async` サフィックスを付ける
+
+**On*Changed コールバック**:
+
+`[ObservableProperty]` は `partial void On<Name>Changed(newValue)` / `partial void On<Name>Changing(oldValue, newValue)` のフックメソッドを自動生成する。プロパティ変更に伴う派生処理はこのフックに書く。
+
+```csharp
+public partial class CardManageViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string _editCardType = "nimoca";
+
+    // _editCardType の変更に追随して再検証
+    partial void OnEditCardTypeChanged(string value)
+    {
+        if (!_isInitializing)
+        {
+            RevalidateCardNumber();
+        }
+    }
+}
+```
+
+**カスケード実行の抑制**:
+
+ViewModel の初期化で複数プロパティを連続設定すると、`On*Changed` が多重に発火して副作用が重なることがある。このようなケースでは `_isInitializing` フラグでガードする。
+
+```csharp
+public MyViewModel(...)
+{
+    _isInitializing = true;
+    try
+    {
+        // ここで複数プロパティを設定しても副作用を抑制
+        UserId = 42;
+        UserName = "初期値";
+    }
+    finally
+    {
+        _isInitializing = false;
+    }
+}
+```
+
+> メイン画面のように `[ObservableProperty]` が 30 個超あるケースでは、初期化順序・カスケードを意識して実装すること。`MainViewModel` はこのパターンを採用している。
+
+### 4.6 Value Objects の使用（#1221）
+
+プリミティブ型（`string`, `int`）の代わりに、`Common/ValueObjects/` 配下の `readonly struct` を積極的に利用する。**型レベルで意味が分離されるため、`CardIdm` を期待する引数に `StaffIdm` を渡すとコンパイルエラーになる**。
+
+```csharp
+// Good: Value Object で意図が明確・取り違えを防止
+public async Task<IcCard?> GetCardAsync(CardIdm idm)
+{
+    return await _repository.GetByIdmAsync(idm);  // implicit operator string で透過的に DB に渡る
+}
+
+// Bad: 生の string では StaffIdm を誤って渡せてしまう
+public async Task<IcCard?> GetCardAsync(string idm) { ... }
+```
+
+`FiscalYear` は年度境界判定・月の列挙をカプセル化する。`FiscalYearHelper` の静的メソッドは互換性のため残っているが、新規コードは `FiscalYear` を推奨。
+
+```csharp
+var fiscalYear = new FiscalYear(2026);
+if (fiscalYear.Contains(DateTime.Today))
+{
+    // 2026年4月〜2027年3月の範囲
+}
+```
 
 ### 4.5 コメント・ドキュメント
 
@@ -908,6 +1145,57 @@ public class RepositoryTests : IDisposable
 }
 ```
 
+### 7.6 時間依存テスト（ISystemClock / FakeClock）
+
+時刻に依存するロジック（30秒ルール、共有モード同期表示、失効判定など）は `DateTime.Now` を直接使わず `ISystemClock` を注入してテストする（#1228）。
+
+```csharp
+public class MyViewModelTests
+{
+    private class FakeClock : ISystemClock
+    {
+        public DateTime Now { get; set; } = new DateTime(2026, 4, 12, 10, 0, 0);
+    }
+
+    [Fact]
+    public void 30秒経過後の挙動()
+    {
+        var clock = new FakeClock();
+        var viewModel = new MyViewModel(clock);
+
+        viewModel.StartOperation();
+
+        // 時刻を 31 秒進めて「30秒ルール」の境界を検証
+        clock.Now = clock.Now.AddSeconds(31);
+        viewModel.OnTimerTick();
+
+        viewModel.IsExpired.Should().BeTrue();
+    }
+}
+```
+
+> `Mock<ISystemClock>` でも代用できるが、戻り値を動的に変化させるケースでは `FakeClock` の方が読みやすい。既存テストは両方のパターンが混在している。
+
+### 7.7 WPF コンテキスト外での ViewModel テスト
+
+`DispatcherTimer` や `Dispatcher.Invoke` を直接使う ViewModel は WPF UI スレッドがないテスト環境では動かない。このため、抽象化を DI 経由で差し替える。
+
+- `ITimerFactory` → `TestTimerFactory`（Tick を手動でトリガ可能）
+- `IDispatcherService` → `SynchronousDispatcherService`（同期実行）
+
+```csharp
+var timerFactory = new TestTimerFactory();
+var dispatcher = new SynchronousDispatcherService();
+var viewModel = new MainViewModel(..., timerFactory, dispatcher);
+
+// Tick を手動トリガ
+timerFactory.LastTimer.Trigger();
+```
+
+### 7.8 InternalsVisibleTo
+
+`ICCardManager.csproj` で `ICCardManager.Tests` を `InternalsVisibleTo` 指定しているため、`internal` メソッドもテストから直接呼び出せる。純粋関数はあえて `internal` にして、public API を汚さずにテストカバレッジを拡張するのが本プロジェクトの方針。
+
 ---
 
 ## 8. ビルドとデプロイ
@@ -1008,13 +1296,20 @@ dotnet test /p:CollectCoverage=true
 
 | ドキュメント | 内容 |
 |--------------|------|
-| CLAUDE.md | 開発ガイド（簡易版） |
+| CLAUDE.md | 開発ガイド（簡易版）・必読ルール集 |
+| CHANGELOG.md | バージョン履歴（変更内容の正） |
+| docs/design/00_用語集.md | 業務用語・システム用語の一覧 |
+| docs/design/00a_技術スタック用語集.md | 初学者向け技術スタック解説（#1231） |
 | docs/design/01_システム概要設計書.md | システム概要 |
 | docs/design/02_DB設計書.md | データベース設計 |
 | docs/design/03_画面設計書.md | UI設計 |
 | docs/design/04_機能設計書.md | 機能仕様 |
 | docs/design/05_クラス設計書.md | クラス設計 |
 | docs/design/06_シーケンス図.md | 処理フロー |
+| docs/design/07_テスト設計書.md | テストケース一覧・テスト戦略 |
+| docs/design/08_ドキュメント設計書.md | ドキュメント管理方針 |
+| docs/DISTRIBUTION.md | リリース手順・配布方法 |
+| docs/THIRD_PARTY_LICENSES.md | サードパーティライブラリ / 音声素材のライセンス一覧 |
 
 ### C. トラブルシューティング
 


### PR DESCRIPTION
## 概要

Issue #1242 の対応。`docs/manual/開発者ガイド.md` がバージョン 2.4.2（2026 年 4 月）のまま停止しており、実装の v2.7.0 と乖離していた。主要な refactor PR（#1221〜#1228）や v2.5.0〜v2.7.0 で導入された構造変更を反映する。

## 変更内容

### ヘッダー・メタ情報
- バージョン: 2.4.2 → **2.7.0**
- 最終更新日: 2026 年 4 月 → **2026 年 4 月 15 日**

### 技術スタック表（§1.3）
実 `ICCardManager.csproj` の値に同期：
- `ClosedXML` 0.102.x → **0.105.0**
- `Microsoft.Extensions.Logging` 3.1.x → **8.0.1**
- `CommunityToolkit.Mvvm` 8.x → **8.2.2**
- `System.Data.SQLite.Core`, `FelicaLib.DotNet`, `Microsoft.Extensions.Caching.Memory`, `Microsoft.Extensions.Configuration.Json`, DI コンテナを追記
- NuGet ロックファイル運用（サプライチェーン攻撃対策）を補足

### ディレクトリ構造（§2.2）
- 新規追加: `Common/ValueObjects/`（#1221）、`Common/Messages/`（#852）、`Dtos/`、`Services/Import/`（#1223）、`Infrastructure/Timing/`（#1228）、`Views/Converters/`、`Views/Helpers/`、`Resources/Styles/`
- 主要ファイル名を明記（LendingService / ReportService / SharedModeMonitor / NavigationService 等）
- refactor 履歴を §2.5 に誘導するサマリ追加

### インターフェース一覧（§2.4 拡充）
Infrastructure / Data / Service 層にグループ化し、以下を追記：
- `ISystemClock` / `ITimerFactory` / `IDispatcherService`（#1228）
- `IDialogService` / `INavigationService`
- `IStaffAuthService`（#429）
- `IDatabaseInfo`、`IStationMasterService`、`IReportDataBuilder`
- `ILedgerQueryService` / `ILedgerMergeRepository`（#1224 CQRS 分離）
- 各 `IMigration`

### 新設: §2.5 アーキテクチャの発展
v2.5.0〜v2.7.0 の主要 refactor を開発者が学習しやすい順で整理：
1. **Value Object（#1221）**: CardIdm / StaffIdm / FiscalYear / Money
2. **MainViewModel からのサービス抽出（#1222）**: SharedModeMonitor / WarningService / DashboardService / LedgerConsistencyChecker
3. **CsvImportService の partial class 分割（#1223）**: 3,311 行 → 5 ファイル
4. **LedgerRepository の CQRS 風分離（#1224）**
5. **ISystemClock によるテスト容易化（#1228）**
6. **DbContext の ConnectionLease / TransactionScope パターン（#1165, #1209）**

### コーディング規約の追記
- §4.4 **MVVM パターン拡充**: `partial void On<Name>Changed` コールバックの活用、`_isInitializing` ガードで初期化カスケードを抑制するパターン
- §4.6 **Value Objects の使用**（新設）: 型レベルでの取り違え防止と `FiscalYear` の使用例

### DB 構成（§3）
ER 図と各テーブル定義を実スキーマに同期：
- `ic_card`: `starting_page_number`（#005）/ `is_refunded` / `refunded_at`（#006）/ `carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year`（#009）を追記
- `ledger_detail`: `group_id`（#003）/ `sequence_number` / `raw_bytes` を追記
- マイグレーション表に **#008 AddCardTypeNumberUniqueIndex**（#1106）と **#009 AddCarryoverTotals**（#1215）を追加
- 各カラム・各マイグレーションに **導入 PR/Issue** 番号を明記

### テスト規約の拡充（§7）
- §7.6 **時間依存テスト（ISystemClock / FakeClock）**（新設）
- §7.7 **WPF コンテキスト外での ViewModel テスト**（新設）: TestTimerFactory / SynchronousDispatcherService
- §7.8 **InternalsVisibleTo**（新設）: `internal` メソッドのテスト方針

### 付録 B 参照ドキュメント
設計書を 01〜08 の全域 + 00 用語集 / 00a 技術スタック用語集に拡張、CHANGELOG、DISTRIBUTION、THIRD_PARTY_LICENSES も追記。

## 検証

- **変更規模**: 1 ファイル、+383 / -88 行（総 1,030 → 1,325 行）
- **ビルド影響**: なし（ドキュメントのみ）
- **既存テスト**: 影響なし
- **単体テスト**: ドキュメント変更のため不要

## 手動確認いただきたい項目

以下はドキュメントの**正確性**を確認していただきたい点です：

- [ ] §2.2 ディレクトリ構造が実際のワークスペース配置と一致しているか
- [ ] §2.4 インターフェース一覧に漏れ・誤った実装クラス記載がないか
- [ ] §2.5 アーキテクチャの発展に記載した refactor PR 番号（#1221〜#1228 等）が正しいか
- [ ] §3.1/§3.2 の DB ER 図とカラム表が `Data/schema.sql` および Migration_005/006/009 と一致しているか
- [ ] §3.5 マイグレーション表に抜けがないか（現状 9 件まで記載）

## 関連 Issue

- Closes #1242
- 参考元 PR: #1221（Value Object）、#1222（MainViewModel 分割）、#1223（CsvImportService 分割）、#1224（LedgerRepository CQRS 分離）、#1228（ISystemClock）
- PR #1215（carryover 導入）、#1106（UNIQUE INDEX 追加）

## Test plan
- [x] Markdown 構文エラーなし（Mermaid ダイアグラム含む）
- [x] マニュアル変換スクリプト（`docs/manual/convert-to-pdf.ps1` / `convert-to-docx.ps1`）で正しく PDF/DOCX 化できる（Windows 環境で要確認）
- [ ] 実際の `docs/manual/開発者ガイド.md` を読み、用語・構造が現行コードベースと整合しているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)