### PR TITLE
docs: TODO.md を deprecated 化し CHANGELOG.md を正の情報源に (#1249)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,12 @@ WSL2では "/mnt/c/Program Files/dotnet/dotnet.exe" を使用すること。
 
 ## 参照ドキュメント
 
+- `ICCardManager/CHANGELOG.md` — **バージョン履歴・変更内容の Single Source of Truth**（TODO.md より優先）
 - `docs/design/` — 設計書一式（01〜08）
 - `docs/manual/` — マニュアル（ユーザー・管理者・開発者）
 - `Resources/Templates/物品出納簿テンプレート.xlsx` — 月次帳票テンプレート
 - `docs/線区駅順コード/StationCode.csv` — 駅コード→駅名マスター（[出典](https://produ.irelang.jp/blog/2017/08/305/)、[新駅参照](https://ja.ysrl.org/atc/station-code.html)）
+
+## 非推奨ドキュメント
+
+- `TODO.md`（リポジトリ直下） — v2.2.0 時点の初期実装タスクアーカイブ。**deprecated**（Issue #1249）。以降の進捗・要望管理は GitHub Issues と `CHANGELOG.md` を使用する。新規作業の優先度判断には使用しないこと。

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,30 @@
 # 開発ToDo リスト
 
-## 現在のステータス: v2.2.0 リリース済み（全フェーズ完了）
+> **⚠️ このファイルは deprecated です（2026-04-17 付け・Issue #1249）**
+>
+> 本ファイルは **v2.2.0 時点の初期実装タスク進捗** を記録したもので、v2.3.0 以降の機能追加・リファクタリング・バグ修正は反映されていません（現行バージョンは v2.7.0）。
+>
+> **新しい情報源**:
+> - バージョン履歴・変更内容 → [`ICCardManager/CHANGELOG.md`](ICCardManager/CHANGELOG.md)
+> - 進行中タスク・バグ・要望 → [GitHub Issues](https://github.com/kuwayamamasayuki/ICCardManager/issues)
+> - 開発者向けガイド → [`ICCardManager/docs/manual/開発者ガイド.md`](ICCardManager/docs/manual/開発者ガイド.md)
+> - 設計書（アーキテクチャ・DB・機能仕様） → [`ICCardManager/docs/design/`](ICCardManager/docs/design/)
+>
+> 以下の内容は **v2.2.0 時点（2026 年 3 月末）のアーカイブ** として保持しています。新規作業の優先度判断には使用しないでください。
 
 ---
 
-## 実装タスク一覧
+## 付録: v2.2.0 時点の初期実装タスクアーカイブ
 
-### Phase 1: 環境確認
+> 以下は **v2.2.0 リリース時点で完了済み** とマークされていた初期実装タスク群です。歴史的記録として保持しています。当時の「現在のステータス: v2.2.0 リリース済み（全フェーズ完了）」は本ヘッダーの時点で **陳腐化** しており、以降の全変更は上記 CHANGELOG.md を参照してください。
+
+### 実装タスク一覧
+
+#### Phase 1: 環境確認
 - [x] Windows側でビルド・実行確認
 - [x] PaSoRi接続テスト（単体テスト＋統合テスト作成済み）
 
-### Phase 2: Models層の実装
+#### Phase 2: Models層の実装
 - [x] Staff.cs（職員エンティティ）
 - [x] IcCard.cs（交通系ICカードエンティティ）
 - [x] Ledger.cs（履歴概要エンティティ）
@@ -20,7 +34,7 @@
 - [x] MonthlyReportData.cs（月次帳票データ）
 - [x] ReportRow.cs（帳票行データ）
 
-### Phase 3: Data層の実装
+#### Phase 3: Data層の実装
 - [x] schema.sql（テーブル定義）
 - [x] DbContext.cs（DB接続管理）
 - [x] IStaffRepository / StaffRepository
@@ -29,7 +43,7 @@
 - [x] ISettingsRepository / SettingsRepository
 - [x] IOperationLogRepository / OperationLogRepository
 
-### Phase 4: Services層の実装
+#### Phase 4: Services層の実装
 - [x] CardTypeDetector.cs（カード種別判別）
 - [x] WarekiConverter.cs（和暦変換）
 - [x] SummaryGenerator.cs（摘要文字列生成）
@@ -48,7 +62,7 @@
 - [x] ToastNotificationService.cs（トースト通知）
 - [x] OperationLogExcelExportService.cs（操作ログExcel出力）
 
-### Phase 5: Infrastructure層の実装
+#### Phase 5: Infrastructure層の実装
 - [x] ICardReader.cs（インターフェース）
 - [x] FelicaCardReader.cs（PaSoRi + felicalib 経由でのFeliCa読み取り）
 - [x] HybridCardReader.cs（ハイブリッドリーダー）
@@ -56,7 +70,7 @@
 - [x] ISoundPlayer.cs（インターフェース）
 - [x] SoundPlayer.cs（効果音再生）
 
-### Phase 6: ViewModels層の実装
+#### Phase 6: ViewModels層の実装
 - [x] ViewModelBase.cs（基底クラス）
 - [x] MainViewModel.cs（メイン画面）
 - [x] SettingsViewModel.cs（設定画面）
@@ -75,7 +89,7 @@
 
 > **Note:** 履歴表示（HistoryViewModel）は独立した画面ではなく、MainViewModelおよびLedgerDetailViewModelに統合されている。
 
-### Phase 7: Views層の実装
+#### Phase 7: Views層の実装
 - [x] MainWindow.xaml（メイン画面）
 - [x] SettingsDialog.xaml（設定ダイアログ）
 - [x] ReportDialog.xaml（帳票作成ダイアログ）
@@ -98,7 +112,7 @@
 
 > **Note:** 履歴表示画面（HistoryView.xaml）は独立した画面ではなく、LedgerDetailDialog等に統合されている。
 
-### Phase 8: テスト拡充
+#### Phase 8: テスト拡充
 - [x] CardTypeDetectorTests.cs
 - [x] WarekiConverterTests.cs
 - [x] SummaryGeneratorTests.cs
@@ -109,7 +123,7 @@
 - [x] LedgerRepositoryTests.cs
 - [x] その他 90以上のテストファイル（合計101ファイル、カバレッジ70%以上を維持）
 
-### Phase 9: 統合・リリース
+#### Phase 9: 統合・リリース
 - [x] Windows側でのビルド確認
 - [x] CI通過確認（GitHub Actions: ci.yml、カバレッジ70%閾値）
 - [x] 結合テストの実施
@@ -121,9 +135,9 @@
 
 ---
 
-## 完了したタスク
+### 完了したタスク
 
-### CI/CD環境構築（完了）
+#### CI/CD環境構築（完了）
 - [x] .gitignore 作成
 - [x] ディレクトリ構造作成
 - [x] ICCardManager.sln 作成
@@ -136,7 +150,7 @@
 - [x] 単体テスト作成
 - [x] GitHub Actions CI 確認
 
-### コア機能実装（完了）
+#### コア機能実装（完了）
 - [x] Models層（エンティティ定義）
 - [x] Data層（DB接続、リポジトリ）
 - [x] Services層（ビジネスロジック）
@@ -145,7 +159,7 @@
 - [x] Views層（メイン画面＋全ダイアログ）
 - [x] DIコンテナ設定（App.xaml.cs）
 
-### 追加機能（当初計画外で実装済み）
+#### 追加機能（当初計画外で実装済み）
 - [x] 共有フォルダモード（複数PC共有DB対応）
 - [x] データ入出力（CSV Export/Import）
 - [x] 履歴マージ機能
@@ -159,7 +173,7 @@
 
 ---
 
-## 参考リンク
+### 参考リンク
 
 - GitHub リポジトリ: https://github.com/kuwayamamasayuki/ICCardManager
 - GitHub Actions: https://github.com/kuwayamamasayuki/ICCardManager/actions


### PR DESCRIPTION
## 概要

Issue #1249 の対応（**案1: 廃止** を選択）。リポジトリ直下の `TODO.md` が v2.2.0 時点の「全フェーズ完了」状態のまま停止しており、v2.3.0〜v2.7.0 の主要変更（共有モード、Value Object 化、複数 refactor PR 等）が反映されていなかった。新規参画者がこれを現行ステータスと誤解する可能性があったため、**deprecated 化** して CHANGELOG.md と GitHub Issues を正の情報源として明示する。

## 選択した対応案

Issue #1249 の対応案のうち **案1（廃止）** を採用：

> ✅ **案1: 廃止** — TODO.md の先頭に「このファイルは deprecated です」と明記、残る内容は archive
> ❌ 案2: 刷新 — v2.7.0 時点の現行 TODO に置き換え

**案1 を選んだ理由**:
- TODO はフローが激しい（毎週変わる）ため、一度刷新しても数ヶ月で再陳腐化する
- GitHub Issues が既に機能しており、進行中タスクの追跡はそちらに集約されている
- CHANGELOG.md が歴史的経緯を詳細に記録している
- Single Source of Truth を明確にすることで情報の分散を防ぐ

## 変更内容

### `TODO.md`（リポジトリ直下）

#### 1. 冒頭に deprecated 警告ブロックを追加

```markdown
> **⚠️ このファイルは deprecated です（2026-04-17 付け・Issue #1249）**
>
> 本ファイルは v2.2.0 時点の初期実装タスク進捗を記録したもので、
> v2.3.0 以降の機能追加・リファクタリング・バグ修正は反映されていません
> （現行バージョンは v2.7.0）。
>
> **新しい情報源**:
> - バージョン履歴・変更内容 → CHANGELOG.md
> - 進行中タスク・バグ・要望 → GitHub Issues
> - 開発者向けガイド → 開発者ガイド.md
> - 設計書 → docs/design/
```

#### 2. 既存内容を「付録: アーカイブ」として保持

- **内容は削除せず**、§「付録: v2.2.0 時点の初期実装タスクアーカイブ」として保持
- 歴史的記録として追跡可能に
- 見出しレベルを調整（`##` → `###`、`###` → `####`）してアーカイブ内の階層構造を維持
- アーカイブ冒頭で「当時の『全フェーズ完了』は陳腐化」と明記

### `CLAUDE.md`（リポジトリ直下）

#### 「参照ドキュメント」セクションを拡充
冒頭に **`ICCardManager/CHANGELOG.md` を Single Source of Truth** として追加。

#### 「非推奨ドキュメント」セクションを新設

```markdown
## 非推奨ドキュメント

- `TODO.md`（リポジトリ直下） — v2.2.0 時点の初期実装タスクアーカイブ。
  **deprecated**（Issue #1249）。以降の進捗・要望管理は GitHub Issues と
  CHANGELOG.md を使用する。新規作業の優先度判断には使用しないこと。
```

これにより、Claude Code または新規参画者が CLAUDE.md を読んだ時点で「TODO.md は使うべきではない」と判断できる導線を設計。

## 効果

- **誤用防止**: 新規参画者が TODO.md の「全フェーズ完了」を現行ステータスと誤解しない
- **歴史保全**: v2.2.0 リリース時の計画と結果を記録として保持
- **SSoT 明確化**: CHANGELOG.md / GitHub Issues が正の情報源であることを CLAUDE.md で明示
- **スキャン効率**: CLAUDE.md が最上位ガイドなので、そこから deprecation 状態が即座に伝わる

## 検証

- **変更規模**: 2 ファイル、+35 / -16 行
- **ビルド影響**: なし（ドキュメントのみ）
- **単体テスト**: ドキュメント変更のため不要
- **内容削除なし**: アーカイブとして全タスク記録を保持

## 手動確認いただきたい項目

- [ ] TODO.md 冒頭の警告ブロックが目立つ表示になるか（GitHub / Markdown リーダー）
- [ ] アーカイブ内の見出し階層（`####` Phase 1〜9）が正しくネストされているか
- [ ] CLAUDE.md の新セクション「非推奨ドキュメント」が Claude Code の自動参照で機能するか
- [ ] リンク（`ICCardManager/CHANGELOG.md` 等）が正しく辿れるか

## 関連

- Closes #1249
- 参考: `ICCardManager/CHANGELOG.md` — 本 PR で SSoT として位置付け
- 参考: GitHub Issues — 進行中タスクの正式な管理場所

🤖 Generated with [Claude Code](https://claude.com/claude-code)