### PR TITLE
test: SummaryGenerator テストの静的状態汚染による偶発的失敗を修正 (#1307)

### DIFF
--- a/ICCardManager/tests/ICCardManager.Tests/Services/OrganizationOptionsTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/OrganizationOptionsTests.cs
@@ -15,6 +15,11 @@ namespace ICCardManager.Tests.Services;
 /// <summary>
 /// OrganizationOptions のテスト
 /// </summary>
+/// <remarks>
+/// Issue #1307: 本クラスは <c>SummaryGenerator.Configure</c> で静的状態を変更する。
+/// 並列実行時の他テストへの波及を避けるため <see cref="SummaryGeneratorCollection"/> に属させる。
+/// </remarks>
+[Collection(SummaryGeneratorCollection.Name)]
 public class OrganizationOptionsTests : IDisposable
 {
     public OrganizationOptionsTests()

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SharedModeMonitorRecoveryTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SharedModeMonitorRecoveryTests.cs
@@ -125,8 +125,14 @@ public class SharedModeMonitorRecoveryTests
     /// <summary>
     /// ヘルスチェックタイマーの Tick が発火 → CheckConnection が呼ばれ HealthCheckCompleted が発火すること。
     /// </summary>
+    /// <remarks>
+    /// Issue #1307: 以前は 2 秒ポーリングで待機していたが、CI 負荷下で threadpool が
+    /// <c>Task.Run(() =&gt; _databaseInfo.CheckConnection())</c> の継続を拾うのが遅れ、
+    /// 偶発的なタイムアウト失敗を引き起こしていた。<see cref="TaskCompletionSource"/> で
+    /// 決定論的に待機しつつ、CI負荷を考慮して十分長い上限 (30秒) を設ける。
+    /// </remarks>
     [Fact]
-    public void Issue1257_HealthCheckTimerTick_InvokesCheckConnectionAndFiresEvent()
+    public async Task Issue1257_HealthCheckTimerTick_InvokesCheckConnectionAndFiresEvent()
     {
         // Arrange
         _databaseInfoMock.Setup(d => d.CheckConnection()).Returns(true);
@@ -137,22 +143,23 @@ public class SharedModeMonitorRecoveryTests
         healthCheckTimer.Interval.Should().Be(TimeSpan.FromSeconds(30),
             "ヘルスチェックは30秒間隔で発火");
 
-        DatabaseHealthEventArgs? captured = null;
-        _monitor.HealthCheckCompleted += (_, e) => captured = e;
+        // OnHealthCheckTick は async void のため、TaskCompletionSource で完了を待機する
+        var tcs = new TaskCompletionSource<DatabaseHealthEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _monitor.HealthCheckCompleted += (_, e) => tcs.TrySetResult(e);
 
         // Act: Tick を手動発火
         healthCheckTimer.SimulateTick();
 
-        // OnHealthCheckTick は async void のため、完了待ち用に短時間ポーリング
-        var timeout = DateTime.UtcNow.AddSeconds(2);
-        while (captured == null && DateTime.UtcNow < timeout)
-        {
-            System.Threading.Thread.Sleep(10);
-        }
+        // 完了を待機（CI負荷を考慮して上限30秒。正常時は<100msで完了）
+        var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+        completedTask.Should().BeSameAs(tcs.Task,
+            "Tick から30秒以内に HealthCheckCompleted が発火する必要がある");
 
         // Assert
+        var captured = await tcs.Task;
         captured.Should().NotBeNull("Tick でヘルスチェックが実行される");
-        captured!.IsConnected.Should().BeTrue();
+        captured.IsConnected.Should().BeTrue();
         _databaseInfoMock.Verify(d => d.CheckConnection(), Times.Once);
     }
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorCollection.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorCollection.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// Issue #1307: SummaryGenerator 静的状態共有のためのテストコレクション定義。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ICCardManager.Services.SummaryGenerator"/> は
+/// <c>_options</c> / <c>_transferStationGroups</c> を <c>static</c> フィールドとして保持しており、
+/// <c>SummaryGenerator.Configure()</c> や <c>ResetToDefaults()</c> を呼ぶテストが並列実行されると、
+/// 他のテストが読み取る <c>_options</c> を上書きしてしまい、偶発的な失敗（flaky test）を引き起こす。
+/// </para>
+/// <para>
+/// 根本解決（静的状態のインスタンス化）は影響範囲が広いため別チケットで対応予定。
+/// 本チケットでは、静的状態を変更するテストおよび上書き結果に影響を受けるテストを
+/// 同一 xUnit Collection に属させ、<c>DisableParallelization = true</c> により
+/// シリアル実行させることで偶発的失敗を解消する。
+/// </para>
+/// <para>
+/// <b>運用ルール:</b> <c>SummaryGenerator.Configure</c> / <c>ResetToDefaults</c> を呼ぶテスト、
+/// もしくは特定の摘要文字列（鉄道/バスの乗継統合や往復検出等）をアサートするテストを
+/// 新規追加する場合は、必ず <c>[Collection("SummaryGenerator Static State")]</c>
+/// 属性を付与すること。
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class SummaryGeneratorCollection
+{
+    public const string Name = "SummaryGenerator Static State";
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorCollectionConfigurationTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorCollectionConfigurationTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// Issue #1307: <see cref="SummaryGeneratorCollection"/> の設定および
+/// 対象テストクラスへの <c>[Collection]</c> 属性付与を検証する回帰テスト。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ICCardManager.Services.SummaryGenerator"/> の静的フィールド <c>_options</c> /
+/// <c>_transferStationGroups</c> を変更するテスト（<c>Configure</c> / <c>ResetToDefaults</c> 呼び出し）と、
+/// その影響を受けるテストは、必ず <see cref="SummaryGeneratorCollection.Name"/> Collection に
+/// 属している必要がある。本テストは将来 Collection 属性の付与漏れを静的に検出する。
+/// </para>
+/// <para>
+/// ランタイム上の並列実行抑止そのもの（xUnit Scheduler の挙動）は単体テストでは検証困難なため、
+/// 属性の付与・プロパティ値・命名の整合性を検証することで代替する。
+/// </para>
+/// </remarks>
+public class SummaryGeneratorCollectionConfigurationTests
+{
+    /// <summary>
+    /// <see cref="SummaryGeneratorCollection"/> 自身が <c>CollectionDefinition</c> 属性を持ち、
+    /// <c>DisableParallelization = true</c> が設定されていること。
+    /// </summary>
+    /// <remarks>
+    /// xUnit の <c>CollectionDefinitionAttribute</c> / <c>CollectionAttribute</c> は
+    /// <c>Name</c> プロパティを公開していないため、<see cref="CustomAttributeData"/> 経由で
+    /// コンストラクタ引数として渡された名前を取得する。
+    /// </remarks>
+    [Fact]
+    public void Collection定義が並列実行を無効化していること()
+    {
+        // Arrange
+        var collectionType = typeof(SummaryGeneratorCollection);
+        var attributeData = CustomAttributeData.GetCustomAttributes(collectionType)
+            .FirstOrDefault(a => a.AttributeType == typeof(CollectionDefinitionAttribute));
+
+        // Assert
+        attributeData.Should().NotBeNull(
+            "SummaryGeneratorCollection は CollectionDefinition 属性を持つ必要がある");
+        var name = attributeData!.ConstructorArguments[0].Value as string;
+        name.Should().Be(SummaryGeneratorCollection.Name);
+        var disableParallelization = attributeData.NamedArguments
+            .FirstOrDefault(a => a.MemberName == nameof(CollectionDefinitionAttribute.DisableParallelization))
+            .TypedValue.Value;
+        disableParallelization.Should().Be(true,
+            "DisableParallelization=true でないと静的状態が並列実行で汚染される");
+    }
+
+    /// <summary>
+    /// 静的状態を変更するテストクラスが <see cref="SummaryGeneratorCollection"/> に属していること。
+    /// </summary>
+    [Theory]
+    [InlineData(typeof(SummaryGeneratorTests))]
+    [InlineData(typeof(SummaryGeneratorEdgeCaseTests))]
+    [InlineData(typeof(SummaryGeneratorComprehensiveTests))]
+    [InlineData(typeof(OrganizationOptionsTests))]
+    public void SummaryGenerator関連テストクラスがCollectionに属していること(Type testClass)
+    {
+        // Act
+        var attributeData = CustomAttributeData.GetCustomAttributes(testClass)
+            .FirstOrDefault(a => a.AttributeType == typeof(CollectionAttribute));
+
+        // Assert
+        attributeData.Should().NotBeNull(
+            $"{testClass.Name} は [Collection(SummaryGeneratorCollection.Name)] を持つ必要がある");
+        var name = attributeData!.ConstructorArguments[0].Value as string;
+        name.Should().Be(SummaryGeneratorCollection.Name,
+            $"{testClass.Name} の Collection 名が一致しない");
+    }
+
+    /// <summary>
+    /// Collection 対象のテストクラスが IDisposable を実装し、
+    /// Dispose で ResetToDefaults を呼べる形になっていること。
+    /// </summary>
+    /// <remarks>
+    /// 静的状態を確実にクリーンアップするためのベースライン。
+    /// 実際の Reset 呼び出しはソースレベルで担保される。
+    /// </remarks>
+    [Theory]
+    [InlineData(typeof(SummaryGeneratorTests))]
+    [InlineData(typeof(SummaryGeneratorEdgeCaseTests))]
+    [InlineData(typeof(SummaryGeneratorComprehensiveTests))]
+    [InlineData(typeof(OrganizationOptionsTests))]
+    public void Collection対象テストクラスはIDisposableを実装していること(Type testClass)
+    {
+        // Act
+        var implementsDisposable = typeof(IDisposable).IsAssignableFrom(testClass);
+
+        // Assert
+        implementsDisposable.Should().BeTrue(
+            $"{testClass.Name} は IDisposable を実装し Dispose で ResetToDefaults を呼ぶ必要がある");
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorComprehensiveTests.cs
@@ -44,14 +44,23 @@ namespace ICCardManager.Tests.Services;
 /// - 西鉄福岡(天神)(101), 薬院(103), 西鉄平尾(105), 高宮(107), 大橋(109), 井尻(111),
 ///   雑餉隈(113), 春日原(115), 白木原(117), 下大利(119), 都府楼前(121), 西鉄二日市(123)
 /// </summary>
-public class SummaryGeneratorComprehensiveTests
+[Collection(SummaryGeneratorCollection.Name)]
+public class SummaryGeneratorComprehensiveTests : IDisposable
 {
     private readonly SummaryGenerator _generator = new();
     private readonly ITestOutputHelper _output;
 
     public SummaryGeneratorComprehensiveTests(ITestOutputHelper output)
     {
+        // Issue #1307: 並列実行で他テストが Configure した静的状態を初期化
+        SummaryGenerator.ResetToDefaults();
         _output = output;
+    }
+
+    public void Dispose()
+    {
+        SummaryGenerator.ResetToDefaults();
+        GC.SuppressFinalize(this);
     }
 
     #region ヘルパーメソッド

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorEdgeCaseTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorEdgeCaseTests.cs
@@ -12,6 +12,11 @@ namespace ICCardManager.Tests.Services;
 /// SummaryGeneratorのエッジケーステスト
 /// 既存テストで検出できない設定オプション・組み合わせパターンを検証する。
 /// </summary>
+/// <remarks>
+/// Issue #1307: 本クラスは <c>SummaryGenerator.Configure</c> で静的状態を変更する。
+/// 並列実行時の他テストへの波及を避けるため <see cref="SummaryGeneratorCollection"/> に属させる。
+/// </remarks>
+[Collection(SummaryGeneratorCollection.Name)]
 public class SummaryGeneratorEdgeCaseTests : IDisposable
 {
     private readonly SummaryGenerator _generator = new();

--- a/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/SummaryGeneratorTests.cs
@@ -15,6 +15,11 @@ namespace ICCardManager.Tests.Services;
 /// SummaryGenerator の固有機能テスト
 /// 基本的な Generate/GenerateByDate のテストは SummaryGeneratorComprehensiveTests を参照
 /// </summary>
+/// <remarks>
+/// Issue #1307: SummaryGenerator の静的状態共有による並列実行時の偶発的失敗を防ぐため、
+/// <see cref="SummaryGeneratorCollection"/> に属させてシリアル実行する。
+/// </remarks>
+[Collection(SummaryGeneratorCollection.Name)]
 public class SummaryGeneratorTests : IDisposable
 {
     private readonly SummaryGenerator _generator;


### PR DESCRIPTION
## Summary
- `SummaryGenerator` の静的フィールド `_options` / `_transferStationGroups` を並列テストが上書きすることで、`SummaryGeneratorTests.Generate_鉄道とバス乗り継ぎ混在_正しく表示される` が偶発的に失敗する問題を修正（Issue #1307）
- Issue 推奨の**案A**を実装: xUnit の `CollectionDefinition` で `DisableParallelization=true` を指定した専用コレクションに対象テストクラスを属させ、シリアル実行
- **案B（静的フィールドのインスタンス化）は影響範囲が広いため別チケットで中長期対応**（Issue 記載）

## 変更内容
### 新規ファイル
- `SummaryGeneratorCollection.cs`: CollectionDefinition 定義（`DisableParallelization = true`）
- `SummaryGeneratorCollectionConfigurationTests.cs`: 回帰防止テスト（属性付与漏れの静的検出）

### 既存テストクラスへの `[Collection]` 付与
| クラス | 静的状態への関与 | 従前の IDisposable |
|--------|---------------|-----------------|
| `SummaryGeneratorTests` | 読み取り | ✓ |
| `SummaryGeneratorEdgeCaseTests` | **変更** (`Configure`) | ✓ |
| `SummaryGeneratorComprehensiveTests` | 読み取り | ✗ → **追加実装** |
| `OrganizationOptionsTests` | **変更** (`Configure`) | ✓ |

## 回帰防止テスト `SummaryGeneratorCollectionConfigurationTests`
- `CollectionDefinition` の `DisableParallelization = true` をリフレクションで検証
- 対象4クラスへの `[Collection(SummaryGeneratorCollection.Name)]` 付与を検証
- 対象4クラスが `IDisposable` を実装していることを検証

xUnit の `CollectionAttribute` / `CollectionDefinitionAttribute` は `Name` を公開プロパティとして露出していないため、`CustomAttributeData.ConstructorArguments` 経由で名前を取得する方式を採用。

## 運用ルール
`SummaryGenerator.Configure` / `ResetToDefaults` を呼ぶテスト、もしくは特定の摘要文字列（鉄道/バスの乗継統合や往復検出等）をアサートするテストを新規追加する場合は、必ず `[Collection(SummaryGeneratorCollection.Name)]` を付与する。（`SummaryGeneratorCollection.cs` コメントに明記）

## Test plan
- [x] SummaryGenerator系テスト単独実行（126件）を5回連続 — 全て成功、flaky無し
- [x] 全テストスイート（2626件）実行 — 全て成功（以前の `Issue1257_HealthCheckTimerTick_...` flaky も通過）
- [x] 再現コマンド (`--filter "FullyQualifiedName~SummaryGenerator"`) で失敗しないことを確認
- [x] ビルド警告なし

Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)