### PR TITLE
docs: FiscalYearHelper と FiscalYear ValueObject の棲み分けを明文化 (#1246)

### DIFF
--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -207,7 +207,7 @@ graph TB
 |--------|------|
 | CardIdm | 交通系ICカードIDm（16進数16文字、大文字正規化、`implicit operator string`） |
 | StaffIdm | 職員証IDm（16進数16文字、大文字正規化、CardIdmとは型レベルで区別） |
-| FiscalYear | 日本の会計年度（4月始まり）。FiscalYearHelperの後継。開始日・終了日・包含判定・前月取得 |
+| FiscalYear | 日本の会計年度（4月始まり）。`FiscalYearHelper` の後継。開始日・終了日・包含判定・前月取得・比較演算子。両者の棲み分けは [§5.8b](#58b-fiscalyearhelper-と-fiscalyear-valueobject-の棲み分けissue-1246) を参照 |
 | Money | 非負の金額（円）。加算・比較演算子、`implicit operator int`） |
 
 ### 3.2 ViewModels
@@ -825,6 +825,93 @@ classDiagram
     ReportRowSet --> ReportTotal
     ReportRow --> ReportRowType
 ```
+
+### 5.8b FiscalYearHelper と FiscalYear ValueObject の棲み分け（Issue #1246）
+
+日本の会計年度（4月始まり）計算には、**2 つの共存する API** がある。新規コードは **`FiscalYear` ValueObject** を使用することを推奨する。`FiscalYearHelper`（静的メソッド群）は Issue #1024 で導入された先行実装で、Value Object 化（Issue #1221）後も後方互換のため残存している。
+
+```mermaid
+classDiagram
+    class FiscalYearHelper {
+        <<static class>>
+        +GetFiscalYear(year, month)$ int
+        +GetFiscalYear(date)$ int
+        +GetFiscalYearStart(fiscalYear)$ DateTime
+        +GetFiscalYearEnd(fiscalYear)$ DateTime
+        +GetPreviousMonth(year, month)$ Tuple~int_int~
+    }
+
+    class FiscalYear {
+        <<readonly struct>>
+        +int Year
+        +FiscalYear(year)
+        +DateTime StartDate
+        +DateTime EndDate
+        +Contains(date) bool
+        +FromDate(date)$ FiscalYear
+        +FromYearMonth(year, month)$ FiscalYear
+        +GetPreviousMonth(year, month)$ Tuple~int_int~
+        +ToString() string
+    }
+
+    note for FiscalYearHelper "互換維持のため残存。新規コードは非推奨"
+    note for FiscalYear "Value Object。型安全・immutable・比較演算子対応"
+```
+
+#### API 対応表
+
+| FiscalYearHelper（旧 API） | FiscalYear ValueObject（新 API） | 備考 |
+|---------------------------|--------------------------------|------|
+| `FiscalYearHelper.GetFiscalYear(year, month)` | `FiscalYear.FromYearMonth(year, month).Year` | 戻り値の意味が型で表現される |
+| `FiscalYearHelper.GetFiscalYear(date)` | `FiscalYear.FromDate(date).Year` | 同上 |
+| `FiscalYearHelper.GetFiscalYearStart(fy)` | `new FiscalYear(fy).StartDate` | インスタンスメソッド化 |
+| `FiscalYearHelper.GetFiscalYearEnd(fy)` | `new FiscalYear(fy).EndDate` | インスタンスメソッド化 |
+| `FiscalYearHelper.GetPreviousMonth(y, m)` | `FiscalYear.GetPreviousMonth(y, m)` | 年度と無関係な純粋関数のため両者に同名で残存 |
+| なし | `fy.Contains(date)` | **新機能**: 日付包含判定 |
+| なし | `==`, `!=`, `<`, `>` など比較演算子 | **新機能**: 年度間比較 |
+| なし | `implicit operator int(FiscalYear)` | **新機能**: 戻り値を int として扱える |
+
+#### 使用方針
+
+**新規コード**: `FiscalYear` ValueObject を使用すること。
+
+```csharp
+// 推奨
+var fy = FiscalYear.FromDate(DateTime.Today);
+if (fy.Contains(record.Date))
+{
+    total += record.Amount;
+}
+
+// 年度間比較も自然に書ける
+var fy2025 = new FiscalYear(2025);
+var fy2026 = new FiscalYear(2026);
+Assert.True(fy2025 < fy2026);
+```
+
+**既存コード**: `FiscalYearHelper` のままでもビルドは通るが、触った際に段階的に `FiscalYear` へ移行する。一括置換は差分が大きくなるため、機能追加や周辺修正のついでに置き換える。
+
+#### 段階的移行計画
+
+既存の `FiscalYearHelper` 呼び出しは全 5 ファイル 12 箇所（本設計書作成時点）。優先度別の移行順を以下に示す。
+
+| 優先度 | 対象ファイル | 呼び出し数 | 移行の判断基準 |
+|--------|------------|----------|----------------|
+| **高** | `Common/WarekiConverter.cs:137, 147, 157` | 3 | コアユーティリティ。WarekiConverter 自体の責務再整理と合わせて FiscalYear ベースに刷新すべき |
+| **高** | `Services/ReportService.cs:671` | 1 | 帳票出力の年度判定。単発呼び出しなので `FiscalYear.FromYearMonth(y, m).Year` に直接置換可能 |
+| **高** | `Services/ReportDataBuilder.cs:95, 96, 182, 197` | 4 | 年度跨ぎの月計・累計計算の起点。`Contains(date)` 導入で意図がより明瞭になる |
+| **中** | `ViewModels/CardManageViewModel.cs:453` | 1 | 年度途中導入時の `CarryoverFiscalYear` 計算（Issue #1215）。単発で置換容易 |
+| **低** | `Services/DebugDataService.cs:196, 197, 703` | 3 | DEBUG ビルドのテストデータ生成。本番挙動に影響しないため後回し可 |
+
+#### 将来の廃止計画
+
+`FiscalYearHelper` は **v3.0 リリース時に `[Obsolete]` 属性付与** → **v3.1 で削除** を目指す。以下が揃った段階で `[Obsolete]` を付与：
+
+1. 上記 12 箇所がすべて `FiscalYear` ValueObject に移行済み
+2. 移行後の全体テストが Green
+3. 外部プラグイン・拡張が存在しないこと（現状該当なし）
+
+`[Obsolete]` 期間中は `FiscalYearHelper` 内部から `FiscalYear` ValueObject に委譲する形に書き換え、振る舞いの乖離を防ぐ。
 
 ### 5.9 InputSanitizer
 


### PR DESCRIPTION
## 概要

Issue #1246 の対応。Value Object 化（Issue #1221）で `FiscalYear` が導入された一方、先行実装の `FiscalYearHelper`（Issue #1024、静的メソッド群）がそのまま残存しており、新規コードでどちらを使うべきか設計書が答えていなかった問題を解消する。

## 変更内容

### 追加: §5.8b FiscalYearHelper と FiscalYear ValueObject の棲み分け

`05_クラス設計書.md` の §5.8a ReportRow 直後に新設。

#### 1. クラス図（mermaid）

`FiscalYearHelper`（`<<static class>>`）と `FiscalYear`（`<<readonly struct>>`）を並列表示。各クラスに Mermaid note で用途を明示：
- `FiscalYearHelper`: 「互換維持のため残存。新規コードは非推奨」
- `FiscalYear`: 「Value Object。型安全・immutable・比較演算子対応」

#### 2. API 対応表

移行時の置換ルールを機械的に適用できるよう、旧→新の変換を 5 行 + 新機能 3 行の計 8 項目で表形式にまとめた：

| FiscalYearHelper（旧） | FiscalYear ValueObject（新） |
|---|---|
| `GetFiscalYear(year, month)` | `FiscalYear.FromYearMonth(year, month).Year` |
| `GetFiscalYear(date)` | `FiscalYear.FromDate(date).Year` |
| `GetFiscalYearStart(fy)` | `new FiscalYear(fy).StartDate` |
| `GetFiscalYearEnd(fy)` | `new FiscalYear(fy).EndDate` |
| — | `fy.Contains(date)` / 比較演算子 / `implicit operator int` |

#### 3. 使用方針

**新規コード**: `FiscalYear` ValueObject を使用
- `FiscalYear.FromDate(today).Contains(record.Date)` などの型安全な書き方を推奨形として記載
- 年度間比較（`fy2025 < fy2026`）の例も掲載

**既存コード**: 触った際に段階的に移行（一括置換は避ける）

#### 4. 段階的移行計画 — 実コード走査による

`grep "FiscalYearHelper\."` で実コードを走査し、全 5 ファイル 12 箇所の呼び出しを発見。優先度別に分類：

| 優先度 | ファイル（行番号） | 呼び出し数 | 判断基準 |
|--------|------------------|----------|----------|
| **高** | `Common/WarekiConverter.cs:137, 147, 157` | 3 | コアユーティリティ。責務再整理と合わせて刷新 |
| **高** | `Services/ReportService.cs:671` | 1 | 帳票出力の年度判定。単発で置換可能 |
| **高** | `Services/ReportDataBuilder.cs:95, 96, 182, 197` | 4 | 年度跨ぎ計算の起点。`Contains()` 導入で意図明瞭化 |
| **中** | `ViewModels/CardManageViewModel.cs:453` | 1 | `CarryoverFiscalYear` 計算（Issue #1215） |
| **低** | `Services/DebugDataService.cs:196, 197, 703` | 3 | DEBUG ビルドのテストデータ生成。本番挙動に影響なし |

#### 5. 将来の廃止計画

2 段階計画を明文化：
- **v3.0**: `FiscalYearHelper` に `[Obsolete]` 属性付与（上記 12 箇所の移行完了後）
- **v3.1**: `FiscalYearHelper` を削除

`[Obsolete]` 期間中は `FiscalYearHelper` 内部から `FiscalYear` VO に委譲する形に書き換え、振る舞いの乖離を防ぐ運用方針も明記。

### 相互参照追加

§3.1 Value Objects 表の `FiscalYear` 行から §5.8b への明示リンクを追加し、Model 一覧から詳細セクションへ到達可能に。

## 効果

- 新規コードが `FiscalYearHelper` を使ってしまう誤選択を防止
- 既存コードの段階的移行ロードマップが明確化
- `[Obsolete]` / 削除の判断基準が文書化され、将来のリリース計画に組み込める

## 検証

- **変更規模**: 1 ファイル、+88 / -1 行
- **ビルド影響**: なし（ドキュメントのみ）
- **単体テスト**: ドキュメント変更のため不要
- **callsite 網羅性**: `grep "FiscalYearHelper\."` を実コードに対して実行し、12 箇所全てを表に収容済み

## 手動確認いただきたい項目

- [ ] §3.1 からの `#58b-fiscalyearhelper-と-fiscalyear-valueobject-の棲み分けissue-1246` アンカーリンクが GitHub の自動生成 ID で動作するか
- [ ] クラス図の Mermaid note 表記がレンダリング時に正しく表示されるか
- [ ] API 対応表のレイアウトが pandoc / docx 変換後も崩れないか
- [ ] `docs/manual/convert-to-pdf.ps1` / `convert-to-docx.ps1` での変換結果（Windows 環境で要確認）

## 関連

- Closes #1246
- 関連 Issue: #1221（Value Object と Model 層 Rich 化）— 本 PR で補完
- 関連 Issue: #1024（FiscalYearHelper 導入）— 後継関係を明文化
- 関連 Issue: #1215（`CarryoverFiscalYear` 導入）— 移行計画の対象
- 参考 PR: #1292（開発者ガイド v2.7.0 同期）— §4.6「Value Objects の使用」と整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)