### PR TITLE
test: ReportDataBuilder の calendar年/fiscal年境界テストを追加 (#1258)

### DIFF
--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1075,6 +1075,9 @@ ReturnAsync を通して Ledger の `Expense` / `Balance` / `Note` / `StaffName`
 | 22 | 過去年度帳票では累計非加算（Issue #1258） | CarryoverFiscalYear=2025, 2024年10月 | CumulativeTotal.Income=0, Expense=250（紙累計7000は加算されない） |
 | 23 | CarryoverIncomeTotalのみ加算（Issue #1258） | CarryoverIncomeTotal=15000, CarryoverExpenseTotal=0, 2025年9月 | CumulativeTotal.Income=15000, Expense=210 |
 | 24 | CarryoverExpenseTotalのみ加算（Issue #1258） | CarryoverIncomeTotal=0, CarryoverExpenseTotal=6500, 2025年11月 | CumulativeTotal.Income=3000, Expense=6500 |
+| 25 | calendar年一致・fiscal年不一致は非加算（Issue #1258境界） | CarryoverFiscalYear=2025, 2025年3月（FY2024） | CumulativeTotal.Income=0, Expense=380（紙累計8000は加算されない） |
+| 26 | 1月は前FY扱いで非加算（Issue #1258境界） | CarryoverFiscalYear=2025, 2025年1月（FY2024） | CumulativeTotal.Income=0, Expense=360（紙累計9000は加算されない） |
+| 27 | 未来年度設定は現年度に効かない（Issue #1258境界） | CarryoverFiscalYear=2030, 2025年10月 | CumulativeTotal.Income=0, Expense=400（紙累計20000は加算されない） |
 
 **テストクラス:** `ReportDataBuilderTests`
 

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportDataBuilderTests.cs
@@ -653,6 +653,159 @@ public class ReportDataBuilderTests
         result.CumulativeTotal.Expense.Should().Be(6500);
     }
 
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_CalendarYearMatchesButFiscalYearDiffers_DoesNotAddCarryoverTotals()
+    {
+        // Arrange: Issue #1258 境界テスト — calendar年 と CarryoverFiscalYear が等しいが、
+        // 対象月が 1-3月 のため fiscal year が別という境界ケース。
+        // calendar 2025 年 3 月 → FY2024 （GetFiscalYear(2025, 3) = 2024）のため、
+        // CarryoverFiscalYear=2025 とは不一致 → 紙累計は加算されない。
+        // ユーザーが「CarryoverFiscalYear=2025 は 2025年の帳票に効く」と誤解して設定した場合でも、
+        // 1-3月は前年度扱いとなり誤加算が起きないことを保証する。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 20000,
+            CarryoverExpenseTotal = 8000,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var marchLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 3, 15),
+                "鉄道", 0, 280, 4720)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 2,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 2, 20), "鉄道", 0, 100, 5000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 3, marchLedgers);
+        // 年度=2024（4月=2024/4/1〜2025/3/31）
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2024, 4, 1), new DateTime(2025, 3, 31),
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 2, 20), "鉄道", 0, 100, 5000),
+                CreateTestLedger(1, TestCardIdm, new DateTime(2025, 3, 15), "鉄道", 0, 280, 4720)
+            });
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 3);
+
+        // Assert: calendar=2025 だが fiscal=2024 のため CarryoverFiscalYear=2025 とは不一致 → 加算されない
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0,
+            "calendar year 一致でも fiscal year が異なる場合は紙累計は加算されない");
+        result.CumulativeTotal.Expense.Should().Be(380,
+            "加算は当年度(FY2024)実績の 100+280 のみ、紙累計8000は加算されない");
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_JanuaryOfCalendarYearMatchingCarryover_DoesNotAdd()
+    {
+        // Arrange: Issue #1258 境界テスト — 1月の fiscal year 境界。
+        // calendar 2025 年 1 月 → FY2024（GetFiscalYear(2025, 1) = 2024）。
+        // CarryoverFiscalYear=2025 とは不一致 → 加算されない。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 30000,
+            CarryoverExpenseTotal = 9000,
+            CarryoverFiscalYear = 2025
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var januaryLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 1, 8),
+                "鉄道", 0, 210, 5290)
+        };
+        // 前月（2024年12月）の残高
+        SetupMonthlyLedgers(TestCardIdm, 2024, 12,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2024, 12, 20), "鉄道", 0, 150, 5500)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 1, januaryLedgers);
+        // 年度=2024（4月=2024/4/1〜2025/3/31）、対象月は 1月時点
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2024, 4, 1), new DateTime(2025, 1, 31),
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2024, 12, 20), "鉄道", 0, 150, 5500),
+                CreateTestLedger(1, TestCardIdm, new DateTime(2025, 1, 8), "鉄道", 0, 210, 5290)
+            });
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 1);
+
+        // Assert
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0,
+            "1月は FY=2024 のため CarryoverFiscalYear=2025 と不一致 → 加算されない");
+        result.CumulativeTotal.Expense.Should().Be(360,
+            "加算は FY2024 実績の 150+210 のみ、紙累計9000は加算されない");
+    }
+
+    [Fact]
+    public async Task BuildAsync_MidYearCarryover_FutureFiscalYearSetting_DoesNotAddToCurrentYear()
+    {
+        // Arrange: Issue #1258 境界テスト — CarryoverFiscalYear に未来年度が設定されている場合、
+        // 現在年度の帳票には加算されない。将来リセット後に効かせる運用や、誤設定への防御として
+        // 「FY一致」条件が厳密に機能していることを検証する。
+        var card = new IcCard
+        {
+            CardIdm = TestCardIdm,
+            CardType = "はやかけん",
+            CardNumber = "001",
+            CarryoverIncomeTotal = 50000,
+            CarryoverExpenseTotal = 20000,
+            CarryoverFiscalYear = 2030  // 未来年度
+        };
+        _cardRepositoryMock
+            .Setup(r => r.GetByIdmAsync(TestCardIdm, true))
+            .ReturnsAsync(card);
+
+        var octoberLedgers = new List<Ledger>
+        {
+            CreateTestLedger(1, TestCardIdm, new DateTime(2025, 10, 5),
+                "鉄道", 0, 300, 4700)
+        };
+        SetupMonthlyLedgers(TestCardIdm, 2025, 9,
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 9, 30), "鉄道", 0, 100, 5000)
+            });
+        SetupMonthlyLedgers(TestCardIdm, 2025, 10, octoberLedgers);
+        SetupDateRangeLedgers(TestCardIdm,
+            new DateTime(2025, 4, 1), new DateTime(2025, 10, 31),
+            new List<Ledger>
+            {
+                CreateTestLedger(0, TestCardIdm, new DateTime(2025, 9, 30), "鉄道", 0, 100, 5000),
+                CreateTestLedger(1, TestCardIdm, new DateTime(2025, 10, 5), "鉄道", 0, 300, 4700)
+            });
+
+        // Act
+        var result = await _builder.BuildAsync(TestCardIdm, 2025, 10);
+
+        // Assert: FY2025 と CarryoverFiscalYear=2030 は不一致 → 加算されない
+        result.CumulativeTotal.Should().NotBeNull();
+        result.CumulativeTotal.Income.Should().Be(0,
+            "未来年度設定は現年度に効かない（厳密な年度一致のみ加算）");
+        result.CumulativeTotal.Expense.Should().Be(400,
+            "加算は当年度実績の 100+300 のみ、紙累計20000は加算されない");
+    }
+
     #endregion
 
     #region 3月テスト（次年度繰越）


### PR DESCRIPTION
## Summary
PR #1311 で Issue #1258 のチェックリスト 5 項目はカバー済みですが、**calendar 年と fiscal 年が diverge する 1-3 月**と `CarryoverFiscalYear` の相互作用が明示的にテストされていませんでした。本 PR で境界ケース 3 件を追加し、Issue #1258 を正式に close します。

## 背景
`FiscalYearHelper.GetFiscalYear(year, month)` は `month >= 4 ? year : year - 1` で fiscal year を返します。`ReportDataBuilder` の加算条件は:

```csharp
if (card.CarryoverFiscalYear.HasValue && card.CarryoverFiscalYear.Value == fiscalYearStartYear)
```

したがって、`CarryoverFiscalYear=2025` のカードに対して:
- 2025年10月の帳票 → FY2025 → 加算される ✓（PR #1311でカバー済）
- 2026年3月の帳票 → FY2025 → 加算される ✓（PR #1311でカバー済）
- **2025年3月の帳票 → FY2024 → 加算されない ← 未カバーの境界**
- **2025年1月の帳票 → FY2024 → 加算されない ← 未カバーの境界**

ユーザーが「CarryoverFiscalYear=2025 は calendar 2025 年の帳票に効く」と誤解して設定した場合でも、1-3 月で誤加算が発生しないことを保証する必要があります。

## 追加テスト（UT-018 TC25-27）
| No | テストケース | 期待結果 |
|----|-------------|---------|
| TC25 | calendar年一致・fiscal年不一致（2025/3, CarryoverFiscalYear=2025） | 加算されない |
| TC26 | 1月は前FY扱い（2025/1, CarryoverFiscalYear=2025） | 加算されない |
| TC27 | 未来年度設定（2025/10, CarryoverFiscalYear=2030） | 加算されない |

## Issue #1258 チェックリスト対応状況
| 項目 | PR #1311 | 本 PR |
|------|---------|------|
| FY2025の10月→CumulativeTotalに加算 | ✅ | - |
| FY2026の5月→加算しない | ✅ | - |
| CarryoverFiscalYear=nullの挙動 | ✅ | - |
| 繰越Ledger Incomeを月計から除外（TC12） | ✅ | - |
| 累計金額表示の小数点・桁区切り | ✅ | - |
| **calendar年/fiscal年境界（1-3月）** | - | **✅** |

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~ReportDataBuilderTests"` → 28件（既存25+新規3）全て成功
- [x] 全テストスイート（2629件）成功、回帰なし
- [x] テスト設計書 UT-018 に TC25-27 を同期追加

## 関連
- Issue #1258 の PR #1311 に続く追加実装
- Issue #1215: 年度途中導入の累計初期値設定
- Issue #1219: 年度途中繰越ledgerの受入欄修正

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)