### PR TITLE
test: バス判別ロジック（IsBus）のエッジケーステスト追加 (#1253)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -105,6 +105,28 @@
 
 > ※ No.7: 駅コードは非ゼロだが、StationMasterServiceで駅名に解決できないケース。西鉄バス等の交通機関で発生する。
 
+**エッジケース（Issue #1253）:**
+
+FeliCa履歴ブロックのデコード時（`FelicaHistoryBlockDecoder.Decode`）に判定されるバス判別条件の境界テスト。
+実装条件: `!isCharge && !isPointRedemption && ((入場コード==0 && 出場コード==0) || (入場駅名==null && 出場駅名==null))`
+
+| No | テストケース | 入場駅コード | 出場駅コード | リゾルバ挙動 | is_charge | is_pt | 期待結果 |
+|----|-------------|-------------|-------------|-------------|-----------|-------|---------|
+| E1 | 入場のみ0・出場解決 | 0 | 0x5678 | 解決可 | false | false | is_bus=false |
+| E2 | 入場のみ0・出場解決不可 | 0 | 0x5678 | null | false | false | is_bus=**true**（両方null扱い） |
+| E3 | 出場のみ0・入場解決 | 0x1234 | 0 | 解決可 | false | false | is_bus=false |
+| E4 | リゾルバが空文字列を返す | 0x1234 | 0x5678 | "" | false | false | is_bus=false（空文字はnull非該当） |
+| E5 | null/空文字混在 | 0x1234 | 0x5678 | null/"" | false | false | is_bus=false |
+| E6 | チャージ+駅名解決可 | 0x1234 | 0x5678 | 解決可 | true | false | is_bus=false |
+| E7 | ポイント還元+駅名解決可 | 0x1234 | 0x5678 | 解決可 | false | true | is_bus=false |
+| E8 | Issue #942フォールバック発動（駅コード0+残高増加） | 0 | 0 | - | false | →true | is_bus=**true**（現状動作: 再計算されず維持） |
+| E9 | 駅コード両方0時のリゾルバ未呼出 | 0 | 0 | カウント | false | false | リゾルバ呼出=0回 |
+| E10 | リゾルバが例外をスロー | 0x1234 | 0x5678 | throw | - | - | Decode結果=null（内部catch） |
+
+> E8注: Issue #942のポイント還元フォールバックは`isPointRedemption`のみを`true`に変更し、`isBus`は再計算しない。そのため駅コード0で残高が増加する場合、`IsBus=true`かつ`IsPointRedemption=true`の複合状態が保存される。後段の`SummaryGenerator`は`!IsPointRedemption`でフィルタするため実害はない（現状動作の回帰防止テスト）。
+
+**テストクラス:** `FelicaHistoryBlockDecoderTests`
+
 ---
 
 ### 2.2 摘要文字列生成（SummaryGenerator）

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/FelicaHistoryBlockDecoderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/CardReader/FelicaHistoryBlockDecoderTests.cs
@@ -325,6 +325,183 @@ public class FelicaHistoryBlockDecoderTests
 
     #endregion
 
+    #region Issue #1253: バス判別のエッジケース
+
+    /// <summary>
+    /// Issue #1253: 入場駅コードのみ0、出場駅は駅名解決可能 → IsBus=false
+    /// 実装: 「駅コード両方0」の条件を満たさず、「駅名両方null」も満たさない（exitStationName は解決済み）
+    /// ため、バス判定されない
+    /// </summary>
+    [Fact]
+    public void Decode_EntryStationZero_ExitStationResolved_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0, exitStationCode: 0x5678, balance: 1000);
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, FakeResolver, out _);
+
+        result.IsBus.Should().BeFalse("出場駅名が解決できれば駅コード0でもバス扱いしない");
+        result.EntryStation.Should().BeNull("入場駅コード0のためリゾルバ未呼出で null");
+        result.ExitStation.Should().Be("駅5678");
+    }
+
+    /// <summary>
+    /// Issue #1253: 入場駅コードのみ0、出場駅は駅コードありで解決不可 → IsBus=true
+    /// 実装: 「駅コード両方0」は満たさないが、「駅名両方null」を満たす（入場=コード0でnull、出場=解決不可でnull）
+    /// </summary>
+    [Fact]
+    public void Decode_EntryStationZero_ExitStationUnresolved_IsBus()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0, exitStationCode: 0x5678, balance: 1000);
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, NullResolver, out _);
+
+        result.IsBus.Should().BeTrue("駅コード0と解決不可の組み合わせは両方null扱いでバス判定");
+        result.EntryStation.Should().BeNull();
+        result.ExitStation.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Issue #1253: 入場駅は解決可能、出場駅コードのみ0 → IsBus=false（逆パターン）
+    /// </summary>
+    [Fact]
+    public void Decode_ExitStationZero_EntryStationResolved_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0x1234, exitStationCode: 0, balance: 1000);
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, FakeResolver, out _);
+
+        result.IsBus.Should().BeFalse();
+        result.EntryStation.Should().Be("駅1234");
+        result.ExitStation.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Issue #1253: リゾルバが空文字列を返した場合の挙動を明文化
+    /// 実装は `entryStationName == null && exitStationName == null` を判定するため、
+    /// 空文字列は「解決済み」扱いとなり IsBus=false となる
+    /// （null と空文字列は区別される — 西鉄バス等は null を返す前提）
+    /// </summary>
+    [Fact]
+    public void Decode_ResolverReturnsEmptyString_TreatedAsResolved_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0x1234, exitStationCode: 0x5678, balance: 1000);
+        Func<int, int, string> emptyResolver = (_, _) => string.Empty;
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, emptyResolver, out _);
+
+        result.IsBus.Should().BeFalse("空文字列は null と区別され、解決済み扱いでバス判定されない");
+        result.EntryStation.Should().Be(string.Empty);
+        result.ExitStation.Should().Be(string.Empty);
+    }
+
+    /// <summary>
+    /// Issue #1253: null と 空文字列の混在パターン
+    /// 片方が null、片方が空文字列の場合、「両方 null」ではないため IsBus=false
+    /// </summary>
+    [Fact]
+    public void Decode_ResolverMixesNullAndEmpty_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0x1234, exitStationCode: 0x5678, balance: 1000);
+        // 入場は null（解決不可）、出場は空文字（何らかの理由で空文字マスタが引かれた想定）
+        Func<int, int, string> mixedResolver = (line, num) => line == 0x12 ? null : string.Empty;
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, mixedResolver, out _);
+
+        result.IsBus.Should().BeFalse("null と 空文字列の混在では両方nullの条件を満たさずバス判定されない");
+        result.EntryStation.Should().BeNull();
+        result.ExitStation.Should().Be(string.Empty);
+    }
+
+    /// <summary>
+    /// Issue #1253: チャージで駅名も解決可能な場合 → IsBus=false（最優先判定）
+    /// </summary>
+    [Fact]
+    public void Decode_ChargeWithResolvedStations_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x02, entryStationCode: 0x1234, exitStationCode: 0x5678, balance: 1500);
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, FakeResolver, out _);
+
+        result.IsCharge.Should().BeTrue();
+        result.IsBus.Should().BeFalse();
+        result.EntryStation.Should().Be("駅1234");
+        result.ExitStation.Should().Be("駅5678");
+    }
+
+    /// <summary>
+    /// Issue #1253: ポイント還元で駅名も解決可能な場合 → IsBus=false
+    /// </summary>
+    [Fact]
+    public void Decode_PointRedemptionWithResolvedStations_NotBus()
+    {
+        var block = BuildBlock(usageType: 0x0D, entryStationCode: 0x1234, exitStationCode: 0x5678, balance: 1500);
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, FakeResolver, out _);
+
+        result.IsPointRedemption.Should().BeTrue();
+        result.IsBus.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Issue #1253: Issue #942 フォールバック発動時の IsBus の動作を明文化
+    /// 駅コード両方0 + 残高増加（通常利用扱いだが金額が負）の場合、
+    /// 最初に isBus=true（非チャージ・非還元＋駅コード0）と判定されたあとで、
+    /// フォールバックにより isPointRedemption が true に変わる。
+    /// IsBus 自体は再計算されないため IsBus=true のまま残り、
+    /// 「IsBus=true かつ IsPointRedemption=true」の複合状態となる。
+    /// 後段の SummaryGenerator では `!IsPointRedemption` フィルタで分類されるため実害はないが、
+    /// データベース上は複合状態として保存されることを明示的にテストする。
+    /// </summary>
+    [Fact]
+    public void Decode_Issue942Fallback_ZeroStations_IsBusStaysTrueWithFallback()
+    {
+        // 0x16（通常利用）だが残高が増加 → フォールバックで isPointRedemption=true になる
+        var previous = BuildBlock(balance: 500);
+        var current = BuildBlock(usageType: 0x16, entryStationCode: 0, exitStationCode: 0, balance: 700);
+
+        var result = FelicaHistoryBlockDecoder.Decode(current, previous, NullResolver, out var fallback);
+
+        fallback.Should().BeTrue("残高増加でフォールバックが発動する");
+        result.IsPointRedemption.Should().BeTrue();
+        result.IsBus.Should().BeTrue(
+            "Issue #942 フォールバックは IsBus を再計算しないため、駅コード0での初期判定 IsBus=true が維持される（後段処理では IsPointRedemption が優先されるため実害なし）");
+        result.Amount.Should().Be(200);
+    }
+
+    /// <summary>
+    /// Issue #1253: 駅コード=0 とリゾルバ nullの区別 — 両方0の場合は resolveStationName が呼ばれない
+    /// resolveStationName 呼び出しがゼロ回であることを検証
+    /// </summary>
+    [Fact]
+    public void Decode_BothStationCodesZero_ResolverNotCalled()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0, exitStationCode: 0, balance: 1000);
+        var callCount = 0;
+        Func<int, int, string> countingResolver = (_, _) => { callCount++; return "呼ばれちゃダメ"; };
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, countingResolver, out _);
+
+        callCount.Should().Be(0, "駅コード両方0の場合はリゾルバを呼び出さない");
+        result.IsBus.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Issue #1253: resolveStationName が例外を投げた場合も decoder は null を返す（内部 try-catch による防衛）
+    /// </summary>
+    [Fact]
+    public void Decode_ResolverThrowsException_ReturnsNull()
+    {
+        var block = BuildBlock(usageType: 0x16, entryStationCode: 0x1234, exitStationCode: 0x5678, balance: 1000);
+        Func<int, int, string> throwingResolver = (_, _) => throw new InvalidOperationException("マスタ参照エラー");
+
+        var result = FelicaHistoryBlockDecoder.Decode(block, null, throwingResolver, out var fallback);
+
+        result.Should().BeNull("リゾルバ例外は内部 catch で null を返すため、呼び出し側で null チェックが可能");
+        fallback.Should().BeFalse();
+    }
+
+    #endregion
+
     #region 金額計算
 
     /// <summary>


### PR DESCRIPTION
## 概要
Issue #1253 の対応。`Services/SummaryGenerator.cs` およびバス判別の実装箇所 `FelicaHistoryBlockDecoder.Decode` の境界条件テストを拡充する。バス判別は月次帳票生成の起点となる重要機能のため、エッジケースの回帰防止テストを追加。

## 実装箇所の特定
バス判別ロジックは本番経路では以下のみ:
- `FelicaHistoryBlockDecoder.Decode` — カード実タッチ時の判定（**対象**）
- `VirtualCardViewModel.Commit` — `#if DEBUG` 専用（DEBUGビルドのみ有効、本番非経路）
- `CsvImportService` — 既にフラグ化された `is_bus` を取り込むのみで判別ロジックなし

本番判別条件:
`!isCharge && !isPointRedemption && ((入場コード==0 && 出場コード==0) || (入場駅名==null && 出場駅名==null))`

## Issue #1253 チェックリスト対応
- [x] **`is_charge=true` かつ乗車駅・降車駅が空欄 → `is_bus=false`**: 既存 `Decode_ChargeWithZeroStations_NotBus` + 新規 `Decode_ChargeWithResolvedStations_NotBus`
- [x] **`is_point_redemption=true` かつ乗車駅・降車駅が空欄 → `is_bus=false`**: 既存 `Decode_PointRedemptionWithZeroStations_NotBus` + 新規 `Decode_PointRedemptionWithResolvedStations_NotBus`
- [x] **駅コード非ゼロだが駅名解決不可の場合（西鉄バス等、TC007）**: 既存 `Decode_StationCodesPresentButUnresolved_IsBus` カバー済
- [x] **null と空文字列の混在パターン**: 新規 `Decode_ResolverReturnsEmptyString_TreatedAsResolved_NotBus` / `Decode_ResolverMixesNullAndEmpty_NotBus`
- [x] **駅コード=0 と未設定の区別**: 新規 `Decode_EntryStationZero_ExitStationResolved_NotBus` / `Decode_EntryStationZero_ExitStationUnresolved_IsBus` / `Decode_ExitStationZero_EntryStationResolved_NotBus` / `Decode_BothStationCodesZero_ResolverNotCalled`

## 追加テスト一覧（FelicaHistoryBlockDecoderTests — 10件）
| テスト | 検証ポイント |
|--------|-------------|
| `Decode_EntryStationZero_ExitStationResolved_NotBus` | 片方駅コード0・もう片方解決可 → IsBus=false |
| `Decode_EntryStationZero_ExitStationUnresolved_IsBus` | 片方駅コード0・もう片方解決不可 → IsBus=true（両方null扱い） |
| `Decode_ExitStationZero_EntryStationResolved_NotBus` | 逆パターン |
| `Decode_ResolverReturnsEmptyString_TreatedAsResolved_NotBus` | 空文字列はnullと区別される |
| `Decode_ResolverMixesNullAndEmpty_NotBus` | null/空文字混在時はIsBus=false |
| `Decode_ChargeWithResolvedStations_NotBus` | チャージ+駅名解決可 |
| `Decode_PointRedemptionWithResolvedStations_NotBus` | ポイント還元+駅名解決可 |
| `Decode_BothStationCodesZero_ResolverNotCalled` | 駅コード両方0時はリゾルバ未呼出 |
| `Decode_ResolverThrowsException_ReturnsNull` | リゾルバ例外は内部catchで吸収 |
| `Decode_Issue942Fallback_ZeroStations_IsBusStaysTrueWithFallback` | **Issue #942フォールバック時の現状動作を明文化**: IsBusは再計算されず維持されるが後段で影響なし |

## 既知の仕様メモ（Issue #942 フォールバック）
駅コード0 + 残高増加で Issue #942 のポイント還元フォールバックが発動すると、`IsBus=true` かつ `IsPointRedemption=true` の複合状態になる。これは `isBus` が計算後に再評価されない設計のため。ただし後段の `SummaryGenerator` は `!IsPointRedemption` でフィルタするため最終結果に実害はない。本PRではこの現状動作を明示的にテストで固定し、テスト設計書にも備考として記載。

## テスト設計書更新
- UT-001 に「エッジケース（Issue #1253）」テーブル（E1〜E10）を追加
- Issue #942 フォールバックの仕様メモを追記

## 関連
- Issue #1253
- Issue #942（ポイント還元フォールバック — 参照）

## Test plan
- [x] 新規10件すべてGreen
- [x] `FelicaHistoryBlockDecoderTests` 全38件Green（既存28件 + 新規10件）
- [x] 全2542件Green（リグレッションなし）
- [x] テスト設計書 `07_テスト設計書.md` を同期更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)