### PR TITLE
test: 年度跨ぎ（3月末/4月初）の累計・繰越計算テスト拡充 (#1252)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -286,12 +286,16 @@
 | 1 | 繰越行なし | Carryover=null | DataRows空 |
 | 1a | 年度途中繰越の受入欄空欄 | Summary="7月から繰越", Income=5000 | Income=null（既存データでも受入欄を空欄化） |
 | 2 | 4月前年度繰越 | 4月, Income=5000 | 繰越行: Income=5000, IsBold=true, RowType=Carryover |
+| 2a | 4月前年度繰越行のExpense空欄（Issue #1252） | 4月繰越, Income=10000 | 繰越行: Income=10000, **Expense=null**（繰越行は払出欄を持たない） |
 | 3 | 月次繰越の受入なし | 8月, Income=null | 繰越行: Income=null |
+| 3a | 月次繰越のIncome/Expense両方空欄（Issue #1252） | 10月繰越, Income=null | Income=null, Expense=null, Balance=4500のみ |
 | 4 | 明細行の日付和暦変換 | Date=2024-06-15 | DateDisplay=WarekiConverter結果 |
 | 5 | 収入0→null変換 | Income=0 | row.Income=null |
 | 6 | 支出0→null変換 | Expense=0 | row.Expense=null |
 | 7 | 収入・支出正の値保持 | Income=1000, Expense=500 | 値そのまま保持 |
 | 8 | 繰越行→明細行の順序 | 繰越+明細 | [0]=Carryover, [1]=Data |
+| 8a | 3月の完全行順序（Issue #1252） | 3月, 繰越+明細2+月計+累計+次年度繰越 | DataRows=[Carryover,Data,Data], MonthlyTotal→CumulativeTotal→CarryoverToNextYear の全要素が設定 |
+| 8b | 4月の行順序（Issue #1252） | 4月, 繰越+明細+月計のみ | DataRows=[Carryover,Data], MonthlyTotal.Balance有, CumulativeTotal=null, CarryoverToNextYear=null |
 | 9 | 月計変換 | Label="6月計", Income=5000 | MonthlyTotal正しく変換 |
 | 10 | 4月月計に残額あり | Balance=7700 | MonthlyTotal.Balance=7700, CumulativeTotal=null |
 | 11 | 累計変換 | Income=20000, Balance=14600 | CumulativeTotal正しく変換 |
@@ -974,6 +978,13 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 10 | 年度途中導入の累計加算(Issue #1215) | 10月 | CarryoverIncomeTotal=10000, CarryoverExpenseTotal=3200, CarryoverFiscalYear=2025 | CumulativeTotal.Income += 10000, Expense += 3200 |
 | 11 | 翌年度は累計加算しない(Issue #1215) | 5月(翌年度) | CarryoverFiscalYear=2025, 当年度=2026 | 紙の累計が加算されない |
 | 12 | 繰越ledgerの受入は月計から除外 | 8月 | "7月から繰越"(Income=5000) + 通常利用 | MonthlyTotal.Income=0（繰越の受入を除外） |
+| 13 | 3月末→4月初のシームレス遷移（Issue #1252） | 同一カードで2026年3月と2026年4月を連続生成 | march.CarryoverToNextYear == april.Carryover.Income（次年度繰越と前年度繰越Incomeが一致） |
+| 14 | 複数年度履歴の当年度累計独立（Issue #1252） | 2026年度5月, 過去年度データあり | CumulativeTotal.Expense=210（当年度分のみ、過去年度混入なし） |
+| 15 | 3月の全年度累計合計（Issue #1252） | 各月1件×12ヶ月の年度末3月 | CumulativeTotal=年度全体の合計, CarryoverToNextYear=月末残高と一致 |
+| 16 | 紙の出納簿累計の翌々年度非加算（Issue #1252） | CarryoverFiscalYear=2025, 2028年度6月 | CumulativeTotal.Expense=400のみ（紙の15000は加算されない） |
+| 17 | 繰越年度4月では月計に紙累計を加算しない（Issue #1252） | CarryoverFiscalYear=2025, 2025年4月 | MonthlyTotal.Expense=210（当月実績のみ、紙累計は月計に加算されない） |
+| 18 | 4月前年度繰越はIncomeのみ保持（Issue #1252） | 4月, 前年度残高=7500 | Carryover.Income=7500, Balance=7500（Expenseプロパティ不在で設計上分離） |
+| 19 | 非4月の月次繰越はIncome=null（Issue #1252） | 10月, 前月残高=3000 | Carryover.Income=null, Balance=3000 |
 
 **テストクラス:** `ReportDataBuilderTests`
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
@@ -562,4 +562,302 @@ public class ReportDataBuilderTests
     }
 
     #endregion
+
+    #region Issue #1252: 年度跨ぎ（3月末→4月初）のシームレス遷移テスト
+
+    [Fact]
+    public async Task BuildAsync_MarchEndToAprilStart_SeamlessTransition()
+    {
+        // Arrange: 2025年度末（2026年3月）の残額が 2026年度初め（2026年4月）の前年度繰越として引き継がれる
+        // 同一カードで 3月帳票 → 4月帳票 を連続生成し、3月の CarryoverToNextYear と 4月の前年度繰越 Income が一致することを検証
+        SetupCard();
+
+        // 2026年3月の履歴: 月初残高3000, 3/5に300円利用 → 月末残高2700
+        var marchLedgers = new List<Ledger>
+        {
+            CreateTestLedger(20, TestCardIdm, new DateTime(2026, 3, 5),
+                "鉄道（天神～博多）", 0, 300, 2700)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2026, 2,
+            new List<Ledger>
+            {
+                CreateTestLedger(19, TestCardIdm, new DateTime(2026, 2, 20), "鉄道", 0, 200, 3000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2026, 3, marchLedgers);
+
+        // 2025年度全体（2025/4/1～2026/3/31）の履歴
+        var yearlyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10), "鉄道", 0, 500, 4500),
+            CreateTestLedger(19, TestCardIdm, new DateTime(2026, 2, 20), "鉄道", 0, 200, 3000),
+            CreateTestLedger(20, TestCardIdm, new DateTime(2026, 3, 5), "鉄道", 0, 300, 2700)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2026, 3, 31), yearlyLedgers);
+
+        // 2026年度の繰越残高は2025年度末の2700円
+        SetupCarryoverBalance(TestCardIdm, 2025, 2700);
+
+        // 2026年4月の履歴: 4/10に210円利用 → 残高2490
+        var aprilLedgers = new List<Ledger>
+        {
+            CreateTestLedger(21, TestCardIdm, new DateTime(2026, 4, 10),
+                "鉄道（天神～博多）", 0, 210, 2490)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2026, 4, aprilLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2026, 4, 1), new DateTime(2026, 4, 30), aprilLedgers);
+
+        // Act
+        var marchResult = await _builder.BuildAsync(TestCardIdm, 2026, 3);
+        var aprilResult = await _builder.BuildAsync(TestCardIdm, 2026, 4);
+
+        // Assert: 3月の次年度繰越額と 4月の前年度繰越 Income および Balance が一致
+        marchResult.CarryoverToNextYear.Should().Be(2700, "3月は年度末残高を次年度繰越として保持する");
+        aprilResult.Carryover.Should().NotBeNull();
+        aprilResult.Carryover.Income.Should().Be(2700, "4月の前年度繰越受入は前年度末の残高と一致する");
+        aprilResult.Carryover.Balance.Should().Be(2700);
+        aprilResult.Carryover.Income.Should().Be(marchResult.CarryoverToNextYear,
+            "3月末→4月初のシームレス遷移：次年度繰越と前年度繰越Incomeは同じ値");
+
+        // 4月は累計省略で月計に残額表示
+        aprilResult.MonthlyTotal.Balance.Should().Be(2490);
+        aprilResult.CumulativeTotal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BuildAsync_MultiYearCard_EachFiscalYearCumulativeIndependent()
+    {
+        // Arrange: 2024年度から2026年度まで履歴があるカードで、2026年度5月の帳票を作成
+        // 累計は「当年度分のみ」であり、過去年度の累計が混入しないことを検証
+        SetupCard();
+
+        // 2026年4月の残高（2025年度末からの繰越）
+        SetupCarryoverBalance(TestCardIdm, 2025, 3000);
+
+        var mayLedgers = new List<Ledger>
+        {
+            CreateTestLedger(300, TestCardIdm, new DateTime(2026, 5, 10),
+                "鉄道（天神～博多）", 0, 210, 2790)
+        };
+        // 前月(2026年4月)の残高レコード
+        SetupMonthlyLedgers(TestCardIdm, 2026, 4,
+            new List<Ledger>
+            {
+                CreateTestLedger(299, TestCardIdm, new DateTime(2026, 4, 5), "鉄道", 0, 0, 3000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2026, 5, mayLedgers);
+
+        // 2026年度の範囲（2026/4/1～2026/5/31）は2件のみ
+        var fy2026Ledgers = new List<Ledger>
+        {
+            CreateTestLedger(299, TestCardIdm, new DateTime(2026, 4, 5), "鉄道", 0, 0, 3000),
+            CreateTestLedger(300, TestCardIdm, new DateTime(2026, 5, 10), "鉄道", 0, 210, 2790)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2026, 4, 1), new DateTime(2026, 5, 31), fy2026Ledgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2026, 5);
+
+        // Assert: 累計は2026年度分のみ（過去年度は混入しない）
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Expense.Should().Be(210,
+            "累計は当年度（2026年度）のみで、過去年度の支出は含まれない");
+        result.CumulativeTotal.Income.Should().Be(0);
+        result.CumulativeTotal.Balance.Should().Be(2790);
+
+        // 月次繰越行は前月末残高（=前年度末残高）
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Balance.Should().Be(3000);
+        result.Carryover.Income.Should().BeNull("5月の月次繰越は受入欄空欄");
+    }
+
+    [Fact]
+    public async Task BuildAsync_March_WithMultipleMonthsData_CumulativeSumsWholeFiscalYear()
+    {
+        // Arrange: 2025年4月～2026年3月まで各月に利用がある場合の3月帳票
+        // 累計が年度全体を正しく合計し、3月の次年度繰越額が月末残高と一致することを検証
+        SetupCard();
+
+        var marchLedgers = new List<Ledger>
+        {
+            CreateTestLedger(100, TestCardIdm, new DateTime(2026, 3, 20),
+                "役務費によりチャージ", 1000, 0, 4500),
+            CreateTestLedger(101, TestCardIdm, new DateTime(2026, 3, 28),
+                "鉄道（天神～博多）", 0, 500, 4000)
+        };
+
+        SetupMonthlyLedgers(TestCardIdm, 2026, 2,
+            new List<Ledger>
+            {
+                CreateTestLedger(50, TestCardIdm, new DateTime(2026, 2, 28), "鉄道", 0, 200, 3500)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2026, 3, marchLedgers);
+
+        // 年度累計: 各月1件ずつ（4月/7月/10月/1月/2月/3月）
+        var yearlyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10), "チャージ", 5000, 0, 5000),
+            CreateTestLedger(2, TestCardIdm, new DateTime(2025, 7, 15), "鉄道", 0, 300, 4700),
+            CreateTestLedger(3, TestCardIdm, new DateTime(2025, 10, 20), "鉄道", 0, 400, 4300),
+            CreateTestLedger(4, TestCardIdm, new DateTime(2026, 1, 15), "鉄道", 0, 300, 4000),
+            CreateTestLedger(50, TestCardIdm, new DateTime(2026, 2, 28), "鉄道", 0, 200, 3500),
+            CreateTestLedger(100, TestCardIdm, new DateTime(2026, 3, 20), "チャージ", 1000, 0, 4500),
+            CreateTestLedger(101, TestCardIdm, new DateTime(2026, 3, 28), "鉄道", 0, 500, 4000)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2026, 3, 31), yearlyLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2026, 3);
+
+        // Assert: 累計は年度全体の合計
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(6000, "年度累計の受入=4月5000+3月1000");
+        result.CumulativeTotal.Expense.Should().Be(1700, "年度累計の払出=300+400+300+200+500");
+        result.CumulativeTotal.Balance.Should().Be(4000);
+
+        // 次年度繰越は月末残高と一致
+        result.CarryoverToNextYear.Should().Be(4000,
+            "3月の次年度繰越は月末残高（=累計のBalance）と一致");
+    }
+
+    #endregion
+
+    #region Issue #1252: CarryoverIncomeTotal/ExpenseTotal の翌年度非加算（強化テスト）
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_ThreeYearsLater_NeverAddsCarryoverTotals()
+    {
+        // Arrange: 2025年度導入、3年後の2028年度帳票では絶対に加算されないことを検証
+        // 「翌年度で非加算」だけでなく、以降の全年度でも非加算であることの回帰防止
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 50000,
+            CarryoverExpenseTotal = 15000,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var junLedgers = new List<Ledger>
+        {
+            CreateTestLedger(500, TestCardIdm, new DateTime(2028, 6, 10), "鉄道", 0, 300, 2000)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2028, 5,
+            new List<Ledger>
+            {
+                CreateTestLedger(499, TestCardIdm, new DateTime(2028, 5, 31), "鉄道", 0, 100, 2300)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2028, 6, junLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2028, 4, 1), new DateTime(2028, 6, 30),
+            new List<Ledger>
+            {
+                CreateTestLedger(499, TestCardIdm, new DateTime(2028, 5, 31), "鉄道", 0, 100, 2300),
+                CreateTestLedger(500, TestCardIdm, new DateTime(2028, 6, 10), "鉄道", 0, 300, 2000)
+            });
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2028, 6);
+
+        // Assert: 紙時代の累計（50000/15000）は一切加算されない
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0, "導入年度(2025)以降の別年度は累計加算対象外");
+        result.CumulativeTotal.Expense.Should().Be(400, "加算は 100+300 のみ、紙時代の15000は加算しない");
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_AprilOfCarryoverYear_AppliesToCumulativeCalculation()
+    {
+        // Arrange: 2025年度途中導入で、繰越年度(2025)の4月帳票を作成するケース
+        // 4月は累計省略のため月計Balanceに反映されるが、紙時代の累計は加算対象
+        // （4月の月計は「年度全体=1ヶ月」なので cumulative と同義）
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 8000,
+            CarryoverExpenseTotal = 2000,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        SetupCarryoverBalance(TestCardIdm, 2024, 5000);
+        var aprilLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 4, 10), "鉄道", 0, 210, 4790)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 4, aprilLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 4, 30), aprilLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 4);
+
+        // Assert: 4月は累計省略（cumulativeはnull）。月計は当月分のみで、紙時代累計は cumulative 側の計算にのみ乗る
+        // 実装では cumulativeTotal=null となり、月計側の集計には紙時代累計は加算されない設計
+        result.CumulativeTotal.Should().BeNull("4月は累計省略");
+        result.MonthlyTotal.Income.Should().Be(0, "月計は当月実績のみ、紙時代累計は月計に加算しない");
+        result.MonthlyTotal.Expense.Should().Be(210);
+        result.MonthlyTotal.Balance.Should().Be(4790);
+    }
+
+    #endregion
+
+    #region Issue #1252: 繰越行金額表示（Income/Expense分離）
+
+    [Fact]
+    public async Task BuildAsync_April_CarryoverRow_HasIncomeOnly()
+    {
+        // Arrange: 4月の前年度繰越行は Income に残高を持ち、Expense は概念上存在しない
+        // （CarryoverRowData は Income プロパティのみを持つ設計）
+        SetupCard();
+        SetupCarryoverBalance(TestCardIdm, 2024, 7500);
+        SetupMonthlyLedgers(TestCardIdm, 2025, 4, new List<Ledger>());
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 4, 30), new List<Ledger>());
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 4);
+
+        // Assert: 4月繰越行は Income=Balance、Expense 概念なし（CarryoverRowData に Expense プロパティは存在しない）
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Income.Should().Be(7500);
+        result.Carryover.Balance.Should().Be(7500);
+        // CarryoverRowData には Expense が存在しないことで Income/Expense 分離が保証されている
+    }
+
+    [Fact]
+    public async Task BuildAsync_NonApril_CarryoverRow_HasNoIncome()
+    {
+        // Arrange: 5月以降の月次繰越行は Income=null（受入欄空欄）、Balance のみ
+        SetupCard();
+        var octoberLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 10, 5), "鉄道", 0, 210, 2790)
+        };
+        SetupBasicMonth(2025, 10, 3000, octoberLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 10, 31), octoberLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 10);
+
+        // Assert: 月次繰越は Income=null、Balance のみ
+        result.Carryover.Should().NotBeNull();
+        result.Carryover.Income.Should().BeNull("月次繰越の受入欄は空欄");
+        result.Carryover.Balance.Should().Be(3000);
+        result.Carryover.Summary.Should().Contain("9月").And.Contain("繰越");
+    }
+
+    #endregion
 }

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportRowBuilderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportRowBuilderTests.cs
@@ -329,6 +329,152 @@ public class ReportRowBuilderTests
 
     #endregion
 
+    #region Issue #1252: 繰越行の金額表示（Income/Expense 分離）
+
+    [Fact]
+    public void Build_4月前年度繰越行のExpenseは常に空欄()
+    {
+        // 繰越行は受入（Income）のみを持つ設計。CarryoverRowData に Expense プロパティが
+        // 存在しないため、ReportRow.Expense は決して設定されないことを検証
+        var data = CreateBaseData(2025, 4);
+        data.Carryover = new CarryoverRowData
+        {
+            Date = new DateTime(2025, 4, 1),
+            Summary = "前年度より繰越",
+            Income = 10000,
+            Balance = 10000
+        };
+        data.Ledgers = new List<Ledger>();
+
+        var result = ReportRowBuilder.Build(data);
+
+        var row = result.DataRows[0];
+        row.RowType.Should().Be(ReportRowType.Carryover);
+        row.Income.Should().Be(10000, "4月の前年度繰越は受入欄に金額を持つ");
+        row.Expense.Should().BeNull("繰越行は払出欄を持たない（Income/Expense 分離）");
+        row.Balance.Should().Be(10000);
+    }
+
+    [Fact]
+    public void Build_月次繰越行のIncomeもExpenseも空欄()
+    {
+        // 5月以降の月次繰越行は Income=null、Expense=null（どちらも空欄）
+        // Balance のみ持つ
+        var data = CreateBaseData(2025, 10);
+        data.Carryover = new CarryoverRowData
+        {
+            Date = new DateTime(2025, 10, 1),
+            Summary = "9月より繰越",
+            Income = null,
+            Balance = 4500
+        };
+        data.Ledgers = new List<Ledger>();
+
+        var result = ReportRowBuilder.Build(data);
+
+        var row = result.DataRows[0];
+        row.RowType.Should().Be(ReportRowType.Carryover);
+        row.Income.Should().BeNull("月次繰越は受入欄空欄");
+        row.Expense.Should().BeNull("繰越行は払出欄を持たない");
+        row.Balance.Should().Be(4500);
+    }
+
+    #endregion
+
+    #region Issue #1252: 帳票出力の行順序（繰越→明細→月計→累計→次年度繰越）
+
+    [Fact]
+    public void Build_3月の完全な行順序_繰越と明細と月計と累計と次年度繰越()
+    {
+        // 3月帳票には全5種の行要素が含まれる:
+        //   DataRows: [0]=Carryover → [1..n]=Data
+        //   続いて: MonthlyTotal → CumulativeTotal → CarryoverToNextYear
+        // ReportRowSet の構造でこの順序が保証されていることを検証
+        var data = CreateBaseData(2025, 3);
+        data.Carryover = new CarryoverRowData
+        {
+            Date = new DateTime(2025, 3, 1),
+            Summary = "2月より繰越",
+            Income = null,
+            Balance = 5000
+        };
+        data.Ledgers = new List<Ledger>
+        {
+            new() { Date = new DateTime(2025, 3, 5), Summary = "鉄道（博多～天神）",
+                     Income = 0, Expense = 300, Balance = 4700 },
+            new() { Date = new DateTime(2025, 3, 20), Summary = "役務費によりチャージ",
+                     Income = 2000, Expense = 0, Balance = 6700 }
+        };
+        data.MonthlyTotal = new ReportTotalData
+        {
+            Label = "3月計", Income = 2000, Expense = 300, Balance = null
+        };
+        data.CumulativeTotal = new ReportTotalData
+        {
+            Label = "累計", Income = 10000, Expense = 3300, Balance = 6700
+        };
+        data.CarryoverToNextYear = 6700;
+
+        var result = ReportRowBuilder.Build(data);
+
+        // DataRows 先頭は繰越行、後続は明細行
+        result.DataRows.Should().HaveCount(3, "繰越1件 + 明細2件");
+        result.DataRows[0].RowType.Should().Be(ReportRowType.Carryover, "1行目は繰越");
+        result.DataRows[0].Summary.Should().Be("2月より繰越");
+        result.DataRows[1].RowType.Should().Be(ReportRowType.Data, "2行目は明細");
+        result.DataRows[2].RowType.Should().Be(ReportRowType.Data, "3行目は明細");
+
+        // 集計行はそれぞれ設定される（月計 → 累計 → 次年度繰越）
+        result.MonthlyTotal.Should().NotBeNull();
+        result.MonthlyTotal.Label.Should().Be("3月計");
+        result.MonthlyTotal.Income.Should().Be(2000);
+        result.MonthlyTotal.Expense.Should().Be(300);
+
+        result.CumulativeTotal.Should().NotBeNull("3月は累計あり");
+        result.CumulativeTotal!.Label.Should().Be("累計");
+        result.CumulativeTotal.Balance.Should().Be(6700);
+
+        result.CarryoverToNextYear.Should().Be(6700, "3月の最後に次年度繰越");
+    }
+
+    [Fact]
+    public void Build_4月の行順序_繰越と明細と月計のみ_累計も次年度繰越もなし()
+    {
+        // 4月帳票は累計省略・次年度繰越なし。月計に残額を表示する
+        var data = CreateBaseData(2025, 4);
+        data.Carryover = new CarryoverRowData
+        {
+            Date = new DateTime(2025, 4, 1),
+            Summary = "前年度より繰越",
+            Income = 5000,
+            Balance = 5000
+        };
+        data.Ledgers = new List<Ledger>
+        {
+            new() { Date = new DateTime(2025, 4, 10), Summary = "鉄道",
+                     Income = 0, Expense = 210, Balance = 4790 }
+        };
+        data.MonthlyTotal = new ReportTotalData
+        {
+            Label = "4月計", Income = 0, Expense = 210, Balance = 4790
+        };
+        data.CumulativeTotal = null;
+        data.CarryoverToNextYear = null;
+
+        var result = ReportRowBuilder.Build(data);
+
+        result.DataRows.Should().HaveCount(2);
+        result.DataRows[0].RowType.Should().Be(ReportRowType.Carryover);
+        result.DataRows[0].Income.Should().Be(5000, "4月繰越は Income 持つ");
+        result.DataRows[1].RowType.Should().Be(ReportRowType.Data);
+
+        result.MonthlyTotal.Balance.Should().Be(4790, "4月は月計に残額を表示");
+        result.CumulativeTotal.Should().BeNull("4月は累計省略");
+        result.CarryoverToNextYear.Should().BeNull("4月は次年度繰越なし");
+    }
+
+    #endregion
+
     #region 統合テスト（繰越 + 明細 + 合計 + 累計）
 
     [Fact]


### PR DESCRIPTION
## 概要
Issue #1252 の対応。`ReportDataBuilder` / `ReportRowBuilder` の年度跨ぎ処理（月計→累計→次年度繰越→前年度繰越）のテストカバレッジを拡充する。年1回しか実行されない処理だが誤りが財務報告書に直結する重大機能のため、3月末→4月初のシームレス遷移を中心に回帰防止テストを追加。

## Issue #1252 チェックリスト対応
- [x] **3月末データ → 4月開始のシームレス遷移**: `BuildAsync_MarchEndToAprilStart_SeamlessTransition` で `march.CarryoverToNextYear == april.Carryover.Income` を検証
- [x] **繰越行の金額表示（Income/Expense の分離）**: `BuildAsync_April_CarryoverRow_HasIncomeOnly` / `BuildAsync_NonApril_CarryoverRow_HasNoIncome` / `Build_4月前年度繰越行のExpenseは常に空欄` / `Build_月次繰越行のIncomeもExpenseも空欄` で検証
- [x] **帳票出力の行順序（繰越 → 明細 → 月計 → 累計 → 次年度繰越）**: `Build_3月の完全な行順序_繰越と明細と月計と累計と次年度繰越` / `Build_4月の行順序_繰越と明細と月計のみ_累計も次年度繰越もなし` で検証
- [x] **複数年度にまたがるカードの履歴統計**: `BuildAsync_MultiYearCard_EachFiscalYearCumulativeIndependent` / `BuildAsync_March_WithMultipleMonthsData_CumulativeSumsWholeFiscalYear` で検証
- [x] **`CarryoverIncomeTotal` / `CarryoverExpenseTotal` の翌年度での非加算検証**: 既存 `BuildAsync_MidYearCarryover_NextFiscalYear_DoesNotAddCarryoverTotals` を強化する `BuildAsync_MidYearCarryover_ThreeYearsLater_NeverAddsCarryoverTotals`（3年後でも非加算）と `BuildAsync_MidYearCarryover_AprilOfCarryoverYear_AppliesToCumulativeCalculation`（4月は累計省略時の月計非加算）を追加
- [x] **繰越 Ledger（Summary=\"7月から繰越\"）の Income を月計から除外**: 既存 `BuildAsync_MidYearCarryoverLedger_ExcludedFromMonthlyIncome` でカバー済み（Issue #1215）

## 変更内容
### ReportDataBuilderTests.cs（7件追加）
1. `BuildAsync_MarchEndToAprilStart_SeamlessTransition` - 3月末→4月初の繰越連鎖
2. `BuildAsync_MultiYearCard_EachFiscalYearCumulativeIndependent` - 複数年度履歴の当年度累計独立性
3. `BuildAsync_March_WithMultipleMonthsData_CumulativeSumsWholeFiscalYear` - 3月の年度全体累計合計
4. `BuildAsync_MidYearCarryover_ThreeYearsLater_NeverAddsCarryoverTotals` - 紙累計の翌々年度非加算
5. `BuildAsync_MidYearCarryover_AprilOfCarryoverYear_AppliesToCumulativeCalculation` - 繰越年度4月での月計非加算
6. `BuildAsync_April_CarryoverRow_HasIncomeOnly` - 4月繰越行の Income-only 設計検証
7. `BuildAsync_NonApril_CarryoverRow_HasNoIncome` - 非4月月次繰越のIncome=null

### ReportRowBuilderTests.cs（4件追加）
1. `Build_4月前年度繰越行のExpenseは常に空欄` - Income/Expense 分離
2. `Build_月次繰越行のIncomeもExpenseも空欄`
3. `Build_3月の完全な行順序_繰越と明細と月計と累計と次年度繰越`
4. `Build_4月の行順序_繰越と明細と月計のみ_累計も次年度繰越もなし`

### テスト設計書（`07_テスト設計書.md`）
- UT-002g に #2a, #3a, #8a, #8b を追加
- UT-018 に #13〜#19 を追加

## 関連
- Issue #1252
- Issue #1215 年度途中導入対応
- Issue #1219 年度途中繰越ledgerの受入欄修正

## Test plan
- [x] 追加した11件すべてGreen
- [x] `ReportDataBuilderTests` / `ReportRowBuilderTests` 全39件Green
- [x] 全2532件Green（リグレッションなし）
- [x] テスト設計書 `07_テスト設計書.md` を同期更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)