### PR TITLE
docs: 02_DB設計書の GetConnection() 非推奨反映とマイグレーション表の DEFAULT 値追記 (#1244)

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -375,20 +375,25 @@ erDiagram
 
 スキーマ変更は `src/ICCardManager/Data/Migrations/` の連番マイグレーションクラスとして実装されており、`MigrationRunner` がアプリ起動時に未適用分を順次実行します。
 
-| No. | クラス | 概要 | 関連Issue |
-|-----|--------|------|-----------|
-| 001 | Migration_001_Initial | 初期スキーマ(staff / ic_card / ledger / ledger_detail / operation_log / settings)作成 | - |
-| 002 | Migration_002_AddPointRedemption | `ledger_detail.is_point_redemption` カラム追加 | - |
-| 003 | Migration_003_AddTripGroupId | `ledger_detail.group_id` カラム追加(乗継統合) | #484 |
-| 004 | Migration_004_AddPerformanceIndexes | パフォーマンス向上用のインデックス追加(`idx_card_lent_deleted`, `idx_ledger_card_id` など) | - |
-| 005 | Migration_005_AddStartingPageNumber | `ic_card.starting_page_number` カラム追加(帳票開始ページ番号) | #510 |
-| 006 | Migration_006_AddRefundedStatus | `ic_card.is_refunded` / `refunded_at` カラム追加(払戻管理) | #530 |
-| 007 | Migration_007_AddMergeHistory | `ledger_merge_history` テーブル追加(統合履歴とundo) | #548 |
-| 008 | Migration_008_AddCardTypeNumberUniqueIndex | `idx_card_type_number_active` UNIQUE 部分インデックス追加 | - |
-| 009 | Migration_009_AddCarryoverTotals | `ic_card.carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` カラム追加(年度途中導入時の累計初期値) | #1215 |
+| No. | クラス | 概要 | DEFAULT値 | 関連Issue |
+|-----|--------|------|-----------|-----------|
+| 001 | Migration_001_Initial | 初期スキーマ(staff / ic_card / ledger / ledger_detail / operation_log / settings)作成 | (schema.sql 内で個別定義) | - |
+| 002 | Migration_002_AddPointRedemption | `ledger_detail.is_point_redemption` カラム追加 | — (NULL許容) | - |
+| 003 | Migration_003_AddTripGroupId | `ledger_detail.group_id` カラム追加(乗継統合) | — (NULL許容) | #484 |
+| 004 | Migration_004_AddPerformanceIndexes | パフォーマンス向上用のインデックス追加(`idx_card_lent_deleted`, `idx_ledger_card_id` など) | — (インデックスのみ) | - |
+| 005 | Migration_005_AddStartingPageNumber | `ic_card.starting_page_number` カラム追加(帳票開始ページ番号) | `starting_page_number = 1` | #510 |
+| 006 | Migration_006_AddRefundedStatus | `ic_card.is_refunded` / `refunded_at` カラム追加(払戻管理) | `is_refunded = 0` / `refunded_at` は NULL | #530 |
+| 007 | Migration_007_AddMergeHistory | `ledger_merge_history` テーブル追加(統合履歴とundo) | テーブル定義内に記載 | #548 |
+| 008 | Migration_008_AddCardTypeNumberUniqueIndex | `idx_card_type_number_active` UNIQUE 部分インデックス追加 | — (インデックスのみ) | - |
+| 009 | Migration_009_AddCarryoverTotals | `ic_card.carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` カラム追加(年度途中導入時の累計初期値) | `carryover_income_total = 0` / `carryover_expense_total = 0` / `carryover_fiscal_year` は NULL | #1215 |
+
+> **DEFAULT 値の読み方**:
+> - `= 値` は `ALTER TABLE ADD COLUMN ... DEFAULT 値` で設定されており、既存行にも遡及適用される
+> - `NULL` は `DEFAULT` 句なしでカラム追加されたため、既存行では NULL となる
+> - アプリ側の読み取りコードでは該当カラムの NULL チェック要否がこの列に従う（例: `refunded_at IS NULL` を払戻未実施と解釈）
 
 > **新規マイグレーションを追加した際のチェックリスト**:
-> 1. 本表に1行追加する
+> 1. 本表に1行追加する（`DEFAULT値` 列も忘れずに）
 > 2. 該当テーブル定義(§3)のカラム説明に「(マイグレーション番号 / Issue番号)」を追記する
 > 3. `MigrationRunner` のテストを追加する(`07_テスト設計書.md` 参照)
 
@@ -503,17 +508,30 @@ DELETE FROM operation_log WHERE date(timestamp) < date('now', '-6 years', 'local
 
 ---
 
-## 9. 外部キー制約
+## 9. 外部キー制約・接続管理
 
-### 9.1 有効化
+### 9.1 外部キー制約の有効化
 
 ```sql
 PRAGMA foreign_keys = ON;
 ```
 
-> `DbContext.GetConnection()` で接続時に必ず実行されます。SQLiteは外部キー制約をデフォルトで無効化しているため、明示的に有効化する必要があります(よくあるハマりどころ)。
+> `DbContext.ConfigurePragmas()` が接続確立時に必ず実行します（同時に `PRAGMA busy_timeout = 5000` と共有モード時は `PRAGMA journal_mode = DELETE` も設定）。SQLite は外部キー制約をデフォルトで無効化しているため、明示的に有効化する必要があります(よくあるハマりどころ)。
 
-### 9.2 制約一覧
+### 9.2 推奨される接続取得方法
+
+アプリケーションコードから `SQLiteConnection` を取得する際は、以下の **RAII 的な API** を使用します。詳細と典型的な使用パターンは [`05_クラス設計書.md` §5.5b 接続リース・トランザクションスコープ](05_クラス設計書.md#55b-接続リーストランザクションスコープissue-1243) を参照してください。
+
+| API | 用途 | 備考 |
+|-----|------|------|
+| `DbContext.LeaseConnectionAsync()` | 非同期で接続を借用 | 推奨。`using var lease = await ...` で使用 |
+| `DbContext.LeaseConnection()` | 同期で接続を借用 | 初期化等の同期コンテキスト専用。リエントラント可 |
+| `DbContext.BeginTransactionAsync()` | トランザクション付きで接続を借用 | 書き込み系の推奨形。`Dispose` で未コミットなら自動ロールバック |
+| `DbContext.ExecuteWithRetryAsync()` | `SQLITE_BUSY` / `SQLITE_LOCKED` 時の自動リトライラッパ | 共有モードでのトランザクション必須ペア |
+
+> **⚠️ `DbContext.GetConnection()` は非推奨です（Issue #1209）**: `[Obsolete("スレッドセーフな LeaseConnectionAsync() または LeaseConnection() を使用してください")]` で警告が出ます。既存コードから段階的に `LeaseConnectionAsync()` / `LeaseConnection()` へ移行中です。新規コードでは使用しないでください。
+
+### 9.3 制約一覧
 
 | 子テーブル | 親テーブル | 制約 |
 |------------|------------|------|
@@ -521,6 +539,8 @@ PRAGMA foreign_keys = ON;
 | ledger.card_idm | ic_card.card_idm | REFERENCES |
 | ledger.lender_idm | staff.staff_idm | REFERENCES |
 | ledger_detail.ledger_id | ledger.id | ON DELETE CASCADE |
+
+> 子テーブル側の FOREIGN KEY 宣言は `schema.sql` に明示されています（SQLite は PRAGMA 有効時のみ制約チェックを行う）。
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #1244 の対応。`docs/design/02_DB設計書.md` にある 2 つの乖離を解消する。

### 乖離 1: GetConnection() が現役扱い

- 設計書: `DbContext.GetConnection()` で接続時に必ず実行、と記載（§9.1）
- 実装: `Data/DbContext.cs:382-386` は `[Obsolete]` で非推奨化済み（Issue #1209）、`LeaseConnectionAsync()` / `LeaseConnection()` を推奨

### 乖離 2: マイグレーション履歴表に DEFAULT 値が不記載

- 設計書: カラム追加マイグレーション（#005/#006/#009）の DEFAULT 値が書かれていない
- アプリ実装上、DEFAULT 句の有無で既存行が NULL になるか否かが変わるため、NULL チェック要否の判断に必要

## 変更内容

### §9 外部キー制約 → 「外部キー制約・接続管理」に再構成

**§9.1 外部キー制約の有効化**
- `DbContext.GetConnection()` への言及を **`ConfigurePragmas()`** に変更
- 共有モード時に同時設定される `busy_timeout=5000` と `journal_mode=DELETE` を併記

**§9.2 推奨される接続取得方法（新設）**
以下の 4 API を用途別に表形式で列挙：

| API | 用途 |
|-----|------|
| `LeaseConnectionAsync()` | 非同期で接続を借用（推奨） |
| `LeaseConnection()` | 同期で接続を借用（リエントラント可） |
| `BeginTransactionAsync()` | トランザクション付き借用（書き込み系推奨形） |
| `ExecuteWithRetryAsync()` | `SQLITE_BUSY` / `SQLITE_LOCKED` リトライラッパ |

詳細な使用パターンは **`05_クラス設計書.md` §5.5b** への参照で委譲（Issue #1243 とのクロスリンク）。

`GetConnection()` は **警告ブロック** で `[Obsolete]` 状態（Issue #1209）であることを明記し、新規コードでの使用を禁止。

**§9.3 制約一覧（旧 §9.2）**
- `schema.sql` における FOREIGN KEY 宣言の位置に関する注記を追加
- SQLite が PRAGMA 有効時のみ制約チェックを行う点を明示

### §4 マイグレーション履歴表に「DEFAULT 値」列追加

**Migration ファイル実コード** から正確な DEFAULT 値を抽出（推測でなく確認済み）：

```
ALTER TABLE ic_card ADD COLUMN starting_page_number INTEGER DEFAULT 1       ← Migration_005
ALTER TABLE ic_card ADD COLUMN is_refunded INTEGER DEFAULT 0                ← Migration_006
ALTER TABLE ic_card ADD COLUMN refunded_at TEXT                             ← Migration_006 (NULL)
ALTER TABLE ic_card ADD COLUMN carryover_income_total INTEGER DEFAULT 0     ← Migration_009
ALTER TABLE ic_card ADD COLUMN carryover_expense_total INTEGER DEFAULT 0    ← Migration_009
ALTER TABLE ic_card ADD COLUMN carryover_fiscal_year INTEGER                ← Migration_009 (NULL)
```

カラム追加以外（#001 初期スキーマ / #004 インデックス / #007 新規テーブル / #008 インデックス）は「—」または適切な注記で埋めた。

**DEFAULT 値の読み方ガイド** を補足ブロックで追加：
- `= 値` は遡及適用（既存行も書き換わる）
- `NULL` は `DEFAULT` 句なし → 既存行は NULL のまま
- アプリ側 NULL チェック要否がこの列に従う（例: `refunded_at IS NULL` を払戻未実施と解釈）

## 検証

- **変更規模**: 1 ファイル、+36 / -16 行
- **ビルド影響**: なし（ドキュメントのみ）
- **単体テスト**: ドキュメント変更のため不要
- **DEFAULT 値の正確性**: `grep "ADD COLUMN\|DEFAULT" Migration_005/006/009_*.cs` で実コードから抽出

## 手動確認いただきたい項目

- [ ] §9.2 の `05_クラス設計書.md#55b-接続リーストランザクションスコープissue-1243` アンカーリンクが正しく動作するか（Issue #1243 の PR #1294 がマージされた後に確認可能）
- [ ] §4 表のレンダリングが Markdown リーダー / GitHub / pandoc いずれでも崩れないか（DEFAULT 値列の追加でカラム幅が変わる）
- [ ] `docs/manual/convert-to-pdf.ps1` / `convert-to-docx.ps1` の変換結果が正常か（Windows 環境で要確認）

## 関連

- Closes #1244
- 関連 PR: #1294 (#1243, 05_クラス設計書 §5.5b 新設) — 本 PR の §9.2 から参照している
- 関連 Issue: #1209 (`GetConnection()` を `LeaseConnection()` に移行) — 本 PR で「段階移行中」を正式文書化

🤖 Generated with [Claude Code](https://claude.com/claude-code)