### PR TITLE
docs: 06_シーケンス図を非同期/TransactionScope 対応に刷新 (#1245)

### DIFF
--- a/ICCardManager/docs/design/06_シーケンス図.md
+++ b/ICCardManager/docs/design/06_シーケンス図.md
@@ -11,6 +11,8 @@
 
 > **Mermaidの読み方**: `participant X as Y` は「X というエイリアスで Y を登場させる」、`A->>B: msg` は同期呼び出し、`B-->>A: resp` は戻り値。`alt` / `loop` / `Note` ブロックで条件分岐・繰り返し・補足を表現します。
 
+> **トランザクション表記について（Issue #1245）**: 本書のシーケンス図では書き込み系処理を `await BeginTransactionAsync()` → `TransactionScope (using)` → `scope.Commit()` の形で表記しています。`scope.Rollback()` は原則として図に出しません — 例外経路では **`scope.Dispose()` が自動的にロールバックする** ためです。この仕様の詳細は [§9.1 TransactionScope の自動ロールバック仕様](#91-transactionscope-の自動ロールバック仕様重要) を参照してください。
+
 ---
 
 ## 1. シーケンス図マップ
@@ -125,8 +127,9 @@ sequenceDiagram
         LS-->>VM: Error: 職員証が登録されていません
     end
 
-    LS->>DB: BeginTransaction()
-    DB-->>LS: Transaction
+    LS->>DB: await BeginTransactionAsync()
+    DB-->>LS: TransactionScope (using)
+    Note over LS,DB: 以降の DB 操作は TransactionScope 内で実行
 
     LS->>LR: InsertAsync(Ledger)
     Note right of LR: summary = "（貸出中）"<br/>is_lent_record = true
@@ -139,7 +142,8 @@ sequenceDiagram
     DB-->>CR: success
     CR-->>LS: success
 
-    LS->>DB: Commit()
+    LS->>DB: scope.Commit()
+    Note over LS,DB: using 脱出時に scope.Dispose() が<br/>トランザクションとリースを順次解放
 
     LS->>LS: LastProcessedCardIdm = cardIdm
     LS->>LS: LastProcessedTime = now
@@ -186,7 +190,8 @@ sequenceDiagram
 
     LS->>LS: 貸出時刻以降の利用履歴を抽出
 
-    LS->>DB: BeginTransaction()
+    LS->>DB: await BeginTransactionAsync()
+    DB-->>LS: TransactionScope (using)
 
     loop 日付ごとにグループ化
         alt チャージあり
@@ -207,7 +212,8 @@ sequenceDiagram
 
     LS->>CR: UpdateLentStatusAsync(cardIdm, false, null, null)
 
-    LS->>DB: Commit()
+    LS->>DB: scope.Commit()
+    Note over LS,DB: using 脱出時に scope.Dispose() が<br/>トランザクションとリースを順次解放
 
     LS->>LS: 残高チェック
     alt 残高 < 警告閾値
@@ -425,6 +431,20 @@ sequenceDiagram
 
 ## 9. エラー処理シーケンス
 
+### 9.1 TransactionScope の自動ロールバック仕様（重要）
+
+`DbContext.BeginTransactionAsync()` が返す `TransactionScope` は RAII 的なラッパーであり、**`using` を抜けた時点で `scope.Commit()` も `scope.Rollback()` も呼ばれていなければ `Dispose()` が自動的にロールバックする**。
+
+このため、例外経路での明示的な `Rollback()` 呼び出しは**不要**である（呼んでも冗長になるだけ）。
+
+- 正常系: `scope.Commit()` → トランザクション確定
+- 例外系: 例外が `using` 文を突き抜ける → `scope.Dispose()` が自動ロールバック
+- 明示ロールバック: `scope.Rollback()` は "明示的にロールバックしたい" ことを意図的に示す場合のみ使用（可読性向上）
+
+詳細は [`05_クラス設計書.md` §5.5b 接続リース・トランザクションスコープ](05_クラス設計書.md#55b-接続リーストランザクションスコープissue-1243) を参照。
+
+### 9.2 エラー処理シーケンス図
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -435,14 +455,19 @@ sequenceDiagram
 
     VM->>LS: LendAsync(staffIdm, cardIdm)
 
-    LS->>DB: BeginTransaction()
-    DB-->>LS: Transaction
+    LS->>DB: await BeginTransactionAsync()
+    DB-->>LS: TransactionScope (using)
 
     LS->>LS: 処理実行中...
 
-    alt データベースエラー発生
-        LS->>DB: Rollback()
-        LS-->>VM: LendingResult(Success = false, ErrorMessage = "エラーメッセージ")
+    alt 正常系
+        LS->>DB: scope.Commit()
+        Note over LS,DB: using 脱出時に Dispose() が<br/>トランザクション→リースの順で解放
+        LS-->>VM: LendingResult(Success = true)
+    else データベースエラー発生
+        Note over LS: 例外が using を突き抜ける
+        Note over LS,DB: scope.Dispose() が<br/>自動ロールバック（Rollback 不要）
+        LS-->>VM: LendingResult(Success = false, ErrorMessage)
     end
 
     VM->>Sound: PlayError()
@@ -454,6 +479,8 @@ sequenceDiagram
     VM->>VM: 状態を WaitingForStaffCard に戻す
     VM->>VM: 画面表示更新
 ```
+
+> **SQLITE_BUSY / SQLITE_LOCKED 時の自動リトライ**: 書き込み系では `await _dbContext.ExecuteWithRetryAsync(async () => { ... })` で上記トランザクションブロックを包むのが推奨形（共有モードでは最大 5 回、指数バックオフ + ジッター付き）。本図では簡略化のため省略している。
 
 ---
 
@@ -500,12 +527,14 @@ sequenceDiagram
     MS->>SG: Generate(allDetails)
     SG-->>MS: 再生成された摘要
 
-    MS->>DB: BeginTransaction()
+    MS->>DB: await BeginTransactionAsync()
+    DB-->>MS: TransactionScope (using)
     MS->>LR: UpdateAsync(統合先Ledger)
     MS->>LR: DeleteAsync(統合元Ledger群)
     MS->>LR: InsertMergeHistoryAsync(undoData)
     MS->>OL: LogAsync("MERGE", ...)
-    MS->>DB: Commit()
+    MS->>DB: scope.Commit()
+    Note over MS,DB: using 脱出時に scope.Dispose() が<br/>トランザクションとリースを順次解放
 
     MS-->>VM: LedgerMergeResult(Success)
     VM-->>User: 統合完了メッセージ


### PR DESCRIPTION
## 概要

Issue #1245 の対応。`docs/design/06_シーケンス図.md` のトランザクション表記を、実装に即した非同期 / `TransactionScope` ベースに刷新する。

### 乖離の実態

- 設計書（4 箇所）: `LS->>DB: BeginTransaction()` / `Commit()` / `Rollback()` と同期呼び出し風
- 実装（`LendingService.cs:231, 378, 548, 1158` 等）: `await _dbContext.BeginTransactionAsync()` による `TransactionScope` パターン
- **例外時の自動ロールバック仕様** が図に一切表現されていないため、新規開発者が `try/catch/Rollback` を冗長に書きがち

## 変更内容

### §3 貸出処理 / §4 返却処理 / §10 履歴統合 — トランザクション箇所の統一

| 旧表記 | 新表記 |
|--------|--------|
| `LS->>DB: BeginTransaction()` | `LS->>DB: await BeginTransactionAsync()` |
| `DB-->>LS: Transaction` | `DB-->>LS: TransactionScope (using)` |
| `LS->>DB: Commit()` | `LS->>DB: scope.Commit()` |
| （なし） | `Note: using 脱出時に scope.Dispose() が順次解放` |

計 3 つのシーケンス図で統一表記を適用。

### §9 エラー処理 — サブセクション構造に再編

**§9.1 TransactionScope の自動ロールバック仕様（新設）**:

実装上の重要ポイントを文章で明示：
- **正常系**: `scope.Commit()` → 確定
- **例外系**: 例外が `using` を突き抜ける → **`scope.Dispose()` が自動ロールバック**
- 明示 `scope.Rollback()` は可読性向上目的でのみ使用

`05_クラス設計書.md §5.5b`（Issue #1243 で新設）への相互参照を追加。

**§9.2 エラー処理シーケンス図（本体）**:

- `alt 正常系 ... else データベースエラー発生` の 2 分岐に再構成
- 例外経路では **`scope.Rollback()` を明示的に図に出さず**、「例外が using を突き抜ける」「`scope.Dispose()` が自動ロールバック（`Rollback` 不要）」の Note で表現
- `ExecuteWithRetryAsync` による SQLITE_BUSY/LOCKED 時の自動リトライを注記で補足

### §0 導入ガイドの拡充

Mermaid 読み方ブロックの直後に **「トランザクション表記について」** を追加。本書全体の方針（`Rollback()` は原則図に出さない、理由は §9.1 参照）を Issue #1245 への参照付きで明示し、各シーケンス図を読む前の前提知識として一度だけ提示。

## 効果

- 新規開発者が `BeginTransaction()` 同期 API を使おうとする誤解を防止
- `try/catch/Rollback` の冗長パターンを書かなくなる（実装は `scope.Commit()` のみ、Dispose で自動ロールバック）
- SQLITE_BUSY/LOCKED 時の正しい書き方（`ExecuteWithRetryAsync` ラップ）を自然に発見できる

## 検証

- **変更規模**: 1 ファイル、+41 / -12 行
- **ビルド影響**: なし（ドキュメントのみ）
- **単体テスト**: ドキュメント変更のため不要
- **整合性**: 実装 `LendingService.cs:231, 378, 548, 1158` の表記（`await BeginTransactionAsync()`）とシーケンス図が完全一致

## 手動確認いただきたい項目

- [ ] §0 と §9.1 のアンカーリンク `#91-transactionscope-の自動ロールバック仕様重要` / `#55b-接続リーストランザクションスコープissue-1243` が GitHub 上で動作するか
- [ ] §9.2 の `alt 正常系 ... else データベースエラー発生` ブロックの Mermaid 構文が正しくレンダリングされるか
- [ ] `docs/manual/convert-to-pdf.ps1` / `convert-to-docx.ps1` の変換結果が正常か（Mermaid の Note 表記変更後に確認、Windows 要）

## 関連

- Closes #1245
- 関連 PR: #1294 (#1243, 05_クラス設計書 §5.5b) — 本 PR の §9.1 から参照
- 関連 PR: #1295 (#1244, 02_DB 設計書 §9.2) — 接続取得 API の推奨形の根拠
- 関連 Issue: #1209 (`GetConnection()` → `LeaseConnection()` 移行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)