### PR TITLE
test: 30秒以内同一カード再タッチ逆操作のテスト拡充 (#1255)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -943,6 +943,8 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 
 #### UT-017d: 30秒ルール（再タッチ判定）
 
+**基本テスト（`LendingServiceTests`, `LendingServiceEdgeCaseTests`）:**
+
 | No | テストケース | 条件 | 期待結果 |
 |----|-------------|------|---------|
 | 1 | タイムアウト内 | 貸出直後に同一カード | true |
@@ -951,6 +953,25 @@ CSVインポートで新規履歴詳細（利用履歴ID空欄）をインポー
 | 4 | ClearHistory後 | 貸出→ClearHistory | false, LastProcessedCardIdm=null |
 | 5 | 貸出後の逆操作 | Lend後にチェック | LastOperationType=Lend（→Return実行） |
 | 6 | 返却後の逆操作 | Return後にチェック | LastOperationType=Return（→Lend実行） |
+| 7 | null引数 | IsRetouchWithinTimeout(null) | false（例外なし） |
+| 8 | ゼロ秒ウィンドウ | RetouchWindowSeconds=0 | 例外なし |
+
+**境界値・状態遷移・複数カード・設定反映テスト（Issue #1255, `LendingServiceRetouchTimeoutTests`）:**
+
+タイムアウト値の時間制御にはリフレクションで `LastProcessedTime` プロパティの private setter を呼び出し、経過時間をシミュレートする。
+
+| No | テストケース | 条件 | 期待結果 |
+|----|-------------|------|---------|
+| T1 | 29秒経過 | 貸出→29秒偽装→IsRetouchWithinTimeout | true（LastOperationType=Lend） |
+| T2 | ちょうど30秒 | 貸出→30秒偽装（境界値） | true（`elapsed.TotalSeconds <= _retouchTimeoutSeconds`のため inclusive） |
+| T3 | 31秒経過 | 返却→31秒偽装 | false（新規操作として扱う） |
+| T4 | Lend→29秒→再タッチ状態遷移 | 1回目Lend後29秒経過、2回目タッチ | IsRetouchWithinTimeout=true, LastOperationType=Lend（→ViewModelがReturn実行を決定） |
+| T5 | Return→31秒→再タッチ状態遷移 | 返却後31秒経過、再タッチ | IsRetouchWithinTimeout=false（LastProcessedCardIdm自体は保持される） |
+| T6 | ClearHistory後の初期状態 | 返却→ClearHistory | 3プロパティ全てnull + IsRetouchWithinTimeout=false |
+| T7 | 他カード割り込みでカードA再タッチ | Card A Lend → Card B Lend | Card A: false, Card B: true（LastProcessedCardIdmはCard B） |
+| T8 | 交互操作での混同防止 | A Lend → B Lend → A再タッチ | Card A: false（カードBによって直近性が奪われる） |
+| T9 | AppOptionsの反映（設定値–1秒） | RetouchWindowSeconds∈{10,30,60,120} で (設定値–1)秒偽装 | true |
+| T10 | AppOptionsの反映（設定値+1秒） | 同上で (設定値+1)秒偽装 | false |
 
 #### UT-017e: 同日既存Ledger統合
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceRetouchTimeoutTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceRetouchTimeoutTests.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using ICCardManager.ViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// LendingService.IsRetouchWithinTimeout の境界値・状態遷移テスト (Issue #1255)。
+///
+/// 以下の観点を検証する:
+/// 1. タイムアウト境界値（29秒以内 / ちょうど30秒 / 31秒経過）
+/// 2. LastProcessedCardIdm / LastOperationType の状態遷移
+/// 3. ClearHistory 後の初期状態
+/// 4. 複数カードの交互操作時の混同防止
+/// 5. AppOptions.RetouchWindowSeconds 設定の反映
+///
+/// 時刻操作は DateTime.Now ベースのため、LastProcessedTime をリフレクションで
+/// 書き換えて経過時間をシミュレートする。
+/// </summary>
+public class LendingServiceRetouchTimeoutTests : IDisposable
+{
+    private readonly DbContext _dbContext;
+    private readonly Mock<ICardRepository> _cardRepositoryMock;
+    private readonly Mock<IStaffRepository> _staffRepositoryMock;
+    private readonly Mock<ILedgerRepository> _ledgerRepositoryMock;
+    private readonly Mock<ISettingsRepository> _settingsRepositoryMock;
+    private readonly SummaryGenerator _summaryGenerator;
+    private readonly CardLockManager _lockManager;
+
+    private const string CardAIdm = "0102030405060708";
+    private const string CardBIdm = "A1A2A3A4A5A6A7A8";
+    private const string StaffIdm = "1112131415161718";
+
+    public LendingServiceRetouchTimeoutTests()
+    {
+        _dbContext = new DbContext(":memory:");
+        _dbContext.InitializeDatabase();
+
+        _cardRepositoryMock = new Mock<ICardRepository>();
+        _staffRepositoryMock = new Mock<IStaffRepository>();
+        _ledgerRepositoryMock = new Mock<ILedgerRepository>();
+        _settingsRepositoryMock = new Mock<ISettingsRepository>();
+        _settingsRepositoryMock.Setup(s => s.GetAppSettings()).Returns(new AppSettings());
+        _settingsRepositoryMock.Setup(s => s.GetAppSettingsAsync()).ReturnsAsync(new AppSettings());
+        _summaryGenerator = new SummaryGenerator();
+        _lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);
+
+        _staffRepositoryMock.Setup(r => r.GetByIdmAsync(StaffIdm, false))
+            .ReturnsAsync(new Staff { StaffIdm = StaffIdm, Name = "テスト職員", IsDeleted = false });
+
+        _ledgerRepositoryMock.Setup(x => x.DeleteAllLentRecordsAsync(It.IsAny<string>()))
+            .ReturnsAsync(1);
+    }
+
+    public void Dispose()
+    {
+        _lockManager.Dispose();
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private LendingService CreateService(int retouchWindowSeconds = 30)
+    {
+        return new LendingService(
+            _dbContext,
+            _cardRepositoryMock.Object,
+            _staffRepositoryMock.Object,
+            _ledgerRepositoryMock.Object,
+            _settingsRepositoryMock.Object,
+            _summaryGenerator,
+            _lockManager,
+            Options.Create(new AppOptions { RetouchWindowSeconds = retouchWindowSeconds }),
+            NullLogger<LendingService>.Instance);
+    }
+
+    /// <summary>
+    /// 未貸出のカードとしてLendAsync用のモック設定を行う。
+    /// </summary>
+    private void SetupLendMocks(string cardIdm)
+    {
+        _cardRepositoryMock.Setup(r => r.GetByIdmAsync(cardIdm, false))
+            .ReturnsAsync(new IcCard
+            {
+                CardIdm = cardIdm,
+                CardType = "はやかけん",
+                CardNumber = "C001",
+                IsLent = false,
+                IsDeleted = false
+            });
+        _cardRepositoryMock.Setup(r => r.UpdateLentStatusAsync(
+                cardIdm, It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<string?>()))
+            .ReturnsAsync(true);
+        _ledgerRepositoryMock.Setup(r => r.InsertAsync(It.IsAny<Ledger>())).ReturnsAsync(1);
+    }
+
+    /// <summary>
+    /// 貸出中のカードとしてReturnAsync用のモック設定を行う。
+    /// </summary>
+    private void SetupReturnMocks(string cardIdm)
+    {
+        _cardRepositoryMock.Setup(r => r.GetByIdmAsync(cardIdm, false))
+            .ReturnsAsync(new IcCard
+            {
+                CardIdm = cardIdm,
+                CardType = "はやかけん",
+                CardNumber = "C001",
+                IsLent = true,
+                IsDeleted = false
+            });
+        _cardRepositoryMock.Setup(r => r.UpdateLentStatusAsync(
+                cardIdm, It.IsAny<bool>(), It.IsAny<DateTime?>(), It.IsAny<string?>()))
+            .ReturnsAsync(true);
+        _ledgerRepositoryMock.Setup(r => r.GetLentRecordAsync(cardIdm))
+            .ReturnsAsync(new Ledger
+            {
+                Id = 1,
+                CardIdm = cardIdm,
+                LenderIdm = StaffIdm,
+                Date = DateTime.Today,
+                IsLentRecord = true,
+                LentAt = DateTime.Now.AddMinutes(-10)
+            });
+        _ledgerRepositoryMock.Setup(r => r.InsertAsync(It.IsAny<Ledger>())).ReturnsAsync(1);
+        _ledgerRepositoryMock.Setup(r => r.GetLatestBeforeDateAsync(cardIdm, It.IsAny<DateTime>()))
+            .ReturnsAsync(new Ledger { Balance = 5000 });
+        _ledgerRepositoryMock.Setup(r => r.GetExistingDetailKeysAsync(cardIdm, It.IsAny<DateTime>()))
+            .ReturnsAsync(new HashSet<(DateTime?, int?, bool)>());
+    }
+
+    /// <summary>
+    /// LastProcessedTime を指定した時刻に書き換える（経過時間シミュレーション用）。
+    /// auto-property の private setter を反射で呼ぶ。
+    /// </summary>
+    private static void OverrideLastProcessedTime(LendingService service, DateTime overrideTime)
+    {
+        var property = typeof(LendingService).GetProperty(
+            nameof(LendingService.LastProcessedTime),
+            BindingFlags.Instance | BindingFlags.Public);
+        property.Should().NotBeNull("LastProcessedTime プロパティが存在する必要がある");
+        property!.SetValue(service, (DateTime?)overrideTime);
+    }
+
+    #region 境界値テスト（29秒以内 / ちょうど30秒 / 31秒経過）
+
+    /// <summary>
+    /// 貸出から29秒経過時点での再タッチは30秒ルールの対象（true）であること。
+    /// </summary>
+    [Fact]
+    public async Task IsRetouchWithinTimeout_29SecondsAfterLend_ReturnsTrue()
+    {
+        // Arrange: 貸出処理を実行
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupLendMocks(CardAIdm);
+        await service.LendAsync(StaffIdm, CardAIdm);
+
+        // Act: LastProcessedTime を29秒前に偽装
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-29));
+
+        // Assert: 30秒ルール対象
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeTrue(
+            "29秒経過は30秒ルールの対象内");
+        service.LastOperationType.Should().Be(LendingOperationType.Lend,
+            "直前の操作は貸出のため、次のタッチでは逆操作（返却）が実行される");
+    }
+
+    /// <summary>
+    /// 返却から31秒経過時点での再タッチは30秒ルールの対象外（false）であること。
+    /// 新規操作として扱うべきケース。
+    /// </summary>
+    [Fact]
+    public async Task IsRetouchWithinTimeout_31SecondsAfterReturn_ReturnsFalse()
+    {
+        // Arrange: 返却処理を実行
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupReturnMocks(CardAIdm);
+        await service.ReturnAsync(StaffIdm, CardAIdm, new List<LedgerDetail>());
+
+        // Act: LastProcessedTime を31秒前に偽装
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-31));
+
+        // Assert: タイムアウト超過のため新規操作として扱う
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            "31秒経過は30秒ルールの対象外");
+    }
+
+    /// <summary>
+    /// 貸出からちょうど30秒経過の時点では、30秒ルールの対象（true）であること（境界値）。
+    /// 実装は elapsed.TotalSeconds &lt;= _retouchTimeoutSeconds のため境界は含む。
+    /// </summary>
+    [Fact]
+    public async Task IsRetouchWithinTimeout_Exactly30Seconds_ReturnsTrue()
+    {
+        // Arrange
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupLendMocks(CardAIdm);
+        await service.LendAsync(StaffIdm, CardAIdm);
+
+        // Act: 30秒ちょうど前に偽装
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-30));
+
+        // Assert: 境界値は inclusively true
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeTrue(
+            "ちょうど30秒は <= 判定のためtrue");
+    }
+
+    #endregion
+
+    #region 状態遷移テスト (Lend → Lend → Return)
+
+    /// <summary>
+    /// Lend → (29秒以内) Lend → Return のシナリオ:
+    /// 2回目のタッチでは直前がLend状態のため「逆操作=返却」が判定できる。
+    /// </summary>
+    [Fact]
+    public async Task StateTransition_LendThenReTouchWithin29Seconds_DetectsReverseAsReturn()
+    {
+        // Arrange: 1回目 Lend
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupLendMocks(CardAIdm);
+        await service.LendAsync(StaffIdm, CardAIdm);
+
+        // Assert 1回目後の状態
+        service.LastProcessedCardIdm.Should().Be(CardAIdm);
+        service.LastOperationType.Should().Be(LendingOperationType.Lend);
+        service.LastProcessedTime.Should().NotBeNull();
+
+        // Act: 29秒前にLastProcessedTimeを偽装 → 2回目タッチを擬似
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-29));
+
+        // Assert: IsRetouchWithinTimeout=true + LastOperationType=Lend
+        // MainViewModel はこれを見て「逆操作=Return」を選択する
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeTrue();
+        service.LastOperationType.Should().Be(LendingOperationType.Lend,
+            "2回目のタッチ判定時点では直前のLend状態が保持されている");
+    }
+
+    /// <summary>
+    /// Return → (31秒経過) Lend のシナリオ:
+    /// 31秒経過後の再タッチは新規操作として扱われ、LastOperationType は
+    /// 返却のままだが、IsRetouchWithinTimeout は false を返す。
+    /// </summary>
+    [Fact]
+    public async Task StateTransition_ReturnThenReTouchAfter31Seconds_TreatedAsNewOperation()
+    {
+        // Arrange: 返却
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupReturnMocks(CardAIdm);
+        await service.ReturnAsync(StaffIdm, CardAIdm, new List<LedgerDetail>());
+        service.LastOperationType.Should().Be(LendingOperationType.Return);
+
+        // Act: 31秒経過を偽装
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-31));
+
+        // Assert: タイムアウト超過
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            "31秒経過後は30秒ルール非適用。新規の貸出として処理される");
+        // LastOperationType と LastProcessedCardIdm は残っているが、時間ウィンドウが切れている
+        service.LastProcessedCardIdm.Should().Be(CardAIdm);
+    }
+
+    #endregion
+
+    #region ClearHistory 後の初期状態
+
+    /// <summary>
+    /// ClearHistory 実行後は LastProcessedCardIdm / LastProcessedTime /
+    /// LastOperationType が全て null になり、IsRetouchWithinTimeout も false を返すこと。
+    /// </summary>
+    [Fact]
+    public async Task ClearHistory_AfterReturn_InitializesAllStateToNull()
+    {
+        // Arrange: 返却を実行 → 履歴が蓄積された状態
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupReturnMocks(CardAIdm);
+        await service.ReturnAsync(StaffIdm, CardAIdm, new List<LedgerDetail>());
+
+        service.LastProcessedCardIdm.Should().Be(CardAIdm);
+        service.LastProcessedTime.Should().NotBeNull();
+        service.LastOperationType.Should().Be(LendingOperationType.Return);
+
+        // Act
+        service.ClearHistory();
+
+        // Assert: 全て初期状態
+        service.LastProcessedCardIdm.Should().BeNull();
+        service.LastProcessedTime.Should().BeNull();
+        service.LastOperationType.Should().BeNull();
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            "履歴クリア後は直前のカードでも30秒ルール非適用");
+    }
+
+    #endregion
+
+    #region 複数カードの交互操作での混同防止
+
+    /// <summary>
+    /// カードA貸出 → カードB貸出 の順で操作した場合、
+    /// LastProcessedCardIdm はカードBに更新され、カードAで IsRetouchWithinTimeout を
+    /// 呼んでも false になる（カード混同の防止）。
+    /// </summary>
+    [Fact]
+    public async Task IsRetouchWithinTimeout_AfterDifferentCardLent_OriginalCardReturnsFalse()
+    {
+        // Arrange
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupLendMocks(CardAIdm);
+        SetupLendMocks(CardBIdm);
+
+        // Act: カードA貸出 → カードB貸出
+        await service.LendAsync(StaffIdm, CardAIdm);
+        await service.LendAsync(StaffIdm, CardBIdm);
+
+        // Assert: LastProcessedCardIdm はカードB
+        service.LastProcessedCardIdm.Should().Be(CardBIdm);
+
+        // カードAは30秒ルール対象外
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            "直近の処理対象はカードBのため、カードAは30秒ルール非適用");
+
+        // カードBは30秒ルール対象
+        service.IsRetouchWithinTimeout(CardBIdm).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// カードA貸出 → カードB貸出 → カードA再タッチのシーケンスでは、
+    /// カードAは30秒ルール非適用として新規操作扱いになること。
+    /// </summary>
+    [Fact]
+    public async Task IsRetouchWithinTimeout_AlternatingCards_PreventsMixup()
+    {
+        // Arrange
+        var service = CreateService(retouchWindowSeconds: 30);
+        SetupLendMocks(CardAIdm);
+        SetupLendMocks(CardBIdm);
+
+        // Act: A → B → A
+        await service.LendAsync(StaffIdm, CardAIdm);
+        service.LastProcessedCardIdm.Should().Be(CardAIdm);
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeTrue();
+
+        await service.LendAsync(StaffIdm, CardBIdm);
+        service.LastProcessedCardIdm.Should().Be(CardBIdm);
+
+        // Assert: カードAでタッチしても30秒ルール非適用
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            "カードBでの操作が間に挟まったため、カードAの直近性は失われる");
+    }
+
+    #endregion
+
+    #region AppOptions.RetouchWindowSeconds の反映
+
+    /// <summary>
+    /// AppOptions.RetouchWindowSeconds がサービスに正しく反映され、
+    /// 設定値 - 1 秒は true、設定値 + 1 秒は false になること。
+    /// </summary>
+    [Theory]
+    [InlineData(10)]
+    [InlineData(30)]
+    [InlineData(60)]
+    [InlineData(120)]
+    public async Task IsRetouchWithinTimeout_RespectsAppOptionsRetouchWindowSeconds(int configuredSeconds)
+    {
+        // Arrange
+        var service = CreateService(retouchWindowSeconds: configuredSeconds);
+        SetupLendMocks(CardAIdm);
+        await service.LendAsync(StaffIdm, CardAIdm);
+
+        // Act/Assert: 設定値 - 1秒 → true
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-(configuredSeconds - 1)));
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeTrue(
+            $"RetouchWindowSeconds={configuredSeconds} の場合、{configuredSeconds - 1}秒経過は対象内");
+
+        // Act/Assert: 設定値 + 1秒 → false
+        OverrideLastProcessedTime(service, DateTime.Now.AddSeconds(-(configuredSeconds + 1)));
+        service.IsRetouchWithinTimeout(CardAIdm).Should().BeFalse(
+            $"RetouchWindowSeconds={configuredSeconds} の場合、{configuredSeconds + 1}秒経過は対象外");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## 概要
Issue #1255 に対応し、`LendingService.IsRetouchWithinTimeout`（30秒ルール）の境界値・状態遷移テストを拡充しました。専用テストクラス `LendingServiceRetouchTimeoutTests` を新規作成し、12件を追加しています。

Closes #1255

## Issue で要求された観点と追加テストのマッピング

| Issue観点 | 追加テスト |
|---------|---------|
| `Lend → (29秒以内) Lend → Return` → 2番目で逆操作判定 | `IsRetouchWithinTimeout_29SecondsAfterLend_ReturnsTrue` + `StateTransition_LendThenReTouchWithin29Seconds_DetectsReverseAsReturn` |
| `Return → (31秒経過) Lend` → 逆操作判定されない | `IsRetouchWithinTimeout_31SecondsAfterReturn_ReturnsFalse` + `StateTransition_ReturnThenReTouchAfter31Seconds_TreatedAsNewOperation` |
| `LastProcessedCardIdm` と `LastOperationType` の状態遷移検証 | 上記の状態遷移テスト2件 |
| `ClearHistory` 後の初期状態 | `ClearHistory_AfterReturn_InitializesAllStateToNull` |
| 複数カードの交互操作での混同防止 | `IsRetouchWithinTimeout_AfterDifferentCardLent_OriginalCardReturnsFalse` + `IsRetouchWithinTimeout_AlternatingCards_PreventsMixup` |
| タイムアウト値は `AppOptions.RetouchWindowSeconds` 設定反映されるか | `IsRetouchWithinTimeout_RespectsAppOptionsRetouchWindowSeconds`（Theory、10/30/60/120秒の4ケース） |

境界値補強として `IsRetouchWithinTimeout_Exactly30Seconds_ReturnsTrue`（ちょうど30秒は inclusively true）も追加。

## 技術的ポイント
`LastProcessedTime` は `{ get; private set; }` のため、経過時間をシミュレートするにはリフレクションで private setter を呼ぶ必要があります：
\`\`\`csharp
private static void OverrideLastProcessedTime(LendingService service, DateTime overrideTime)
{
    var property = typeof(LendingService).GetProperty(
        nameof(LendingService.LastProcessedTime),
        BindingFlags.Instance | BindingFlags.Public);
    property!.SetValue(service, (DateTime?)overrideTime);
}
\`\`\`
時計抽象化（IClock 等）の導入は本番コードへの影響が大きいため、テスト追加のみを目的とする本PRではリフレクション方式を選択しています。

## 変更内容
- 新規: `ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceRetouchTimeoutTests.cs`（12件、約360行）
- 更新: `ICCardManager/docs/design/07_テスト設計書.md` の UT-017d セクションに T1〜T10 の追加テスト表を追記

## Test plan
- [x] 追加した全12件が合格（`dotnet test --filter \"FullyQualifiedName~LendingServiceRetouchTimeoutTests\"` で全合格）
- [x] LendingService 関連テスト全体で回帰なし（125既存 + 12追加 = 137件全合格）
- [x] テスト設計書を同期更新
- [x] プロダクションコードには変更なし（テスト追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)