### PR TITLE
test: ReportDataBuilder の累計加算条件（FiscalYear分岐）テスト拡充 (#1258)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1070,6 +1070,11 @@ ReturnAsync を通して Ledger の `Expense` / `Balance` / `Note` / `StaffName`
 | 17 | 繰越年度4月では月計に紙累計を加算しない（Issue #1252） | CarryoverFiscalYear=2025, 2025年4月 | MonthlyTotal.Expense=210（当月実績のみ、紙累計は月計に加算されない） |
 | 18 | 4月前年度繰越はIncomeのみ保持（Issue #1252） | 4月, 前年度残高=7500 | Carryover.Income=7500, Balance=7500（Expenseプロパティ不在で設計上分離） |
 | 19 | 非4月の月次繰越はIncome=null（Issue #1252） | 10月, 前月残高=3000 | Carryover.Income=null, Balance=3000 |
+| 20 | CarryoverFiscalYear=nullで累計値があっても非加算（Issue #1258） | 2025年7月, CarryoverFiscalYear=null, CarryoverIncomeTotal=9999, CarryoverExpenseTotal=8888 | CumulativeTotal.Income=0, Expense=210（紙累計は加算されない） |
+| 21 | 繰越年度の最後の月（3月）でも累計加算（Issue #1258） | CarryoverFiscalYear=2025, 2026年3月 | CumulativeTotal.Income=12000, Expense=500+4500（紙累計加算される） |
+| 22 | 過去年度帳票では累計非加算（Issue #1258） | CarryoverFiscalYear=2025, 2024年10月 | CumulativeTotal.Income=0, Expense=250（紙累計7000は加算されない） |
+| 23 | CarryoverIncomeTotalのみ加算（Issue #1258） | CarryoverIncomeTotal=15000, CarryoverExpenseTotal=0, 2025年9月 | CumulativeTotal.Income=15000, Expense=210 |
+| 24 | CarryoverExpenseTotalのみ加算（Issue #1258） | CarryoverIncomeTotal=0, CarryoverExpenseTotal=6500, 2025年11月 | CumulativeTotal.Income=3000, Expense=6500 |
 
 **テストクラス:** `ReportDataBuilderTests`
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTableRowsTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/PrintServiceTableRowsTests.cs
@@ -349,6 +349,56 @@ public class PrintServiceTableRowsTests
         result.Should().NotContain(r => r.Kind == PrintService.PrintRowKind.CumulativeTotal);
     }
 
+    /// <summary>
+    /// Issue #1258: 累計行の金額が大きくても桁区切り（カンマ）で表示され、
+    /// 小数点や不要な記号が付与されない（整数円表示）
+    /// </summary>
+    [Fact]
+    public void BuildPrintTableRows_LargeCumulativeAmounts_FormattedWithThousandsSeparatorNoDecimal()
+    {
+        var data = BuildData(cumulativeTotal: new ReportTotal
+        {
+            Label = "累計",
+            Income = 1234567,
+            Expense = 987654,
+            Balance = 246913,
+        });
+
+        var result = PrintService.BuildPrintTableRows(data, includeSummary: true);
+
+        var cumulative = result.Single(r => r.Kind == PrintService.PrintRowKind.CumulativeTotal);
+        cumulative.Cells[ColIncome].Should().Be("1,234,567", "3桁ごとにカンマ区切り");
+        cumulative.Cells[ColExpense].Should().Be("987,654");
+        cumulative.Cells[ColBalance].Should().Be("246,913");
+        // 小数点や通貨記号が付与されないこと（整数円表示）
+        cumulative.Cells[ColIncome].Should().NotContain(".").And.NotContain("円").And.NotContain("¥");
+        cumulative.Cells[ColExpense].Should().NotContain(".");
+        cumulative.Cells[ColBalance].Should().NotContain(".");
+    }
+
+    /// <summary>
+    /// Issue #1258: 累計行の金額が3桁以下（カンマ不要の値）でも
+    /// 小数点なしで表示され、整数として扱われる
+    /// </summary>
+    [Fact]
+    public void BuildPrintTableRows_SmallCumulativeAmounts_NoDecimalPoint()
+    {
+        var data = BuildData(cumulativeTotal: new ReportTotal
+        {
+            Label = "累計",
+            Income = 500,
+            Expense = 210,
+            Balance = 290,
+        });
+
+        var result = PrintService.BuildPrintTableRows(data, includeSummary: true);
+
+        var cumulative = result.Single(r => r.Kind == PrintService.PrintRowKind.CumulativeTotal);
+        cumulative.Cells[ColIncome].Should().Be("500").And.NotContain(".");
+        cumulative.Cells[ColExpense].Should().Be("210").And.NotContain(".");
+        cumulative.Cells[ColBalance].Should().Be("290").And.NotContain(".");
+    }
+
     #endregion
 
     #region 次年度繰越行（3月のみ）

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
@@ -433,6 +433,226 @@ public class ReportDataBuilderTests
         result.CumulativeTotal.Expense.Should().Be(210);
     }
 
+    [Fact]
+    public async Task BuildAsync_CarryoverFiscalYearNull_WithNonZeroTotals_DoesNotAddToCumulative()
+    {
+        // Arrange: Issue #1258 防御的テスト — CarryoverFiscalYear=null だが
+        // CarryoverIncomeTotal/ExpenseTotal に誤って値が入っているケースでも
+        // どの年度の帳票にも加算されないことを確認する。
+        // CarryoverFiscalYear.HasValue=false の条件分岐を厳密に検証する。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 9999,
+            CarryoverExpenseTotal = 8888,
+            CarryoverFiscalYear = null
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var julyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(10, TestCardIdm, new DateTime(2025, 7, 3),
+                "鉄道", 0, 210, 3790)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 6,
+            new List<Ledger>
+            {
+                CreateTestLedger(9, TestCardIdm, new DateTime(2025, 6, 20), "鉄道", 0, 100, 4000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 7, julyLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 7, 31), julyLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 7);
+
+        // Assert: CarryoverFiscalYear=null のため、値があっても加算されない
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0, "CarryoverFiscalYear=null のため紙累計は加算しない");
+        result.CumulativeTotal.Expense.Should().Be(210, "加算は当月分のみ");
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_MarchOfCarryoverYear_AddsCarryoverTotals()
+    {
+        // Arrange: Issue #1258 境界テスト — 繰越年度(2025)の最後の月である2026年3月の帳票では
+        // 紙の累計が加算される（FiscalYearHelper.GetFiscalYear(2026, 3)=2025 と判定されるため）。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 12000,
+            CarryoverExpenseTotal = 4500,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var marchLedgers = new List<Ledger>
+        {
+            CreateTestLedger(200, TestCardIdm, new DateTime(2026, 3, 10),
+                "鉄道（天神～博多）", 0, 300, 2700)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2026, 2,
+            new List<Ledger>
+            {
+                CreateTestLedger(199, TestCardIdm, new DateTime(2026, 2, 25), "鉄道", 0, 200, 3000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2026, 3, marchLedgers);
+
+        var yearlyLedgers = new List<Ledger>
+        {
+            CreateTestLedger(150, TestCardIdm, new DateTime(2025, 8, 1),
+                "7月から繰越", 0, 0, 3500),
+            CreateTestLedger(199, TestCardIdm, new DateTime(2026, 2, 25), "鉄道", 0, 200, 3000),
+            CreateTestLedger(200, TestCardIdm, new DateTime(2026, 3, 10), "鉄道", 0, 300, 2700)
+        };
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2026, 3, 31), yearlyLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2026, 3);
+
+        // Assert: 繰越年度の3月でも紙累計は加算される（年度境界の内側）
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(12000, "繰越年度内の3月でも紙累計Incomeは加算される");
+        result.CumulativeTotal.Expense.Should().Be(200 + 300 + 4500,
+            "アプリ記録500 + 紙累計4500。繰越ledgerのIncome=0も除外対象");
+        // 3月は次年度繰越あり
+        result.CarryoverToNextYear.Should().Be(2700);
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_PastFiscalYear_DoesNotAddCarryoverTotals()
+    {
+        // Arrange: Issue #1258 境界テスト — 繰越年度(2025)より過去の年度(2024)の帳票では
+        // 紙の累計が加算されない。過去月の帳票を再印刷したケースを想定。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 20000,
+            CarryoverExpenseTotal = 7000,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var octoberLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2024, 10, 15),
+                "鉄道", 0, 250, 4750)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2024, 9,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2024, 9, 30), "鉄道", 0, 150, 5000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2024, 10, octoberLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2024, 4, 1), new DateTime(2024, 10, 31), octoberLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2024, 10);
+
+        // Assert: 2024年度(FY2024)は繰越年度(FY2025)とは別の年度のため加算されない
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0,
+            "FY2024はCarryoverFiscalYear(2025)と一致しないため加算されない");
+        result.CumulativeTotal.Expense.Should().Be(250,
+            "加算は当月分のみ、紙累計7000は加算しない");
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_OnlyIncomeTotal_AddsIncomeOnly()
+    {
+        // Arrange: Issue #1258 — Income/Expense の独立加算。
+        // 紙の出納簿が受入のみ記録（例: チャージだけだった）のケース。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 15000,
+            CarryoverExpenseTotal = 0,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var septemberLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 9, 10),
+                "鉄道", 0, 210, 4790)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 8,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 8, 20), "鉄道", 0, 100, 5000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 9, septemberLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 9, 30), septemberLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 9);
+
+        // Assert: Income のみ加算、Expense は当月実績のみ
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(15000);
+        result.CumulativeTotal.Expense.Should().Be(210);
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_OnlyExpenseTotal_AddsExpenseOnly()
+    {
+        // Arrange: Issue #1258 — Expense のみが紙累計に記録されているケース。
+        // 受入は当年度以降の記録から始まっている想定。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 0,
+            CarryoverExpenseTotal = 6500,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var novemberLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 11, 5),
+                "役務費によりチャージ", 3000, 0, 8000)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 10,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 10, 25), "鉄道", 0, 200, 5000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 11, novemberLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 11, 30), novemberLedgers);
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 11);
+
+        // Assert: Expense のみ加算、Income は当月実績のみ
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(3000);
+        result.CumulativeTotal.Expense.Should().Be(6500);
+    }
+
     #endregion
 
     #region 3月テスト（次年度繰越）


### PR DESCRIPTION
## Summary
- `ReportDataBuilder` の `CarryoverFiscalYear` を用いた年度判定ロジックの境界ケーステストを追加
- 累計金額の桁区切り・小数点なし表示の確認を `PrintServiceTableRowsTests` に追加
- テスト設計書 `UT-018` に TC20〜24 を追記

## 追加テスト（計7件）

### ReportDataBuilderTests（5件）
- `BuildAsync_CarryoverFiscalYearNull_WithNonZeroTotals_DoesNotAddToCumulative`
  - `CarryoverFiscalYear=null` で `CarryoverIncomeTotal/ExpenseTotal` に誤って値が入っていても加算されない防御的テスト
- `BuildAsync_MidYearCarryover_MarchOfCarryoverYear_AddsCarryoverTotals`
  - 繰越年度(FY2025)の最後の月である2026年3月でも加算される境界テスト
- `BuildAsync_MidYearCarryover_PastFiscalYear_DoesNotAddCarryoverTotals`
  - 繰越年度(FY2025)より過去の2024年度帳票では加算されない境界テスト
- `BuildAsync_MidYearCarryover_OnlyIncomeTotal_AddsIncomeOnly`
  - Income のみ値がある場合、Expense には当月分のみが集計されること
- `BuildAsync_MidYearCarryover_OnlyExpenseTotal_AddsExpenseOnly`
  - Expense のみ値がある場合、Income には当月分のみが集計されること

### PrintServiceTableRowsTests（2件）
- `BuildPrintTableRows_LargeCumulativeAmounts_FormattedWithThousandsSeparatorNoDecimal`
  - 累計金額が6〜7桁でも `#,##0` 形式で3桁ごとに区切られ、小数点・通貨記号が付かないこと
- `BuildPrintTableRows_SmallCumulativeAmounts_NoDecimalPoint`
  - 累計金額が3桁以下でも小数点が付かず整数表示であること

## Issue #1258 チェックリスト対応
- [x] FY2025 の 10月 → `CarryoverFiscalYear=2025` → `CumulativeTotal` に加算（既存TC10 + 新規TC21境界）
- [x] FY2026 の 5月 → `CarryoverFiscalYear=2025` → 加算しない（既存TC11 + 新規TC22境界）
- [x] `CarryoverFiscalYear=null` の場合の挙動（既存 + 新規TC20防御的）
- [x] 繰越 Ledger Income を月計から除外（既存TC12）
- [x] 累計金額表示の小数点・桁区切り（新規 PrintServiceTableRowsTests）

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ReportDataBuilderTests|FullyQualifiedName~PrintServiceTableRowsTests"` → 47件成功
- [x] 新規追加分のみ実行 → 7件成功
- [x] フルテストで既存機能の回帰なし（Issue #1257の既存フレーキーテスト1件を除き2603件成功）

## 関連
- Issue #1215: 年度途中導入でも累計受入・払出を適切に設定
- Issue #1219: 年度途中繰越ledgerの受入欄修正
- Issue #1252: 年度跨ぎ・CarryoverFiscalYearの回帰防止

🤖 Generated with [Claude Code](https://claude.com/claude-code)