### PR TITLE
docs: 05_クラス設計書に TransactionScope / ConnectionLease 系を追記 (#1243)

### DIFF
--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -275,6 +275,15 @@ graph TB
 | ISettingsRepository | SettingsRepository | 設定データのCRUD |
 | IOperationLogRepository | OperationLogRepository | 操作ログのCRUD |
 
+#### DbContext と接続リース系クラス
+
+| クラス | 責務 |
+|--------|------|
+| DbContext | SQLite 接続の生成・健全性チェック・マイグレーション実行・トランザクション開始 |
+| ConnectionLease | `using` 文で接続を借用し、`Dispose` 時にセマフォを解放するラッパ（→ §5.5b） |
+| TransactionScope | `ConnectionLease` と `SQLiteTransaction` を束ね、`Dispose` 時にトランザクション→リースの順で解放。`Commit` / `Rollback` 未呼出しの場合は自動ロールバック（→ §5.5b） |
+| ConnectionSuspensionScope | リストア中など接続再オープンを禁止したい期間を RAII 的に表現（Issue #1166、→ §5.5b） |
+
 ### 3.5 Infrastructure
 
 | インターフェース | 実装クラス | 責務 |
@@ -485,6 +494,8 @@ classDiagram
 - `StartHealthCheck()`: 共有フォルダモード時のみ、30秒間隔の定期ヘルスチェックタイマーを開始
 - `Vacuum()`: 戻り値を `bool` に変更。共有モードで他PCが接続中の場合はVACUUMが失敗しうるため、失敗時は `false` を返す（例外にしない）
 
+> **接続リース・トランザクションの正しい使い方**: `DbContext` の接続を借りる際は、`using` 文でリースを取得する `LeaseConnectionAsync()` / `BeginTransactionAsync()` を利用する。詳細は [§5.5b 接続リース・トランザクションスコープ](#55b-接続リーストランザクションスコープissue-1243) を参照。
+
 ### 5.5a DatabaseOptions
 
 `appsettings.json` の `DatabaseOptions` セクションからバインドされる構成クラス。
@@ -499,6 +510,148 @@ classDiagram
 | プロパティ | 型 | デフォルト | 説明 |
 |-----------|-----|----------|------|
 | Path | string | 空文字列 | DBファイルのパス。空の場合はローカルデフォルト。UNCパス指定で共有フォルダモード |
+
+### 5.5b 接続リース・トランザクションスコープ（Issue #1243）
+
+`DbContext` の接続ライフサイクルとトランザクション境界を型安全に管理する 3 つの RAII 的ラッパクラス。いずれも `Data/DbContext.cs` に定義される `public sealed class` であり、`using` 文での利用を前提としている。
+
+```mermaid
+classDiagram
+    class ConnectionLease {
+        +SQLiteConnection Connection
+        -Action _onDispose
+        -bool _disposed
+        +Dispose() void
+    }
+
+    class TransactionScope {
+        +ConnectionLease Lease
+        +SQLiteTransaction Transaction
+        -bool _disposed
+        +Commit() void
+        +Rollback() void
+        +Dispose() void
+    }
+
+    class ConnectionSuspensionScope {
+        -DbContext _dbContext
+        -bool _disposed
+        +Dispose() void
+    }
+
+    TransactionScope --> ConnectionLease : holds
+    TransactionScope --> SQLiteTransaction : holds
+    ConnectionSuspensionScope --> DbContext : suspends
+```
+
+#### 責務一覧
+
+| クラス | 責務 | 取得元 | 解放契機 |
+|--------|------|--------|----------|
+| `ConnectionLease` | **接続ライフサイクル管理**: `SQLiteConnection` を貸与し、`Dispose` でセマフォを解放して次の呼び出し者へ譲る | `DbContext.LeaseConnectionAsync()` / `LeaseConnection()` | `using` 文を抜けたとき |
+| `TransactionScope` | **トランザクション境界制御**: `ConnectionLease` と `SQLiteTransaction` を束ね、`Dispose` で**トランザクション→リースの順に**解放する | `DbContext.BeginTransactionAsync()` | `using` 文を抜けたとき |
+| `ConnectionSuspensionScope` | **接続一時停止制御**: リストア中など接続再オープンを禁止したい期間を RAII 的に表現し、`Dispose` で自動的に解除する（Issue #1166） | `DbContext.SuspendConnections()` | `using` 文を抜けたとき |
+
+#### TransactionScope.Dispose() の自動ロールバック仕様
+
+**重要**: `Commit()` も `Rollback()` も呼ばずに `Dispose` された場合、`SQLiteTransaction.Dispose()` は **未コミットのトランザクションを自動的にロールバック** する。このため、例外経路でも明示的な `Rollback()` 呼び出しは不要である。
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Scope as TransactionScope
+    participant Tx as SQLiteTransaction
+    participant Lease as ConnectionLease
+
+    Caller->>Scope: using var scope = await BeginTransactionAsync()
+    Note over Scope: リース + トランザクションを取得
+    Caller->>Scope: （業務処理）
+    alt 正常系
+        Caller->>Scope: scope.Commit()
+        Scope->>Tx: Commit()
+    else 例外発生
+        Note over Caller: 例外でブロック脱出
+        Note over Scope: Commit/Rollback 未呼び出し
+    end
+    Caller->>Scope: Dispose()（using 脱出）
+    Scope->>Tx: Dispose()
+    Note over Tx: 未コミットなら自動ロールバック
+    Scope->>Lease: Dispose()
+    Note over Lease: セマフォを解放
+```
+
+この仕様により、典型的な try/catch 定型文を省略できる:
+
+```csharp
+// ❌ 冗長（Dispose が自動ロールバックする）
+using var scope = await _dbContext.BeginTransactionAsync();
+try
+{
+    // 処理
+    scope.Commit();
+}
+catch
+{
+    scope.Rollback();
+    throw;
+}
+
+// ✅ 簡潔（例外時も Dispose が自動ロールバックする）
+using var scope = await _dbContext.BeginTransactionAsync();
+// 処理
+scope.Commit();
+// 例外時は Commit() が呼ばれないまま using を抜け、自動ロールバック
+```
+
+#### 典型的な使用パターン
+
+**1. 読み取り専用の接続借用（単発クエリ）**
+
+```csharp
+using var lease = await _dbContext.LeaseConnectionAsync();
+var connection = lease.Connection;
+
+using var command = connection.CreateCommand();
+command.CommandText = "SELECT value FROM settings WHERE key = @key";
+command.Parameters.AddWithValue("@key", key);
+return (string?)await command.ExecuteScalarAsync();
+// using 脱出時にリースを解放、セマフォ返却
+```
+
+**2. 複数操作を 1 トランザクションで実行（書き込み系の推奨形）**
+
+```csharp
+await _dbContext.ExecuteWithRetryAsync(async () =>
+{
+    using var scope = await _dbContext.BeginTransactionAsync();
+
+    await SetAsync(KeyWarningBalance, settings.WarningBalance.ToString());
+    await SetAsync(KeyFontSize, FontSizeToString(settings.FontSize));
+    // ...複数のキー更新...
+
+    scope.Commit();
+    // 例外発生時は Commit() に到達せず Dispose で自動ロールバック
+});
+```
+
+`ExecuteWithRetryAsync` と組み合わせることで、`SQLITE_BUSY` / `SQLITE_LOCKED` 発生時に指数バックオフ + ジッター付きでリトライする（共有モードでは最大 5 回）。
+
+**3. 接続の一時停止（リストア中など）**
+
+```csharp
+using var suspension = _dbContext.SuspendConnections();
+// この間、バックグラウンドタスクからの GetConnectionInternal() は
+// InvalidOperationException をスロー（Issue #1166）
+await RestoreFromBackupAsync(backupFile);
+// using 脱出時に ResumeConnections() が自動呼び出しされる
+```
+
+#### 排他制御（内部実装の注意点）
+
+- `BeginTransactionAsync()` は `DbContext._semaphore` を取得する（`SemaphoreSlim(1, 1)`）。トランザクション中は他の書き込み系呼び出しがブロックされる
+- `LeaseConnectionAsync()`（非同期版）は現在セマフォを取得しない。同一 `SQLiteConnection` を複数タスクが共有する前提
+- `LeaseConnection()`（同期版）はセマフォを取得し、同一スレッド内でリエントラント（`AsyncLocal<int>` でカウント）
+- 結果として、**書き込み系は必ず `BeginTransactionAsync` 経由** で実行することで、他の書き込みとのレース条件を防げる
 
 ### 5.6 CsvExportService
 


### PR DESCRIPTION
## 概要

Issue #1243 の対応。`Data/DbContext.cs:21-107` に定義される以下 3 つの RAII 的ラッパクラスが `docs/design/05_クラス設計書.md` に記載されていなかった問題を解消する。

- `ConnectionLease`（接続リース、行 21）
- `TransactionScope`（トランザクションスコープ、行 50）
- `ConnectionSuspensionScope`（接続一時停止スコープ、行 89）

## なぜ重要か

これら 3 クラスは **DB アクセスの中核パターン** であり、新規機能実装時に必ず使用される。設計書への記載がなかったため、新規開発者は以下を知る術がなかった：

- `LeaseConnectionAsync()` / `BeginTransactionAsync()` の適切な使い分け
- **`TransactionScope.Dispose()` が `Commit`/`Rollback` 未呼び出し時に自動ロールバックする仕様** — この仕様を知らないと冗長な `try/catch/Rollback` を書きがち
- `SuspendConnections()` の意味（Issue #1166 の背景）

## 変更内容

### 新設: §5.5b 接続リース・トランザクションスコープ

`§5.5a DatabaseOptions` の直後に新設した。含まれる要素：

1. **クラス図** (mermaid): 3 クラスと `SQLiteTransaction` / `DbContext` への依存
2. **責務一覧表**: 取得元（`DbContext` の生成メソッド）と解放契機（`using` 文）を明示
3. **Dispose シーケンス図**: 正常系（`Commit`）と例外系（自動ロールバック）の両方を可視化
4. **使用パターン 3 種**:
   - 読み取り専用の接続借用
   - 複数操作の単一トランザクション（`ExecuteWithRetryAsync` との組み合わせ）
   - 接続の一時停止（リストア時）
5. **冗長な try/catch が不要であることの説明**（アンチパターンと推奨パターンを並記）
6. **排他制御の内部実装メモ**: `_semaphore`, `AsyncLocal<int> _reentrancyCount` の役割

### 相互参照の追加

- `§5.5 DbContext` の末尾に **§5.5b へのナビゲーションブロック** を追加
- `§3.4 Repositories` の表に「**DbContext と接続リース系クラス**」サブセクションを新設し、4 クラスを一覧化（§5.5b への参照を含む）

## 変更しなかった箇所（スコープ外）

- §5.5 DbContext の mermaid 図（`GetConnection()` / `BeginTransaction()` 旧表記のまま）  
  → Issue #1244（「docs: 02_DB設計書の GetConnection() 非推奨反映とマイグレーション表の DEFAULT 値追記」）で対応予定
- §5.5b の内容は、Issue #1243 が明記している 3 クラスに限定。`ExecuteWithRetryAsync` や `SuspendConnections` 等の DbContext 側メソッドは §5.5b からの参照程度に留めた

## 検証

- **変更規模**: 1 ファイル、+153 行（新規追記のみ、既存記述の変更なし）
- **ビルド影響**: なし（ドキュメントのみ）
- **単体テスト**: ドキュメント変更のため不要

## 手動確認いただきたい項目

以下はドキュメントの**正確性・可読性**を目視確認いただきたい点です：

- [ ] §5.5b のクラス図・シーケンス図が mermaid で正しくレンダリングされるか（GitHub 上で）
- [ ] `TransactionScope.Dispose()` の自動ロールバック仕様の記述が、実際の実装（`Data/DbContext.cs:73-81` の `Transaction?.Dispose()` 委譲）と整合しているか
- [ ] §5.5 からの `#55b-接続リーストランザクションスコープissue-1243` アンカーリンクが動作するか（GitHub の自動生成 ID とマッチするか）
- [ ] `docs/manual/convert-to-pdf.ps1` / `convert-to-docx.ps1` で PDF/DOCX 変換時に問題がないか（Windows 環境で要確認）

## 関連

- Closes #1243
- 関連 Issue: #1244（02_DB 設計書 GetConnection() 非推奨反映）— §5.5 DbContext の図更新はこちらに委譲
- 関連 Issue: #1242（開発者ガイド v2.7.0 同期）— 既にマージ済みの PR #1292 で §2.5.6「DbContext の並行アクセス保護」に同等内容を記載済み。両ドキュメントで相互に補完

🤖 Generated with [Claude Code](https://claude.com/claude-code)