### PR TITLE
chore: 依存パッケージのCVE継続監視の仕組みを導入 (#1272)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,6 +15,25 @@ user-invocable: true
 - **PowerShell 7 (`pwsh.exe`) を使用すること**（`powershell.exe` は5.1なので不可）
 - WSL2から呼ぶ際、`-File` の引数は必ず `./` 付きで指定すること（例: `./tools/release.ps1`）
 
+## リリース前のセキュリティチェック（Issue #1272）
+
+Phase 1 を開始する前に、依存パッケージの既知 CVE を必ず確認する。
+
+```bash
+# 作業ディレクトリ: ICCardManager
+"/mnt/c/Program Files/dotnet/dotnet.exe" restore
+"/mnt/c/Program Files/dotnet/dotnet.exe" list package --vulnerable --include-transitive
+```
+
+### 判定基準
+| 結果 | 対応 |
+|------|------|
+| `No vulnerable packages` | リリース続行 |
+| Critical / High 検出 | **リリース保留**。修正版にアップグレードしてから再開（[開発者ガイド §5.7](../../ICCardManager/docs/manual/開発者ガイド.md) 参照） |
+| Moderate / Low 検出 | リリースノートに記載、計画的対応 |
+
+CVE スキャンの詳細プロセスは `docs/manual/開発者ガイド.md` §5.7 を参照。
+
 ## 自動リリース（推奨）
 
 ### 1コマンドリリース

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,86 @@
+# Issue #1272: 依存パッケージの既知 CVE 監視
+#
+# 本プロジェクトはインターネット非接続環境で動作するため、セキュリティ更新は
+# 開発マシンで検証・手動適用する運用。Dependabot は PR を作成するが、
+# マージは開発者が動作確認後に実施する。
+#
+# 戦略:
+# - セキュリティ更新（vulnerability alert 対応）は別ルートで開き、即座に対処
+# - 通常アップデートは週次で確認、意図せぬ破壊的変更を避けるため
+#   メジャーバージョンアップはデフォルトで無視
+version: 2
+
+updates:
+  # NuGet パッケージ（本体プロジェクト）
+  - package-ecosystem: "nuget"
+    directory: "/ICCardManager/src/ICCardManager"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # メジャーバージョンアップは破壊的変更を含むため手動確認を必須とする
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # NuGet パッケージ（テストプロジェクト）
+  - package-ecosystem: "nuget"
+    directory: "/ICCardManager/tests/ICCardManager.Tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "tests"
+    commit-message:
+      prefix: "chore(deps-test)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # NuGet パッケージ（UIテストプロジェクト）
+  - package-ecosystem: "nuget"
+    directory: "/ICCardManager/tests/ICCardManager.UITests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "tests"
+    commit-message:
+      prefix: "chore(deps-uitest)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions 本体（actions/checkout 等）
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,95 @@
+name: Vulnerability Scan
+
+# Issue #1272: 依存パッケージの既知 CVE を定期的に検出する。
+# - 週次（毎週月曜 JST 09:00 = UTC 00:00）で自動実行
+# - main ブランチへの push でも実行（csproj / packages.lock.json 変更時のみ）
+# - workflow_dispatch で手動実行も可能
+#
+# セキュリティ上の注意:
+# 本ワークフローはユーザー入力（issue body / PR title 等）を一切参照しない。
+# すべての run 文は静的文字列または env 経由の固定値で構成されており、
+# コマンドインジェクションリスクはない。
+
+on:
+  schedule:
+    # 毎週月曜 UTC 00:00 (JST 09:00)
+    - cron: '0 0 * * 1'
+  push:
+    branches: [ main ]
+    paths:
+      - 'ICCardManager/**/*.csproj'
+      - 'ICCardManager/**/packages.lock.json'
+      - '.github/workflows/vulnerability-scan.yml'
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  scan-vulnerabilities:
+    name: NuGet Vulnerability Scan
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: ICCardManager
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      # 直接依存の脆弱性チェック
+      - name: Check direct vulnerable packages
+        id: scan-direct
+        shell: pwsh
+        run: |
+          Write-Host "::group::Direct dependencies"
+          $output = dotnet list package --vulnerable 2>&1 | Out-String
+          Write-Host $output
+          Write-Host "::endgroup::"
+          $found = $output -match '>\s+[\w.]+\s+[\d.]+\s+[\d.]+\s+(Critical|High|Moderate|Low)'
+          "found=$found" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # 推移的依存（transitive）の脆弱性チェック
+      - name: Check transitive vulnerable packages
+        id: scan-transitive
+        shell: pwsh
+        run: |
+          Write-Host "::group::Transitive dependencies"
+          $output = dotnet list package --vulnerable --include-transitive 2>&1 | Out-String
+          Write-Host $output
+          Write-Host "::endgroup::"
+          $found = $output -match '>\s+[\w.]+\s+[\d.]+\s+[\d.]+\s+(Critical|High|Moderate|Low)'
+          "found=$found" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # 廃止（deprecated）パッケージのチェック（情報提供のみ、失敗させない）
+      - name: Check deprecated packages (informational)
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Write-Host "::group::Deprecated packages"
+          dotnet list package --deprecated
+          Write-Host "::endgroup::"
+
+      # 脆弱性が検出された場合はジョブを失敗させる
+      - name: Fail if vulnerabilities found
+        if: steps.scan-direct.outputs.found == 'True' || steps.scan-transitive.outputs.found == 'True'
+        shell: pwsh
+        run: |
+          Write-Host "::error::脆弱なパッケージが検出されました。"
+          Write-Host "対応手順: docs/manual/開発者ガイド.md の 5.7 節を参照してください。"
+          Write-Host "重大度に応じた対応:"
+          Write-Host "  - Critical / High: 24時間以内に修正版にアップグレード"
+          Write-Host "  - Moderate: 次回リリースまでに対応検討"
+          Write-Host "  - Low: 情報として記録、計画的に対応"
+          exit 1

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -9,6 +9,9 @@
 - `PathValidator.ContainsPathTraversal` のパストラバーサル検出を強化。従来の `path.Contains("..")` 単純検査を多段階検出に置き換え、(1) URL エンコード (`%2E%2E`) のデコード再検査、(2) セグメント単位の `..` 判定（混合区切り `/` と `\` 対応）、(3) 末尾空白を考慮した `".. "` の正規化判定、(4) UNC パスで `Path.GetFullPath` 後に元の `\\server\share` プレフィクスが保持されるかの境界チェック、を実施。エラーメッセージもユーザー向けに明瞭化（#1268）
 - `PathValidator.ValidateBackupPath` に UNC パス到達性チェック（5秒タイムアウト）を追加。`Directory.Exists` がネットワーク不安定時に数十秒ハングする問題を解決。到達不可時は「ネットワーク共有に到達できません。ネットワーク接続を確認してください」と明確なエラーを表示。非同期版 `ValidateBackupPathAsync` も提供し、設定画面等 UI スレッドからの呼び出しでブロックしないように `SettingsViewModel.SaveAsync` を更新（#1269）
 
+**開発基盤**
+- 依存パッケージの既知 CVE 継続監視の仕組みを導入。(1) GitHub Actions `vulnerability-scan.yml` が週次 + csproj 更新時に `dotnet list package --vulnerable --include-transitive` を自動実行し、検出時にジョブ失敗で通知、(2) Dependabot 設定で本体/テスト/UIテスト/github-actions の4エコシステムを週次監視・PR自動作成、(3) 開発者ガイド §5.7 に重大度別 SLA（Critical/High は24時間以内）と対応手順を明記、(4) リリーススキル (`/release`) に Phase 1 前のセキュリティチェック項目を追加（#1272）
+
 ### v2.7.0 (2026-04-15)
 
 **新機能**

--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -1010,6 +1010,72 @@ UNCパス（`\\` で始まるパス）が指定された場合、自動的に共
 }
 ```
 
+### 5.7 依存パッケージのCVE管理（Issue #1272）
+
+本プロジェクトは**インターネット非接続環境**で動作するため、依存パッケージの脆弱性が実行時に直接悪用されるリスクは限定的ですが、内部者・物理アクセス経由の攻撃や、ビルド環境への侵害リスクは残ります。以下の仕組みで継続的に CVE を監視します。
+
+#### 自動監視の仕組み
+
+| 仕組み | 頻度 | 検出内容 | 対応 |
+|-------|------|---------|------|
+| **`dotnet list package --vulnerable`** (`.github/workflows/vulnerability-scan.yml`) | 週次（月曜JST 09:00）+ csproj 更新時 + 手動実行 | 既知 CVE を持つ直接/推移的依存 | ワークフロー失敗 → 対応PR作成 |
+| **Dependabot** (`.github/dependabot.yml`) | 週次 | 通常アップデート・セキュリティアップデート | 自動 PR 作成 |
+| **リリース前チェック** (`/release` スキル) | リリース毎 | リリース前に `dotnet list package --vulnerable` 実行 | 発見時はリリース保留 |
+
+#### 重大 CVE 発見時の対応プロセス
+
+脆弱性が検出された場合、**重大度に応じて以下の SLA で対応**してください。
+
+| 重大度 | 対応期限 | アクション |
+|--------|---------|-----------|
+| **Critical / High** | 24 時間以内 | 1. 影響範囲評価 → 2. パッチ版へアップグレード → 3. 回帰テスト → 4. 緊急リリース |
+| **Moderate** | 次回定例リリースまで | 1. 影響評価 → 2. 通常のアップグレード PR → 3. 次リリースに含める |
+| **Low** | 計画的対応 | 1. Issue 化 → 2. バックログ管理 → 3. メジャーバージョンアップ時等にまとめて対応 |
+
+#### 発見時の基本手順
+
+1. **影響範囲の評価**:
+   ```bash
+   # WSL2の場合
+   "/mnt/c/Program Files/dotnet/dotnet.exe" list package --vulnerable --include-transitive
+   ```
+   影響を受けるアセンブリ・コードパスを特定。実行時に該当機能が使われるかを評価。
+
+2. **修正版の確認**:
+   - NuGet.org でパッケージの最新安定版を確認
+   - CVE Advisory で修正バージョンを確認（例: GitHub Security Advisory, NVD）
+
+3. **アップグレード**:
+   ```bash
+   # 例: Microsoft.Extensions.Caching.Memory を 8.0.1 → 8.0.2 に更新
+   # csproj の <PackageReference Version="..."> を手動編集
+   "/mnt/c/Program Files/dotnet/dotnet.exe" restore
+   ```
+
+4. **検証**:
+   - `dotnet build` エラーなし
+   - `dotnet test` 全テスト合格
+   - CVE スキャンが緑になること再実行
+
+5. **PR 作成**:
+   - ブランチ: `fix/cve-YYYY-NNNNN-<パッケージ名>` または `chore/deps-<パッケージ名>-<version>`
+   - CHANGELOG の **セキュリティ修正** セクションに記載（`(#<Issue番号>)` 付き）
+   - Critical / High の場合はホットフィックスとして main に直接マージ後リリース
+
+#### 誤検出・例外の扱い
+
+**抑制が必要な場合**（例: 実行時に該当機能を使用しないため影響なし、依存の依存でアップグレード不可）:
+
+- `.github/dependabot.yml` の `ignore:` セクションに追加
+- 理由を記載したコメントを併置
+- 抑制判断の妥当性は四半期ごとに見直す
+
+#### 参考リンク
+
+- [NuGet セキュリティアドバイザリ (.NET doc)](https://learn.microsoft.com/ja-jp/nuget/concepts/auditing-packages)
+- [GitHub Security Advisories](https://github.com/advisories)
+- [NVD (National Vulnerability Database)](https://nvd.nist.gov/)
+
 ---
 
 ## 6. アクセシビリティ規約


### PR DESCRIPTION
## Summary
本プロジェクトはインターネット非接続環境で動作するが、内部者・物理アクセス経由のリスクやビルド環境侵害リスクが残るため、**依存パッケージの既知 CVE を継続的に監視する仕組み**を導入します。

## 実装内容

### 1. GitHub Actions 週次脆弱性スキャン (`vulnerability-scan.yml`)
- **スケジュール**: 毎週月曜 JST 09:00 (UTC 00:00)
- **トリガー**: 週次 + `csproj`/`packages.lock.json` 変更時の push + 手動 (`workflow_dispatch`)
- **実行内容**:
  - `dotnet list package --vulnerable` — 直接依存
  - `dotnet list package --vulnerable --include-transitive` — 推移的依存
  - `dotnet list package --deprecated` — 廃止パッケージ（情報提供のみ）
- **失敗判定**: Critical / High / Moderate / Low いずれか検出でジョブ失敗
- **セキュリティ**: ユーザー入力（issue body / PR title 等）を一切参照しないため workflow injection リスクなし

### 2. Dependabot 設定 (`dependabot.yml`) — 4エコシステム
| ecosystem | directory | PR limit | labels |
|-----------|-----------|----------|--------|
| nuget | `/ICCardManager/src/ICCardManager` | 5 | dependencies, security |
| nuget | `/ICCardManager/tests/ICCardManager.Tests` | 3 | dependencies, tests |
| nuget | `/ICCardManager/tests/ICCardManager.UITests` | 3 | dependencies, tests |
| github-actions | `/` | 3 | dependencies, ci |

- 週次実行（月曜 JST 09:00）
- **メジャーバージョンアップは ignore**（破壊的変更を避けるため手動確認必須。セキュリティアップデートは別経路で開かれるため問題なし）

### 3. 開発者ガイド §5.7: CVE 管理プロセス
- 3つの自動監視仕組みの概要表
- **重大度別 SLA**:
  - Critical / High: **24時間以内**にパッチ版アップグレード → 回帰テスト → 緊急リリース
  - Moderate: 次回定例リリースまで
  - Low: バックログ管理、計画的対応
- 発見時の基本手順（影響評価 → 修正版確認 → アップグレード → 検証 → PR 作成）
- 誤検出・例外の扱い（`dependabot.yml` の `ignore:` 使用）
- 参考リンク（NuGet セキュリティアドバイザリ、GitHub Security Advisories、NVD）

### 4. リリーススキル (`/release`) 拡張
- Phase 1 開始前のセキュリティチェック項目を追加
- `dotnet list package --vulnerable --include-transitive` 実行
- 判定基準（No vulnerable → 続行 / Critical|High → 保留 / Moderate|Low → リリースノート記載で続行）

### 5. CHANGELOG
- Unreleased に "**開発基盤**" セクションを新設して記載

## Issue #1272 チェックリスト対応
- [x] CI（GitHub Actions）で `dotnet list package --vulnerable` を定期実行
- [x] Dependabot を有効化（インターネット非接続環境のため、開発マシンでの定期チェックに留める — PR 自動作成のみ、マージは手動）
- [x] 重大 CVE 発見時の運用プロセスを DEVELOPER ガイドに追記（§5.7）
- [x] リリースごとのバージョン確認プロセスを `release` スキルに組み込む

## テストなし（CI/CD設定と文書のみ）
本 PR は単体テスト可能な C# コード変更を含まないため、既存のテストスイート（2770件）に対する回帰影響はありません。GitHub Actions および Dependabot の設定は、push 後に GitHub 側で自動検証されます。

## 動作確認方法（PR マージ後）
1. GitHub Actions タブで "Vulnerability Scan" ワークフローが表示されること
2. 手動実行（`workflow_dispatch`）して緑になること
3. Dependabot が有効化され、`dependencies` ラベル付き PR が自動作成されること（次の月曜以降）
4. 開発者ガイド §5.7 が目次からリンク可能なこと

Closes #1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)