### PR TITLE
refactor: LendingService の LendAsync/ReturnAsync を責務分割 (Issue #1283)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -28,6 +28,9 @@
 **ユーザー体験改善**
 - エラーメッセージを「何が / なぜ / どうすれば」の3要素を含む具体的な文言に改善。`ValidationService` の全バリデーター（CardIdm/CardNumber/CardType/StaffIdm/StaffName/WarningBalance）と `LedgerRowEditViewModel.Validate` の7種のメッセージを、実際の入力値・期待値・解決アクションを明示する形に統一。例: 「カード種別を選択してください」→「カード種別が未選択です。ドロップダウンから「はやかけん」「nimoca」等を選択してください」。`.claude/rules/error-messages.md` に品質ガイドライン（3要素構成・禁止パターン・行動指示型語尾・最小文字数基準）を追加し、`ValidationServiceErrorMessageQualityTests` で自動検証（#1275）
 
+**リファクタリング**
+- `LendingService.LendAsync` / `ReturnAsync` を責務ごとに internal ヘルパーメソッドへ分割し、可読性とテスト容易性を向上（`LendAsync` 121行 → 62行、`ReturnAsync` 182行 → 99行）。抽出したヘルパー: `ValidateLendPreconditionsAsync` / `ValidateReturnPreconditionsAsync` / `ResolveLentRecordAsync` / `ResolveInitialBalanceAsync` / `InsertLendLedgerAsync` / `FilterUsageSinceLent` / `ResolveReturnBalanceAsync` / `ApplyBalanceWarningAsync` / `PersistReturnAsync`。public API は一切変更せず、既存テストは全件 pass。抽出ヘルパー向けの `LendingServiceHelperTests`（23件）を追加（#1283）
+
 ### v2.7.0 (2026-04-15)
 
 **新機能**

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -362,6 +362,8 @@ graph LR
 
 ### 5.1 LendingService
 
+`LendAsync` / `ReturnAsync` は Issue #1283 で責務ごとに internal ヘルパーへ分割され、orchestration 層として機能する（詳細は `tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs` および `07_テスト設計書.md §2.18 UT-017i`）。
+
 ```mermaid
 classDiagram
     class LendingService {
@@ -378,6 +380,15 @@ classDiagram
         +ReturnAsync(staffIdm, cardIdm, usageDetails) Task~LendingResult~
         +IsRetouchWithinTimeout(cardIdm) bool
         +ClearHistory() void
+        ~ValidateLendPreconditionsAsync(staffIdm, cardIdm) Task
+        ~ValidateReturnPreconditionsAsync(staffIdm, cardIdm) Task
+        ~ResolveLentRecordAsync(cardIdm) Task
+        ~ResolveInitialBalanceAsync(cardIdm, balance) Task~int~
+        ~InsertLendLedgerAsync(cardIdm, staffIdm, staffName, balance, now) Task~Ledger~
+        ~PersistReturnAsync(cardIdm, lentRecord, usageSinceLent, skipDuplicateCheck, result) Task
+        ~FilterUsageSinceLent(details, lentRecord, now)$ List~LedgerDetail~
+        ~ResolveReturnBalanceAsync(details, createdLedgers, cardIdm) Task~int~
+        ~ApplyBalanceWarningAsync(result) Task
         -CreateUsageLedgersAsync(cardIdm, staffName, details) Task~List~Ledger~~
         -GetLastBalanceAsync(cardIdm) Task~int~
     }

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1050,6 +1050,43 @@ ReturnAsync を通して Ledger の `Expense` / `Balance` / `Note` / `StaffName`
 
 **テストクラス:** `LendingServiceTests`
 
+#### UT-017i: 抽出された internal ヘルパーの単体テスト（Issue #1283）
+
+Issue #1283 で `LendAsync` / `ReturnAsync` から責務ごとに切り出された internal ヘルパーメソッドに対する直接テスト。`InternalsVisibleTo` 経由で internal メソッドを呼び出し、Mock リポジトリで入力条件を制御して期待値を検証する。
+
+**テストクラス:** `LendingServiceHelperTests`
+
+| No | 対象ヘルパー | テストケース | 入力 | 期待結果 |
+|----|------------|-------------|------|---------|
+| 1 | `ValidateLendPreconditionsAsync` | カード未登録 | `GetByIdmAsync=null` | ErrorMessage=「カードが登録されていません。」 |
+| 2 | `ValidateLendPreconditionsAsync` | 貸出中のカード | `IsLent=true` | ErrorMessage=「このカードは既に貸出中です。」 |
+| 3 | `ValidateLendPreconditionsAsync` | 職員証未登録 | カード正常, `GetByIdmAsync(staff)=null` | ErrorMessage=「職員証が登録されていません。」 |
+| 4 | `ValidateLendPreconditionsAsync` | 全条件正常 | 未貸出カード + 登録職員 | ErrorMessage=null, Card/Staff 返却 |
+| 5 | `ValidateReturnPreconditionsAsync` | カード未登録 | `GetByIdmAsync=null` | ErrorMessage=「カードが登録されていません。」 |
+| 6 | `ValidateReturnPreconditionsAsync` | 未貸出のカード | `IsLent=false` | ErrorMessage=「このカードは貸出されていません。」 |
+| 7 | `ValidateReturnPreconditionsAsync` | 職員証未登録 | 貸出中カード + `GetByIdmAsync(staff)=null` | ErrorMessage=「職員証が登録されていません。」 |
+| 8 | `ValidateReturnPreconditionsAsync` | 全条件正常 | 貸出中カード + 登録職員 | ErrorMessage=null, Card/Returner 返却 |
+| 9 | `ResolveLentRecordAsync` | 貸出レコードなし | `GetLentRecordAsync=null` | ErrorMessage=「貸出レコードが見つかりません。」 |
+| 10 | `ResolveLentRecordAsync` | 貸出レコードあり | レコード返却 | ErrorMessage=null, LentRecord 返却 |
+| 11 | `ResolveInitialBalanceAsync` | balance 指定あり | `balance=1500` | 1500 を返す（DB 参照なし） |
+| 12 | `ResolveInitialBalanceAsync` | balance=null + 直近 ledger あり | 直近 ledger.Balance=880 | 880 を返す |
+| 13 | `ResolveInitialBalanceAsync` | balance=null + ledger なし | 全て null | 0 を返す |
+| 14 | `FilterUsageSinceLent` | 7 日前より古い履歴は除外 | 貸出日=4/15, 履歴=4/7〜4/18 | 4/8 以降の 3 件のみ（4/7 除外） |
+| 15 | `FilterUsageSinceLent` | UseDate=null は含む | null + 古い日付混在 | null は含まれる |
+| 16 | `FilterUsageSinceLent` | LentAt=null 時は前日を基準 | LentAt=null, now=4/19 | 4/11（= 4/18 - 7 日）以降のみ |
+| 17 | `ResolveReturnBalanceAsync` | カード残高優先 | 詳細先頭 Balance=2500 | 2500（ledger=999 は無視） |
+| 18 | `ResolveReturnBalanceAsync` | カード残高なし → ledger 末尾 | 詳細 null, ledger 末尾=200 | 200 |
+| 19 | `ResolveReturnBalanceAsync` | 両方なし → DB fallback | 詳細/ledger 空, DB=777 | 777 |
+| 20 | `ResolveReturnBalanceAsync` | 全て空 | 詳細/ledger/DB 全て null | 0 |
+| 21 | `ApplyBalanceWarningAsync` | 残高 < しきい値 | Balance=500, WarningBalance=1000 | IsLowBalance=true |
+| 22 | `ApplyBalanceWarningAsync` | 残高 > しきい値 | Balance=1500, WarningBalance=1000 | IsLowBalance=false |
+| 23 | `ApplyBalanceWarningAsync` | 残高 = しきい値（境界値） | Balance=1000, WarningBalance=1000 | IsLowBalance=false（厳密に `<`） |
+
+**設計意図:**
+- `LendAsync` (121 行) / `ReturnAsync` (182 行) が肥大化して単体検証が困難だった問題への対策
+- public API は不変（`LendingServiceTests` の既存 141 件が regression detector として機能）
+- `InsertLendLedgerAsync` / `PersistReturnAsync` は DB トランザクションを内包するため integration 寄りで既存の `LendingServiceTests` 側で確認（重複テストを避ける）
+
 ---
 
 ### 2.19 月次帳票データ構築（ReportDataBuilder）

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,20 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 貸出レコードを取得。見つからない場合はエラーメッセージを返す。
+        /// </summary>
+        /// <returns>(LentRecord, ErrorMessage)。ErrorMessage が非 null の場合は失敗。</returns>
+        internal async Task<(Ledger LentRecord, string ErrorMessage)> ResolveLentRecordAsync(string cardIdm)
+        {
+            var lentRecord = await _ledgerRepository.GetLentRecordAsync(cardIdm);
+            if (lentRecord == null)
+            {
+                return (null, "貸出レコードが見つかりません。");
+            }
+            return (lentRecord, null);
+        }
+
+        /// <summary>
         /// 返却処理の事前検証。カード・貸出状態・職員の存在を順次チェックする。
         /// </summary>
         /// <returns>(Card, Returner, ErrorMessage)。ErrorMessage が非 null の場合は検証失敗。</returns>
@@ -528,11 +542,10 @@ namespace ICCardManager.Services
                     return result;
                 }
 
-                // 貸出レコードを取得
-                var lentRecord = await _ledgerRepository.GetLentRecordAsync(cardIdm);
-                if (lentRecord == null)
+                var (lentRecord, lentRecordError) = await ResolveLentRecordAsync(cardIdm);
+                if (lentRecordError != null)
                 {
-                    result.ErrorMessage = "貸出レコードが見つかりません。";
+                    result.ErrorMessage = lentRecordError;
                     return result;
                 }
 

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,46 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 返却時のトランザクション内処理: 履歴ledger作成 + 貸出レコード削除 + カード状態解除。
+        /// 共有モード時のSQLITE_BUSY対策として ExecuteWithRetryAsync でラップ。
+        /// </summary>
+        internal async Task PersistReturnAsync(
+            string cardIdm,
+            Ledger lentRecord,
+            List<LedgerDetail> usageSinceLent,
+            bool skipDuplicateCheck,
+            LendingResult result)
+        {
+            await _dbContext.ExecuteWithRetryAsync(async () =>
+            {
+                using var scope = await _dbContext.BeginTransactionAsync();
+
+                try
+                {
+                    var createdLedgers = await CreateUsageLedgersAsync(
+                        cardIdm, lentRecord.StaffName ?? string.Empty, usageSinceLent, skipDuplicateCheck);
+
+                    result.CreatedLedgers.AddRange(createdLedgers);
+
+                    result.HasBusUsage = usageSinceLent.Any(d => d.IsBus);
+
+                    // 貸出レコードをすべて削除（履歴に「（貸出中）」が残らないようにする）
+                    // 共有モードで重複した貸出中レコードがある場合にも対応
+                    await _ledgerRepository.DeleteAllLentRecordsAsync(cardIdm);
+
+                    await _cardRepository.UpdateLentStatusAsync(cardIdm, false, null, null);
+
+                    scope.Commit();
+                }
+                catch
+                {
+                    scope.Rollback();
+                    throw;
+                }
+            });
+        }
+
+        /// <summary>
         /// 低残高警告情報を result にセットする。
         /// </summary>
         internal async Task ApplyBalanceWarningAsync(LendingResult result)
@@ -632,38 +672,8 @@ namespace ICCardManager.Services
                 var hadExistingCurrentMonthRecords = existingMonthRecords
                     .Any(l => !l.IsLentRecord);
 
-                // トランザクション開始
-                // 共有モード時のSQLITE_BUSY対策としてリトライでラップ
-                await _dbContext.ExecuteWithRetryAsync(async () =>
-                {
-                    using var scope = await _dbContext.BeginTransactionAsync();
-
-                    try
-                    {
-                        // 利用日ごとにグループ化して履歴を作成
-                        var createdLedgers = await CreateUsageLedgersAsync(
-                            cardIdm, lentRecord.StaffName ?? string.Empty, usageSinceLent, skipDuplicateCheck);
-
-                        result.CreatedLedgers.AddRange(createdLedgers);
-
-                        // バス利用の有無をチェック
-                        result.HasBusUsage = usageSinceLent.Any(d => d.IsBus);
-
-                        // 貸出レコードをすべて削除（履歴に「（貸出中）」が残らないようにする）
-                        // 共有モードで重複した貸出中レコードがある場合にも対応
-                        await _ledgerRepository.DeleteAllLentRecordsAsync(cardIdm);
-
-                        // カードの貸出状態を更新
-                        await _cardRepository.UpdateLentStatusAsync(cardIdm, false, null, null);
-
-                        scope.Commit();
-                    }
-                    catch
-                    {
-                        scope.Rollback();
-                        throw;
-                    }
-                });
+                // トランザクション内で履歴作成 + 貸出レコード削除 + カード状態更新
+                await PersistReturnAsync(cardIdm, lentRecord, usageSinceLent, skipDuplicateCheck, result);
 
                 // 残額チェック（トランザクション外）
                 // カードから直接読み取った残高を優先（履歴の先頭が最新）

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -312,26 +312,10 @@ namespace ICCardManager.Services
                     return result;
                 }
 
-                // カードを取得
-                var card = await _cardRepository.GetByIdmAsync(cardIdm);
-                if (card == null)
+                var (card, staff, validationError) = await ValidateLendPreconditionsAsync(staffIdm, cardIdm);
+                if (validationError != null)
                 {
-                    result.ErrorMessage = "カードが登録されていません。";
-                    return result;
-                }
-
-                // 貸出中チェック
-                if (card.IsLent)
-                {
-                    result.ErrorMessage = "このカードは既に貸出中です。";
-                    return result;
-                }
-
-                // 職員を取得
-                var staff = await _staffRepository.GetByIdmAsync(staffIdm);
-                if (staff == null)
-                {
-                    result.ErrorMessage = "職員証が登録されていません。";
+                    result.ErrorMessage = validationError;
                     return result;
                 }
 
@@ -414,6 +398,33 @@ namespace ICCardManager.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// 貸出処理の事前検証。カード・貸出状態・職員の存在を順次チェックする。
+        /// </summary>
+        /// <returns>(Card, Staff, ErrorMessage)。ErrorMessage が非 null の場合は検証失敗。</returns>
+        internal async Task<(IcCard Card, Staff Staff, string ErrorMessage)> ValidateLendPreconditionsAsync(
+            string staffIdm, string cardIdm)
+        {
+            var card = await _cardRepository.GetByIdmAsync(cardIdm);
+            if (card == null)
+            {
+                return (null, null, "カードが登録されていません。");
+            }
+
+            if (card.IsLent)
+            {
+                return (card, null, "このカードは既に貸出中です。");
+            }
+
+            var staff = await _staffRepository.GetByIdmAsync(staffIdm);
+            if (staff == null)
+            {
+                return (card, null, "職員証が登録されていません。");
+            }
+
+            return (card, staff, null);
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,33 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 返却処理の事前検証。カード・貸出状態・職員の存在を順次チェックする。
+        /// </summary>
+        /// <returns>(Card, Returner, ErrorMessage)。ErrorMessage が非 null の場合は検証失敗。</returns>
+        internal async Task<(IcCard Card, Staff Returner, string ErrorMessage)> ValidateReturnPreconditionsAsync(
+            string staffIdm, string cardIdm)
+        {
+            var card = await _cardRepository.GetByIdmAsync(cardIdm);
+            if (card == null)
+            {
+                return (null, null, "カードが登録されていません。");
+            }
+
+            if (!card.IsLent)
+            {
+                return (card, null, "このカードは貸出されていません。");
+            }
+
+            var returner = await _staffRepository.GetByIdmAsync(staffIdm);
+            if (returner == null)
+            {
+                return (card, null, "職員証が登録されていません。");
+            }
+
+            return (card, returner, null);
+        }
+
+        /// <summary>
         /// ICカードの返却処理を実行し、利用履歴を記録します。
         /// </summary>
         /// <param name="staffIdm">返却者の職員証IDm（16桁の16進数文字列）</param>
@@ -494,26 +521,10 @@ namespace ICCardManager.Services
                     return result;
                 }
 
-                // カードを取得
-                var card = await _cardRepository.GetByIdmAsync(cardIdm);
-                if (card == null)
+                var (card, returner, validationError) = await ValidateReturnPreconditionsAsync(staffIdm, cardIdm);
+                if (validationError != null)
                 {
-                    result.ErrorMessage = "カードが登録されていません。";
-                    return result;
-                }
-
-                // 貸出中チェック
-                if (!card.IsLent)
-                {
-                    result.ErrorMessage = "このカードは貸出されていません。";
-                    return result;
-                }
-
-                // 返却者を取得
-                var returner = await _staffRepository.GetByIdmAsync(staffIdm);
-                if (returner == null)
-                {
-                    result.ErrorMessage = "職員証が登録されていません。";
+                    result.ErrorMessage = validationError;
                     return result;
                 }
 

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,38 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 返却時の残高解決カスケード。
+        /// 優先順位: (1)カード直接読取値 > (2)作成ledger末尾 > (3)DB 直近 ledger(Issue #1139)。
+        /// </summary>
+        internal async Task<int> ResolveReturnBalanceAsync(
+            List<LedgerDetail> detailList, List<Ledger> createdLedgers, string cardIdm)
+        {
+            var cardBalance = detailList.FirstOrDefault()?.Balance;
+            if (cardBalance.HasValue && cardBalance.Value > 0)
+            {
+                _logger.LogDebug("LendingService: カードから直接読み取った残高を使用: {Balance}円", cardBalance.Value);
+                return cardBalance.Value;
+            }
+
+            var latestCreatedLedger = createdLedgers.LastOrDefault();
+            if (latestCreatedLedger != null)
+            {
+                _logger.LogDebug("LendingService: ledgerレコードの残高を使用: {Balance}円", latestCreatedLedger.Balance);
+                return latestCreatedLedger.Balance;
+            }
+
+            var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+            if (latestLedger != null)
+            {
+                _logger.LogInformation(
+                    "ReturnAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", latestLedger.Balance);
+                return latestLedger.Balance;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
         /// 貸出日以降の履歴を抽出する。貸出タッチ忘れに備え貸出日の1週間前から遡る。
         /// 注意: FeliCa履歴の日付は時刻を含まないため、日付部分のみで比較する。
         /// </summary>
@@ -626,34 +658,7 @@ namespace ICCardManager.Services
                 // 残額チェック（トランザクション外）
                 // カードから直接読み取った残高を優先（履歴の先頭が最新）
                 // FelicaCardReaderで読み取った場合、各LedgerDetail.Balanceには実際の残高が設定されている
-                var cardBalance = detailList.FirstOrDefault()?.Balance;
-                if (cardBalance.HasValue && cardBalance.Value > 0)
-                {
-                    result.Balance = cardBalance.Value;
-                    _logger.LogDebug("LendingService: カードから直接読み取った残高を使用: {Balance}円", result.Balance);
-                }
-                else
-                {
-                    // フォールバック1: 作成したledgerレコードの残高を使用
-                    var latestCreatedLedger = result.CreatedLedgers.LastOrDefault();
-                    if (latestCreatedLedger != null)
-                    {
-                        result.Balance = latestCreatedLedger.Balance;
-                        _logger.LogDebug("LendingService: ledgerレコードの残高を使用: {Balance}円", result.Balance);
-                    }
-                    else
-                    {
-                        // Issue #1139: フォールバック2: DB内の直近の履歴残高を使用
-                        // LendAsync側のIssue #656修正と同等のフォールバック
-                        var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
-                        if (latestLedger != null)
-                        {
-                            result.Balance = latestLedger.Balance;
-                            _logger.LogInformation(
-                                "ReturnAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", result.Balance);
-                        }
-                    }
-                }
+                result.Balance = await ResolveReturnBalanceAsync(detailList, result.CreatedLedgers, cardIdm);
 
                 // 低残高チェック
                 var settings = await _settingsRepository.GetAppSettingsAsync();

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -323,17 +323,7 @@ namespace ICCardManager.Services
 
                 // Issue #656: カードから残高を読み取れなかった場合、直近の履歴から残高を取得
                 // READ操作はリトライ範囲の外で実行（不要な再クエリを防止）
-                var currentBalance = balance ?? 0;
-                if (!balance.HasValue)
-                {
-                    var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
-                    if (latestLedger != null)
-                    {
-                        currentBalance = latestLedger.Balance;
-                        _logger.LogInformation(
-                            "LendAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", currentBalance);
-                    }
-                }
+                var currentBalance = await ResolveInitialBalanceAsync(cardIdm, balance);
 
                 // トランザクション開始
                 // 共有モード時のSQLITE_BUSY対策としてリトライでラップ（WRITE操作のみ）
@@ -398,6 +388,27 @@ namespace ICCardManager.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Issue #656: カードから残高を読み取れなかった場合、直近の ledger 残高を fallback として使用。
+        /// </summary>
+        internal async Task<int> ResolveInitialBalanceAsync(string cardIdm, int? balance)
+        {
+            if (balance.HasValue)
+            {
+                return balance.Value;
+            }
+
+            var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+            if (latestLedger != null)
+            {
+                _logger.LogInformation(
+                    "LendAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", latestLedger.Balance);
+                return latestLedger.Balance;
+            }
+
+            return 0;
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -325,43 +325,10 @@ namespace ICCardManager.Services
                 // READ操作はリトライ範囲の外で実行（不要な再クエリを防止）
                 var currentBalance = await ResolveInitialBalanceAsync(cardIdm, balance);
 
-                // トランザクション開始
+                // トランザクション内で貸出ledger作成 + カード状態更新
                 // 共有モード時のSQLITE_BUSY対策としてリトライでラップ（WRITE操作のみ）
-                await _dbContext.ExecuteWithRetryAsync(async () =>
-                {
-                    using var scope = await _dbContext.BeginTransactionAsync();
-
-                    try
-                    {
-                        var ledger = new Ledger
-                        {
-                            CardIdm = cardIdm,
-                            LenderIdm = staffIdm,
-                            Date = now,
-                            Summary = SummaryGenerator.GetLendingSummary(),
-                            Income = 0,
-                            Expense = 0,
-                            Balance = currentBalance,
-                            StaffName = staff.Name,
-                            LentAt = now,
-                            IsLentRecord = true
-                        };
-
-                        var ledgerId = await _ledgerRepository.InsertAsync(ledger);
-                        ledger.Id = ledgerId;
-                        result.CreatedLedgers.Add(ledger);
-
-                        // カードの貸出状態を更新
-                        await _cardRepository.UpdateLentStatusAsync(cardIdm, true, now, staffIdm);
-
-                        scope.Commit();
-                    }
-                    catch
-                    {
-                        scope.Rollback();
-                        throw;
-                    }
-                });
+                var ledger = await InsertLendLedgerAsync(cardIdm, staffIdm, staff.Name, currentBalance, now);
+                result.CreatedLedgers.Add(ledger);
 
                 // 処理情報を記録
                 LastProcessedCardIdm = cardIdm;
@@ -388,6 +355,53 @@ namespace ICCardManager.Services
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// 貸出ledgerレコードを作成し、カードの貸出状態を更新する。
+        /// 共有モード時のSQLITE_BUSY対策として ExecuteWithRetryAsync でラップ。
+        /// </summary>
+        internal async Task<Ledger> InsertLendLedgerAsync(
+            string cardIdm, string staffIdm, string staffName, int balance, DateTime now)
+        {
+            Ledger createdLedger = null;
+
+            await _dbContext.ExecuteWithRetryAsync(async () =>
+            {
+                using var scope = await _dbContext.BeginTransactionAsync();
+
+                try
+                {
+                    var ledger = new Ledger
+                    {
+                        CardIdm = cardIdm,
+                        LenderIdm = staffIdm,
+                        Date = now,
+                        Summary = SummaryGenerator.GetLendingSummary(),
+                        Income = 0,
+                        Expense = 0,
+                        Balance = balance,
+                        StaffName = staffName,
+                        LentAt = now,
+                        IsLentRecord = true
+                    };
+
+                    var ledgerId = await _ledgerRepository.InsertAsync(ledger);
+                    ledger.Id = ledgerId;
+
+                    await _cardRepository.UpdateLentStatusAsync(cardIdm, true, now, staffIdm);
+
+                    scope.Commit();
+                    createdLedger = ledger;
+                }
+                catch
+                {
+                    scope.Rollback();
+                    throw;
+                }
+            });
+
+            return createdLedger;
         }
 
         /// <summary>

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,21 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 貸出日以降の履歴を抽出する。貸出タッチ忘れに備え貸出日の1週間前から遡る。
+        /// 注意: FeliCa履歴の日付は時刻を含まないため、日付部分のみで比較する。
+        /// </summary>
+        internal static List<LedgerDetail> FilterUsageSinceLent(
+            List<LedgerDetail> detailList, Ledger lentRecord, DateTime now)
+        {
+            var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
+            var lentDate = lentAt.Date;
+            var filterStartDate = lentDate.AddDays(-7);
+            return detailList
+                .Where(d => d.UseDate == null || d.UseDate.Value.Date >= filterStartDate)
+                .ToList();
+        }
+
+        /// <summary>
         /// 貸出レコードを取得。見つからない場合はエラーメッセージを返す。
         /// </summary>
         /// <returns>(LentRecord, ErrorMessage)。ErrorMessage が非 null の場合は失敗。</returns>
@@ -556,17 +571,11 @@ namespace ICCardManager.Services
 
                 // 貸出タッチを忘れた場合でも履歴が正しく記録されるよう、日付フィルタを緩和
                 // 重複チェックは CreateUsageLedgersAsync 内の既存履歴照合（Issue #326）で行う
-                // 注意: FeliCa履歴の日付は時刻を含まないため、日付部分のみで比較する
-                var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
-                var lentDate = lentAt.Date;  // 時刻を切り捨てて日付のみにする
-                // 貸出日の1週間前までの履歴を対象とする（貸出タッチ忘れへの対応）
-                var filterStartDate = lentDate.AddDays(-7);
-                var usageSinceLent = detailList
-                    .Where(d => d.UseDate == null || d.UseDate.Value.Date >= filterStartDate)
-                    .ToList();
+                var usageSinceLent = FilterUsageSinceLent(detailList, lentRecord, now);
 
+                var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
                 _logger.LogDebug("LendingService: 貸出時刻={LentAt}, フィルタ開始日={FilterStart}, 抽出後の履歴件数={Count}",
-                    lentAt.ToString("yyyy-MM-dd HH:mm:ss"), filterStartDate.ToString("yyyy-MM-dd"), usageSinceLent.Count);
+                    lentAt.ToString("yyyy-MM-dd HH:mm:ss"), lentAt.Date.AddDays(-7).ToString("yyyy-MM-dd"), usageSinceLent.Count);
 
                 // 履歴データの詳細をログ出力
                 foreach (var detail in usageSinceLent.Take(5))

--- a/ICCardManager/src/ICCardManager/Services/LendingService.cs
+++ b/ICCardManager/src/ICCardManager/Services/LendingService.cs
@@ -453,6 +453,16 @@ namespace ICCardManager.Services
         }
 
         /// <summary>
+        /// 低残高警告情報を result にセットする。
+        /// </summary>
+        internal async Task ApplyBalanceWarningAsync(LendingResult result)
+        {
+            var settings = await _settingsRepository.GetAppSettingsAsync();
+            result.WarningBalance = settings.WarningBalance;
+            result.IsLowBalance = result.Balance < settings.WarningBalance;
+        }
+
+        /// <summary>
         /// 返却時の残高解決カスケード。
         /// 優先順位: (1)カード直接読取値 > (2)作成ledger末尾 > (3)DB 直近 ledger(Issue #1139)。
         /// </summary>
@@ -660,10 +670,7 @@ namespace ICCardManager.Services
                 // FelicaCardReaderで読み取った場合、各LedgerDetail.Balanceには実際の残高が設定されている
                 result.Balance = await ResolveReturnBalanceAsync(detailList, result.CreatedLedgers, cardIdm);
 
-                // 低残高チェック
-                var settings = await _settingsRepository.GetAppSettingsAsync();
-                result.WarningBalance = settings.WarningBalance;
-                result.IsLowBalance = result.Balance < settings.WarningBalance;
+                await ApplyBalanceWarningAsync(result);
 
                 // 処理情報を記録
                 LastProcessedCardIdm = cardIdm;

--- a/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services
+{
+    /// <summary>
+    /// Issue #1283: LendAsync/ReturnAsync から抽出した internal ヘルパーの単体テスト。
+    /// </summary>
+    public class LendingServiceHelperTests : IDisposable
+    {
+        private readonly Mock<ICardRepository> _mockCardRepo = new();
+        private readonly Mock<IStaffRepository> _mockStaffRepo = new();
+        private readonly Mock<ILedgerRepository> _mockLedgerRepo = new();
+        private readonly Mock<ISettingsRepository> _mockSettingsRepo = new();
+        private readonly DbContext _dbContext;
+        private readonly CardLockManager _lockManager;
+
+        public LendingServiceHelperTests()
+        {
+            _dbContext = new DbContext(":memory:");
+            _dbContext.InitializeDatabase();
+            _lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);
+        }
+
+        private LendingService CreateService()
+        {
+            return new LendingService(
+                _dbContext,
+                _mockCardRepo.Object,
+                _mockStaffRepo.Object,
+                _mockLedgerRepo.Object,
+                _mockSettingsRepo.Object,
+                new SummaryGenerator(),
+                _lockManager,
+                Options.Create(new AppOptions()),
+                NullLogger<LendingService>.Instance);
+        }
+
+        public void Dispose()
+        {
+            _lockManager.Dispose();
+            _dbContext.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        // ============================================================
+        // ValidateLendPreconditionsAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_CardNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync((IcCard)null);
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().BeNull();
+            staff.Should().BeNull();
+            error.Should().Be("カードが登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_CardAlreadyLent_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = true });
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().BeNull();
+            error.Should().Be("このカードは既に貸出中です。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_StaffNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = false });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync((Staff)null);
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().BeNull();
+            error.Should().Be("職員証が登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_AllValid_ReturnsNullError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = false });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync(new Staff { StaffIdm = "STAFF01", Name = "テスト職員" });
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().NotBeNull();
+            staff.Name.Should().Be("テスト職員");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ValidateReturnPreconditionsAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_CardNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync((IcCard)null);
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().BeNull();
+            returner.Should().BeNull();
+            error.Should().Be("カードが登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_NotLent_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = false });
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().BeNull();
+            error.Should().Be("このカードは貸出されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_StaffNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = true });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync((Staff)null);
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().BeNull();
+            error.Should().Be("職員証が登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_AllValid_ReturnsNullError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new IcCard { CardIdm = "CARD01", IsLent = true });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync(new Staff { StaffIdm = "STAFF01", Name = "返却者" });
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().NotBeNull();
+            returner.Name.Should().Be("返却者");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ResolveLentRecordAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveLentRecordAsync_NotFound_ReturnsError()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLentRecordAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var (lentRecord, error) = await service.ResolveLentRecordAsync("CARD01");
+
+            lentRecord.Should().BeNull();
+            error.Should().Be("貸出レコードが見つかりません。");
+        }
+
+        [Fact]
+        public async Task ResolveLentRecordAsync_Found_ReturnsRecord()
+        {
+            var record = new Ledger { CardIdm = "CARD01", IsLentRecord = true, StaffName = "職員A" };
+            _mockLedgerRepo.Setup(r => r.GetLentRecordAsync("CARD01"))
+                .ReturnsAsync(record);
+
+            var service = CreateService();
+            var (lentRecord, error) = await service.ResolveLentRecordAsync("CARD01");
+
+            lentRecord.Should().NotBeNull();
+            lentRecord.StaffName.Should().Be("職員A");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ResolveInitialBalanceAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_BalanceProvided_ReturnsGivenValue()
+        {
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", 1500);
+            result.Should().Be(1500);
+        }
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_NullWithLedger_ReturnsLedgerBalance()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync(new Ledger { Balance = 880 });
+
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", null);
+            result.Should().Be(880);
+        }
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_NullWithoutLedger_ReturnsZero()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", null);
+            result.Should().Be(0);
+        }
+
+        // ============================================================
+        // FilterUsageSinceLent
+        // ============================================================
+
+        [Fact]
+        public void FilterUsageSinceLent_DetailsBeforeSevenDays_Excluded()
+        {
+            var now = new DateTime(2026, 4, 19, 10, 0, 0);
+            var lentRecord = new Ledger { LentAt = new DateTime(2026, 4, 15) };
+            // フィルタ開始日 = 2026-04-15 - 7日 = 2026-04-08
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = new DateTime(2026, 4, 7) },   // 除外
+                new() { UseDate = new DateTime(2026, 4, 8) },   // 含まれる（境界値）
+                new() { UseDate = new DateTime(2026, 4, 15) },  // 含まれる
+                new() { UseDate = new DateTime(2026, 4, 18) },  // 含まれる
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(3);
+            result.Should().NotContain(d => d.UseDate == new DateTime(2026, 4, 7));
+        }
+
+        [Fact]
+        public void FilterUsageSinceLent_NullUseDate_Included()
+        {
+            var now = new DateTime(2026, 4, 19);
+            var lentRecord = new Ledger { LentAt = new DateTime(2026, 4, 15) };
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = null },
+                new() { UseDate = new DateTime(2026, 4, 1) },  // 除外
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(1);
+            result[0].UseDate.Should().BeNull();
+        }
+
+        [Fact]
+        public void FilterUsageSinceLent_LentAtNull_UsesYesterday()
+        {
+            var now = new DateTime(2026, 4, 19);
+            var lentRecord = new Ledger { LentAt = null };  // fallback: now - 1 day = 2026-04-18
+            // フィルタ開始日 = 2026-04-18 - 7 = 2026-04-11
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = new DateTime(2026, 4, 10) },  // 除外
+                new() { UseDate = new DateTime(2026, 4, 11) },  // 境界値（含む）
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(1);
+            result[0].UseDate.Should().Be(new DateTime(2026, 4, 11));
+        }
+
+        // ============================================================
+        // ResolveReturnBalanceAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_CardBalancePresent_ReturnsCardBalance()
+        {
+            var details = new List<LedgerDetail>
+            {
+                new() { Balance = 2500 },  // 先頭=最新
+                new() { Balance = 3000 },
+            };
+            var createdLedgers = new List<Ledger> { new() { Balance = 999 } };
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(details, createdLedgers, "CARD01");
+
+            result.Should().Be(2500);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoCardBalance_ReturnsLedgerBalance()
+        {
+            var details = new List<LedgerDetail>
+            {
+                new() { Balance = null }
+            };
+            var createdLedgers = new List<Ledger>
+            {
+                new() { Balance = 100 },
+                new() { Balance = 200 }  // 末尾
+            };
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(details, createdLedgers, "CARD01");
+
+            result.Should().Be(200);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoDetailNoLedger_UsesDbFallback()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync(new Ledger { Balance = 777 });
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(
+                new List<LedgerDetail>(), new List<Ledger>(), "CARD01");
+
+            result.Should().Be(777);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoDetailNoLedgerNoDb_ReturnsZero()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(
+                new List<LedgerDetail>(), new List<Ledger>(), "CARD01");
+
+            result.Should().Be(0);
+        }
+
+        // ============================================================
+        // ApplyBalanceWarningAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceBelowThreshold_SetsIsLowBalance()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 500 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.WarningBalance.Should().Be(1000);
+            result.IsLowBalance.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceAboveThreshold_NotLow()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 1500 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.IsLowBalance.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceEqualThreshold_NotLow()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 1000 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.IsLowBalance.Should().BeFalse();
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-19-issue-1283-lending-service-split.md
+++ b/docs/superpowers/plans/2026-04-19-issue-1283-lending-service-split.md
@@ -1,0 +1,1356 @@
+# Issue #1283: LendingService 分割リファクタ 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `LendAsync` (121行) / `ReturnAsync` (182行) を private ヘルパーへ分割し、各メソッドを 50〜60 行程度の orchestration 層にする。public API は変更しない。
+
+**Architecture:** 外側 `LendAsync`/`ReturnAsync` は「lock → 検証 → DB 操作 → 後処理 → 状態更新」という共通骨格だけを残し、各ステップを private `Async` ヘルパーに委譲する。検証系ヘルパーはタプル `(Entity?, ..., string? ErrorMessage)` を返し、呼び出し側は `ErrorMessage` 非 null で早期 return する。
+
+**Tech Stack:** C# 10 / .NET Framework 4.8 / xUnit / FluentAssertions / Moq
+
+---
+
+## 事前確認
+
+- 作業ブランチ: `refactor/issue-1283-lending-service-split` (main から分岐済み)
+- 対象ファイル: `ICCardManager/src/ICCardManager/Services/LendingService.cs`
+- 既存テスト: `ICCardManager/tests/ICCardManager.Tests/Services/LendingService*.cs` (合計 ~5800 行、141 テスト pass)
+- Build/Test コマンド: `"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService"`
+- `[InternalsVisibleTo("ICCardManager.Tests")]` は `ICCardManager/src/ICCardManager/Properties/AssemblyInfo.cs` に設定済み
+
+---
+
+## File Structure
+
+### 変更するファイル
+
+| パス | 変更内容 |
+|-----|--------|
+| `ICCardManager/src/ICCardManager/Services/LendingService.cs` | 8 つの private/internal ヘルパーを追加し、LendAsync/ReturnAsync を orchestration に再構成 |
+| `ICCardManager/CHANGELOG.md` | 変更点を [Unreleased] セクションに追加 |
+
+### 新規作成するファイル
+
+| パス | 役割 |
+|-----|-----|
+| `ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs` | 抽出した internal ヘルパーのユニットテスト |
+
+### 既存で使える設備
+
+- `ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs` 内の `CreateLendingService()` / `_mockCardRepo` / `_mockStaffRepo` / `_mockLedgerRepo` パターン（既存のテストを参考にする）
+
+---
+
+## Task 1: Baseline 確認とブランチ準備
+
+**Files:**
+- （参照のみ） `ICCardManager/src/ICCardManager/Services/LendingService.cs`
+
+- [ ] **Step 1: ブランチが正しいことを確認**
+
+```bash
+git branch --show-current
+```
+
+Expected: `refactor/issue-1283-lending-service-split`
+
+- [ ] **Step 2: 既存 LendingService テストが全件 pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `成功!   -失敗:     0、合格:   141`（件数は変動可）
+
+---
+
+## Task 2: `ValidateLendPreconditionsAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:315-336` (LendAsync 内の検証ブロック)
+
+**責務:** カード存在 / 未貸出 / 職員存在の 3 連続検証。タプル `(Card Card, Staff Staff, string ErrorMessage)` を返す。
+
+- [ ] **Step 1: ヘルパーメソッドを LendAsync の直下に追加する**
+
+`LendingService.cs` の `LendAsync` メソッド終了後（L417 付近）、かつ `ReturnAsync` 開始前に挿入する。
+
+```csharp
+/// <summary>
+/// 貸出処理の事前検証。カード・貸出状態・職員の存在を順次チェックする。
+/// </summary>
+/// <returns>(Card, Staff, ErrorMessage)。ErrorMessage が非 null の場合は検証失敗。</returns>
+internal async Task<(Card Card, Staff Staff, string ErrorMessage)> ValidateLendPreconditionsAsync(
+    string staffIdm, string cardIdm)
+{
+    var card = await _cardRepository.GetByIdmAsync(cardIdm);
+    if (card == null)
+    {
+        return (null, null, "カードが登録されていません。");
+    }
+
+    if (card.IsLent)
+    {
+        return (card, null, "このカードは既に貸出中です。");
+    }
+
+    var staff = await _staffRepository.GetByIdmAsync(staffIdm);
+    if (staff == null)
+    {
+        return (card, null, "職員証が登録されていません。");
+    }
+
+    return (card, staff, null);
+}
+```
+
+- [ ] **Step 2: LendAsync 内の対応ブロックをヘルパー呼び出しに置き換える**
+
+`LendingService.cs` L315-336 の以下のブロック:
+
+```csharp
+// カードを取得
+var card = await _cardRepository.GetByIdmAsync(cardIdm);
+if (card == null)
+{
+    result.ErrorMessage = "カードが登録されていません。";
+    return result;
+}
+
+// 貸出中チェック
+if (card.IsLent)
+{
+    result.ErrorMessage = "このカードは既に貸出中です。";
+    return result;
+}
+
+// 職員を取得
+var staff = await _staffRepository.GetByIdmAsync(staffIdm);
+if (staff == null)
+{
+    result.ErrorMessage = "職員証が登録されていません。";
+    return result;
+}
+```
+
+を以下に置き換える:
+
+```csharp
+var (card, staff, validationError) = await ValidateLendPreconditionsAsync(staffIdm, cardIdm);
+if (validationError != null)
+{
+    result.ErrorMessage = validationError;
+    return result;
+}
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ValidateLendPreconditionsAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `ResolveInitialBalanceAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:340-352` (LendAsync 内の残高 fallback)
+
+**責務:** `balance` が null の場合に直近 ledger から残高を取得（Issue #656）。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`ValidateLendPreconditionsAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// Issue #656: カードから残高を読み取れなかった場合、直近の ledger 残高を fallback として使用。
+/// </summary>
+internal async Task<int> ResolveInitialBalanceAsync(string cardIdm, int? balance)
+{
+    if (balance.HasValue)
+    {
+        return balance.Value;
+    }
+
+    var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+    if (latestLedger != null)
+    {
+        _logger.LogInformation(
+            "LendAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", latestLedger.Balance);
+        return latestLedger.Balance;
+    }
+
+    return 0;
+}
+```
+
+- [ ] **Step 2: LendAsync 内の対応ブロックをヘルパー呼び出しに置き換える**
+
+L340-352 の:
+
+```csharp
+// Issue #656: カードから残高を読み取れなかった場合、直近の履歴から残高を取得
+// READ操作はリトライ範囲の外で実行（不要な再クエリを防止）
+var currentBalance = balance ?? 0;
+if (!balance.HasValue)
+{
+    var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+    if (latestLedger != null)
+    {
+        currentBalance = latestLedger.Balance;
+        _logger.LogInformation(
+            "LendAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", currentBalance);
+    }
+}
+```
+
+を以下に置き換える:
+
+```csharp
+// Issue #656: カードから残高を読み取れなかった場合、直近の履歴から残高を取得
+// READ操作はリトライ範囲の外で実行（不要な再クエリを防止）
+var currentBalance = await ResolveInitialBalanceAsync(cardIdm, balance);
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ResolveInitialBalanceAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `InsertLendLedgerAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:354-390` (LendAsync 内のトランザクション)
+
+**責務:** トランザクション内で貸出 ledger 挿入 + カード状態更新。作成された Ledger インスタンスを返す。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`ResolveInitialBalanceAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// 貸出ledgerレコードを作成し、カードの貸出状態を更新する。
+/// 共有モード時のSQLITE_BUSY対策として ExecuteWithRetryAsync でラップ。
+/// </summary>
+internal async Task<Ledger> InsertLendLedgerAsync(
+    string cardIdm, string staffIdm, string staffName, int balance, DateTime now)
+{
+    Ledger createdLedger = null;
+
+    await _dbContext.ExecuteWithRetryAsync(async () =>
+    {
+        using var scope = await _dbContext.BeginTransactionAsync();
+
+        try
+        {
+            var ledger = new Ledger
+            {
+                CardIdm = cardIdm,
+                LenderIdm = staffIdm,
+                Date = now,
+                Summary = SummaryGenerator.GetLendingSummary(),
+                Income = 0,
+                Expense = 0,
+                Balance = balance,
+                StaffName = staffName,
+                LentAt = now,
+                IsLentRecord = true
+            };
+
+            var ledgerId = await _ledgerRepository.InsertAsync(ledger);
+            ledger.Id = ledgerId;
+
+            await _cardRepository.UpdateLentStatusAsync(cardIdm, true, now, staffIdm);
+
+            scope.Commit();
+            createdLedger = ledger;
+        }
+        catch
+        {
+            scope.Rollback();
+            throw;
+        }
+    });
+
+    return createdLedger;
+}
+```
+
+- [ ] **Step 2: LendAsync 内の対応ブロックをヘルパー呼び出しに置き換える**
+
+L354-390 の `await _dbContext.ExecuteWithRetryAsync(...)` ブロックを以下に置き換える:
+
+```csharp
+// トランザクション内で貸出ledger作成 + カード状態更新
+// 共有モード時のSQLITE_BUSY対策としてリトライでラップ（WRITE操作のみ）
+var ledger = await InsertLendLedgerAsync(cardIdm, staffIdm, staff.Name, currentBalance, now);
+result.CreatedLedgers.Add(ledger);
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: InsertLendLedgerAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `ValidateReturnPreconditionsAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:461-482` (ReturnAsync 内の検証)
+
+**責務:** カード存在 / 貸出中 / 職員存在の 3 連続検証。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`InsertLendLedgerAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// 返却処理の事前検証。カード・貸出状態・職員の存在を順次チェックする。
+/// </summary>
+/// <returns>(Card, Returner, ErrorMessage)。ErrorMessage が非 null の場合は検証失敗。</returns>
+internal async Task<(Card Card, Staff Returner, string ErrorMessage)> ValidateReturnPreconditionsAsync(
+    string staffIdm, string cardIdm)
+{
+    var card = await _cardRepository.GetByIdmAsync(cardIdm);
+    if (card == null)
+    {
+        return (null, null, "カードが登録されていません。");
+    }
+
+    if (!card.IsLent)
+    {
+        return (card, null, "このカードは貸出されていません。");
+    }
+
+    var returner = await _staffRepository.GetByIdmAsync(staffIdm);
+    if (returner == null)
+    {
+        return (card, null, "職員証が登録されていません。");
+    }
+
+    return (card, returner, null);
+}
+```
+
+- [ ] **Step 2: ReturnAsync 内の対応ブロックをヘルパー呼び出しに置き換える**
+
+L461-482 の:
+
+```csharp
+// カードを取得
+var card = await _cardRepository.GetByIdmAsync(cardIdm);
+if (card == null)
+{
+    result.ErrorMessage = "カードが登録されていません。";
+    return result;
+}
+
+// 貸出中チェック
+if (!card.IsLent)
+{
+    result.ErrorMessage = "このカードは貸出されていません。";
+    return result;
+}
+
+// 返却者を取得
+var returner = await _staffRepository.GetByIdmAsync(staffIdm);
+if (returner == null)
+{
+    result.ErrorMessage = "職員証が登録されていません。";
+    return result;
+}
+```
+
+を以下に置き換える:
+
+```csharp
+var (card, returner, validationError) = await ValidateReturnPreconditionsAsync(staffIdm, cardIdm);
+if (validationError != null)
+{
+    result.ErrorMessage = validationError;
+    return result;
+}
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ValidateReturnPreconditionsAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `ResolveLentRecordAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:484-490`
+
+**責務:** 貸出レコード取得 + null チェック。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`ValidateReturnPreconditionsAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// 貸出レコードを取得。見つからない場合はエラーメッセージを返す。
+/// </summary>
+/// <returns>(LentRecord, ErrorMessage)。ErrorMessage が非 null の場合は失敗。</returns>
+internal async Task<(Ledger LentRecord, string ErrorMessage)> ResolveLentRecordAsync(string cardIdm)
+{
+    var lentRecord = await _ledgerRepository.GetLentRecordAsync(cardIdm);
+    if (lentRecord == null)
+    {
+        return (null, "貸出レコードが見つかりません。");
+    }
+    return (lentRecord, null);
+}
+```
+
+- [ ] **Step 2: ReturnAsync 内の対応ブロックを置き換える**
+
+L484-490 の:
+
+```csharp
+// 貸出レコードを取得
+var lentRecord = await _ledgerRepository.GetLentRecordAsync(cardIdm);
+if (lentRecord == null)
+{
+    result.ErrorMessage = "貸出レコードが見つかりません。";
+    return result;
+}
+```
+
+を以下に置き換える:
+
+```csharp
+var (lentRecord, lentRecordError) = await ResolveLentRecordAsync(cardIdm);
+if (lentRecordError != null)
+{
+    result.ErrorMessage = lentRecordError;
+    return result;
+}
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ResolveLentRecordAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `FilterUsageSinceLent` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:497-509`
+
+**責務:** 貸出時刻以降の履歴フィルタリング（貸出タッチ忘れに備えて 7 日前まで遡る）。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`ResolveLentRecordAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// 貸出日以降の履歴を抽出する。貸出タッチ忘れに備え貸出日の1週間前から遡る。
+/// 注意: FeliCa履歴の日付は時刻を含まないため、日付部分のみで比較する。
+/// </summary>
+internal static List<LedgerDetail> FilterUsageSinceLent(
+    List<LedgerDetail> detailList, Ledger lentRecord, DateTime now)
+{
+    var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
+    var lentDate = lentAt.Date;
+    var filterStartDate = lentDate.AddDays(-7);
+    return detailList
+        .Where(d => d.UseDate == null || d.UseDate.Value.Date >= filterStartDate)
+        .ToList();
+}
+```
+
+- [ ] **Step 2: ReturnAsync 内の対応ブロックを置き換える**
+
+L497-509 の:
+
+```csharp
+// 貸出タッチを忘れた場合でも履歴が正しく記録されるよう、日付フィルタを緩和
+// 重複チェックは CreateUsageLedgersAsync 内の既存履歴照合（Issue #326）で行う
+// 注意: FeliCa履歴の日付は時刻を含まないため、日付部分のみで比較する
+var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
+var lentDate = lentAt.Date;  // 時刻を切り捨てて日付のみにする
+// 貸出日の1週間前までの履歴を対象とする（貸出タッチ忘れへの対応）
+var filterStartDate = lentDate.AddDays(-7);
+var usageSinceLent = detailList
+    .Where(d => d.UseDate == null || d.UseDate.Value.Date >= filterStartDate)
+    .ToList();
+
+_logger.LogDebug("LendingService: 貸出時刻={LentAt}, フィルタ開始日={FilterStart}, 抽出後の履歴件数={Count}",
+    lentAt.ToString("yyyy-MM-dd HH:mm:ss"), filterStartDate.ToString("yyyy-MM-dd"), usageSinceLent.Count);
+```
+
+を以下に置き換える:
+
+```csharp
+// 貸出タッチを忘れた場合でも履歴が正しく記録されるよう、日付フィルタを緩和
+// 重複チェックは CreateUsageLedgersAsync 内の既存履歴照合（Issue #326）で行う
+var usageSinceLent = FilterUsageSinceLent(detailList, lentRecord, now);
+
+var lentAt = lentRecord.LentAt ?? now.AddDays(-1);
+_logger.LogDebug("LendingService: 貸出時刻={LentAt}, フィルタ開始日={FilterStart}, 抽出後の履歴件数={Count}",
+    lentAt.ToString("yyyy-MM-dd HH:mm:ss"), lentAt.Date.AddDays(-7).ToString("yyyy-MM-dd"), usageSinceLent.Count);
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: FilterUsageSinceLent を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `ResolveReturnBalanceAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:557-587`
+
+**責務:** 返却時の残高解決（カード読取値 → 作成 ledger → DB 直近 ledger の順でフォールバック）。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`FilterUsageSinceLent` の直下に追加。
+
+```csharp
+/// <summary>
+/// 返却時の残高解決カスケード。
+/// 優先順位: (1)カード直接読取値 > (2)作成ledger末尾 > (3)DB 直近 ledger(Issue #1139)。
+/// </summary>
+internal async Task<int> ResolveReturnBalanceAsync(
+    List<LedgerDetail> detailList, List<Ledger> createdLedgers, string cardIdm)
+{
+    // (1) カードから直接読み取った残高を優先
+    var cardBalance = detailList.FirstOrDefault()?.Balance;
+    if (cardBalance.HasValue && cardBalance.Value > 0)
+    {
+        _logger.LogDebug("LendingService: カードから直接読み取った残高を使用: {Balance}円", cardBalance.Value);
+        return cardBalance.Value;
+    }
+
+    // (2) 作成した ledger の末尾残高
+    var latestCreatedLedger = createdLedgers.LastOrDefault();
+    if (latestCreatedLedger != null)
+    {
+        _logger.LogDebug("LendingService: ledgerレコードの残高を使用: {Balance}円", latestCreatedLedger.Balance);
+        return latestCreatedLedger.Balance;
+    }
+
+    // (3) Issue #1139: DB の直近 ledger 残高にフォールバック
+    var latestLedger = await _ledgerRepository.GetLatestLedgerAsync(cardIdm);
+    if (latestLedger != null)
+    {
+        _logger.LogInformation(
+            "ReturnAsync: カード残高を読み取れなかったため、直近の履歴残高を使用: {Balance}円", latestLedger.Balance);
+        return latestLedger.Balance;
+    }
+
+    return 0;
+}
+```
+
+- [ ] **Step 2: ReturnAsync 内の対応ブロックを置き換える**
+
+L557-587 の大きな if/else ブロックを以下に置き換える:
+
+```csharp
+// 残額チェック（トランザクション外）
+// カードから直接読み取った残高を優先（履歴の先頭が最新）
+// FelicaCardReaderで読み取った場合、各LedgerDetail.Balanceには実際の残高が設定されている
+result.Balance = await ResolveReturnBalanceAsync(detailList, result.CreatedLedgers, cardIdm);
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ResolveReturnBalanceAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `CalculateBalanceWarningAsync` を抽出
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Services/LendingService.cs:589-592`
+
+**責務:** `AppSettings.WarningBalance` を取得して result にセット。
+
+- [ ] **Step 1: ヘルパーメソッドを追加**
+
+`ResolveReturnBalanceAsync` の直下に追加。
+
+```csharp
+/// <summary>
+/// 低残高警告情報を result にセットする。
+/// </summary>
+internal async Task ApplyBalanceWarningAsync(LendingResult result)
+{
+    var settings = await _settingsRepository.GetAppSettingsAsync();
+    result.WarningBalance = settings.WarningBalance;
+    result.IsLowBalance = result.Balance < settings.WarningBalance;
+}
+```
+
+- [ ] **Step 2: ReturnAsync 内の対応ブロックを置き換える**
+
+L589-592 の:
+
+```csharp
+// 低残高チェック
+var settings = await _settingsRepository.GetAppSettingsAsync();
+result.WarningBalance = settings.WarningBalance;
+result.IsLowBalance = result.Balance < settings.WarningBalance;
+```
+
+を以下に置き換える:
+
+```csharp
+await ApplyBalanceWarningAsync(result);
+```
+
+- [ ] **Step 3: 既存テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Services/LendingService.cs
+git commit -m "$(cat <<'EOF'
+refactor: ApplyBalanceWarningAsync を抽出 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: 新規テストファイル `LendingServiceHelperTests.cs` を作成
+
+**Files:**
+- Create: `ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs`
+
+抽出したヘルパーに対するユニットテストを追加する。既存 `LendingServiceTests.cs` の `CreateLendingService()` ヘルパーと同じモック構築パターンに合わせる。
+
+- [ ] **Step 1: 既存 LendingServiceTests.cs の CreateLendingService パターンを確認**
+
+以下コマンドで既存のモック構築コードを参照:
+
+```bash
+head -120 ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceTests.cs
+```
+
+Expected: `_mockCardRepo`, `_mockStaffRepo`, `_mockLedgerRepo`, `_mockSettingsRepo`, `SummaryGenerator`, `CardLockManager`, `AppOptions`, `ILogger` が揃った setup コードが見られる
+
+- [ ] **Step 2: 新規テストファイルを作成**
+
+`ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs` を以下の内容で作成する。
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ICCardManager.Data;
+using ICCardManager.Data.Repositories;
+using ICCardManager.Models;
+using ICCardManager.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Services
+{
+    /// <summary>
+    /// Issue #1283: LendAsync/ReturnAsync から抽出した private/internal ヘルパーの単体テスト。
+    /// </summary>
+    public class LendingServiceHelperTests : IDisposable
+    {
+        private readonly Mock<ICardRepository> _mockCardRepo = new();
+        private readonly Mock<IStaffRepository> _mockStaffRepo = new();
+        private readonly Mock<ILedgerRepository> _mockLedgerRepo = new();
+        private readonly Mock<ISettingsRepository> _mockSettingsRepo = new();
+
+        private readonly DbContext _dbContext;
+        private readonly CardLockManager _lockManager;
+
+        public LendingServiceHelperTests()
+        {
+            _dbContext = new DbContext(":memory:");
+            _dbContext.InitializeDatabase();
+            _lockManager = new CardLockManager(NullLogger<CardLockManager>.Instance);
+        }
+
+        private LendingService CreateService()
+        {
+            return new LendingService(
+                _dbContext,
+                _mockCardRepo.Object,
+                _mockStaffRepo.Object,
+                _mockLedgerRepo.Object,
+                _mockSettingsRepo.Object,
+                new SummaryGenerator(),
+                _lockManager,
+                Options.Create(new AppOptions()),
+                NullLogger<LendingService>.Instance);
+        }
+
+        public void Dispose()
+        {
+            _lockManager.Dispose();
+            _dbContext.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        // ============================================================
+        // ValidateLendPreconditionsAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_CardNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync((Card)null);
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().BeNull();
+            staff.Should().BeNull();
+            error.Should().Be("カードが登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_CardAlreadyLent_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = true });
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().BeNull();
+            error.Should().Be("このカードは既に貸出中です。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_StaffNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = false });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync((Staff)null);
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().BeNull();
+            error.Should().Be("職員証が登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateLendPreconditionsAsync_AllValid_ReturnsNullError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = false });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync(new Staff { StaffIdm = "STAFF01", Name = "テスト職員" });
+
+            var service = CreateService();
+            var (card, staff, error) = await service.ValidateLendPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            staff.Should().NotBeNull();
+            staff.Name.Should().Be("テスト職員");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ValidateReturnPreconditionsAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_CardNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync((Card)null);
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().BeNull();
+            returner.Should().BeNull();
+            error.Should().Be("カードが登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_NotLent_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = false });
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().BeNull();
+            error.Should().Be("このカードは貸出されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_StaffNotFound_ReturnsError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = true });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync((Staff)null);
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().BeNull();
+            error.Should().Be("職員証が登録されていません。");
+        }
+
+        [Fact]
+        public async Task ValidateReturnPreconditionsAsync_AllValid_ReturnsNullError()
+        {
+            _mockCardRepo.Setup(r => r.GetByIdmAsync("CARD01", false))
+                .ReturnsAsync(new Card { CardIdm = "CARD01", IsLent = true });
+            _mockStaffRepo.Setup(r => r.GetByIdmAsync("STAFF01", false))
+                .ReturnsAsync(new Staff { StaffIdm = "STAFF01", Name = "返却者" });
+
+            var service = CreateService();
+            var (card, returner, error) = await service.ValidateReturnPreconditionsAsync("STAFF01", "CARD01");
+
+            card.Should().NotBeNull();
+            returner.Should().NotBeNull();
+            returner.Name.Should().Be("返却者");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ResolveLentRecordAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveLentRecordAsync_NotFound_ReturnsError()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLentRecordAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var (lentRecord, error) = await service.ResolveLentRecordAsync("CARD01");
+
+            lentRecord.Should().BeNull();
+            error.Should().Be("貸出レコードが見つかりません。");
+        }
+
+        [Fact]
+        public async Task ResolveLentRecordAsync_Found_ReturnsRecord()
+        {
+            var record = new Ledger { CardIdm = "CARD01", IsLentRecord = true, StaffName = "職員A" };
+            _mockLedgerRepo.Setup(r => r.GetLentRecordAsync("CARD01"))
+                .ReturnsAsync(record);
+
+            var service = CreateService();
+            var (lentRecord, error) = await service.ResolveLentRecordAsync("CARD01");
+
+            lentRecord.Should().NotBeNull();
+            lentRecord.StaffName.Should().Be("職員A");
+            error.Should().BeNull();
+        }
+
+        // ============================================================
+        // ResolveInitialBalanceAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_BalanceProvided_ReturnsGivenValue()
+        {
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", 1500);
+            result.Should().Be(1500);
+        }
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_NullWithLedger_ReturnsLedgerBalance()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync(new Ledger { Balance = 880 });
+
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", null);
+            result.Should().Be(880);
+        }
+
+        [Fact]
+        public async Task ResolveInitialBalanceAsync_NullWithoutLedger_ReturnsZero()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var result = await service.ResolveInitialBalanceAsync("CARD01", null);
+            result.Should().Be(0);
+        }
+
+        // ============================================================
+        // FilterUsageSinceLent
+        // ============================================================
+
+        [Fact]
+        public void FilterUsageSinceLent_DetailsBeforeSevenDays_Excluded()
+        {
+            var now = new DateTime(2026, 4, 19, 10, 0, 0);
+            var lentRecord = new Ledger { LentAt = new DateTime(2026, 4, 15) };
+            // フィルタ開始日 = 2026-04-15 - 7日 = 2026-04-08
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = new DateTime(2026, 4, 7) },   // 除外
+                new() { UseDate = new DateTime(2026, 4, 8) },   // 含まれる（境界値）
+                new() { UseDate = new DateTime(2026, 4, 15) },  // 含まれる
+                new() { UseDate = new DateTime(2026, 4, 18) },  // 含まれる
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(3);
+            result.Should().NotContain(d => d.UseDate == new DateTime(2026, 4, 7));
+        }
+
+        [Fact]
+        public void FilterUsageSinceLent_NullUseDate_Included()
+        {
+            var now = new DateTime(2026, 4, 19);
+            var lentRecord = new Ledger { LentAt = new DateTime(2026, 4, 15) };
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = null },
+                new() { UseDate = new DateTime(2026, 4, 1) },  // 除外
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(1);
+            result[0].UseDate.Should().BeNull();
+        }
+
+        [Fact]
+        public void FilterUsageSinceLent_LentAtNull_UsesYesterday()
+        {
+            var now = new DateTime(2026, 4, 19);
+            var lentRecord = new Ledger { LentAt = null };  // fallback: now - 1 day = 2026-04-18
+            // フィルタ開始日 = 2026-04-18 - 7 = 2026-04-11
+            var details = new List<LedgerDetail>
+            {
+                new() { UseDate = new DateTime(2026, 4, 10) },  // 除外
+                new() { UseDate = new DateTime(2026, 4, 11) },  // 境界値（含む）
+            };
+
+            var result = LendingService.FilterUsageSinceLent(details, lentRecord, now);
+
+            result.Should().HaveCount(1);
+            result[0].UseDate.Should().Be(new DateTime(2026, 4, 11));
+        }
+
+        // ============================================================
+        // ResolveReturnBalanceAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_CardBalancePresent_ReturnsCardBalance()
+        {
+            var details = new List<LedgerDetail>
+            {
+                new() { Balance = 2500 },  // 先頭=最新
+                new() { Balance = 3000 },
+            };
+            var createdLedgers = new List<Ledger> { new() { Balance = 999 } };
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(details, createdLedgers, "CARD01");
+
+            result.Should().Be(2500);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoCardBalance_ReturnsLedgerBalance()
+        {
+            var details = new List<LedgerDetail>
+            {
+                new() { Balance = null }
+            };
+            var createdLedgers = new List<Ledger>
+            {
+                new() { Balance = 100 },
+                new() { Balance = 200 }  // 末尾
+            };
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(details, createdLedgers, "CARD01");
+
+            result.Should().Be(200);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoDetailNoLedger_UsesDbFallback()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync(new Ledger { Balance = 777 });
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(
+                new List<LedgerDetail>(), new List<Ledger>(), "CARD01");
+
+            result.Should().Be(777);
+        }
+
+        [Fact]
+        public async Task ResolveReturnBalanceAsync_NoDetailNoLedgerNoDb_ReturnsZero()
+        {
+            _mockLedgerRepo.Setup(r => r.GetLatestLedgerAsync("CARD01"))
+                .ReturnsAsync((Ledger)null);
+
+            var service = CreateService();
+            var result = await service.ResolveReturnBalanceAsync(
+                new List<LedgerDetail>(), new List<Ledger>(), "CARD01");
+
+            result.Should().Be(0);
+        }
+
+        // ============================================================
+        // ApplyBalanceWarningAsync
+        // ============================================================
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceBelowThreshold_SetsIsLowBalance()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 500 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.WarningBalance.Should().Be(1000);
+            result.IsLowBalance.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceAboveThreshold_NotLow()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 1500 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.IsLowBalance.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ApplyBalanceWarningAsync_BalanceEqualThreshold_NotLow()
+        {
+            _mockSettingsRepo.Setup(r => r.GetAppSettingsAsync())
+                .ReturnsAsync(new AppSettings { WarningBalance = 1000 });
+
+            var service = CreateService();
+            var result = new LendingResult { Balance = 1000 };
+            await service.ApplyBalanceWarningAsync(result);
+
+            result.IsLowBalance.Should().BeFalse();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: 新規テストが全件 pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingServiceHelperTests" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`、追加した 20 件前後のテストが pass
+
+- [ ] **Step 4: 全 LendingService 系テストが pass することを確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~LendingService" --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add ICCardManager/tests/ICCardManager.Tests/Services/LendingServiceHelperTests.cs
+git commit -m "$(cat <<'EOF'
+test: LendingService ヘルパーメソッドのユニットテストを追加 (Issue #1283)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: 行数目標の検証と全テスト実行
+
+**Files:**
+- （確認のみ）
+
+- [ ] **Step 1: LendAsync / ReturnAsync の行数を確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" run --project ICCardManager/tools/...  # 使えない
+```
+
+のかわりに Grep で位置を特定:
+
+```bash
+grep -n "public async Task<LendingResult> LendAsync" ICCardManager/src/ICCardManager/Services/LendingService.cs
+grep -n "public async Task<LendingResult> ReturnAsync" ICCardManager/src/ICCardManager/Services/LendingService.cs
+```
+
+Expected: 両メソッドが ~50〜80 行に収まっている（メソッド定義 + 閉じ波括弧の行番号の差で確認）
+
+- [ ] **Step 2: ソリューション全体ビルド**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" build ICCardManager/ICCardManager.sln --nologo --verbosity minimal
+```
+
+Expected: `ビルドに成功しました。` エラー 0
+
+- [ ] **Step 3: ソリューション全体テスト**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --nologo --verbosity minimal
+```
+
+Expected: `失敗: 0`
+
+- [ ] **Step 4: 問題なければ次タスクへ。失敗すれば内容を精査して修正**
+
+---
+
+## Task 12: CHANGELOG 更新
+
+**Files:**
+- Modify: `ICCardManager/CHANGELOG.md` の [Unreleased] セクション
+
+- [ ] **Step 1: 現在の CHANGELOG の [Unreleased] セクション位置を確認**
+
+```bash
+grep -n "## \[Unreleased\]" ICCardManager/CHANGELOG.md
+```
+
+- [ ] **Step 2: [Unreleased] 下の `### Changed` カテゴリに 1 行追加**
+
+既存の `### Changed` セクションがあればその下、なければ新規に `### Changed` を作成し、以下を追加する:
+
+```markdown
+- `LendingService.LendAsync` / `ReturnAsync` を private ヘルパーメソッドに責務分割（Issue #1283）。public API は不変。
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add ICCardManager/CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: CHANGELOG に Issue #1283 リファクタを記載
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Push と PR 作成
+
+**Files:**
+- （git 操作のみ）
+
+- [ ] **Step 1: ブランチを push**
+
+```bash
+git push -u origin refactor/issue-1283-lending-service-split
+```
+
+- [ ] **Step 2: PR 作成**
+
+```bash
+gh pr create --title "refactor: LendingService の LendAsync/ReturnAsync を責務分割 (Issue #1283)" --body "$(cat <<'EOF'
+## Summary
+- `LendAsync` (121行) と `ReturnAsync` (182行) を 8 つの private/internal ヘルパーに分割
+- public API は一切変更せず、外部からの呼び出しに影響なし
+- 抽出したヘルパーに対して `LendingServiceHelperTests` を追加
+
+## Related
+- Closes #1283
+
+## Test plan
+- [ ] `LendingService*Tests` が全件 pass
+- [ ] 新規 `LendingServiceHelperTests` が pass
+- [ ] ソリューション全体ビルド成功
+- [ ] 手動テスト: 実機で貸出 → 返却の golden path が動作すること（画面操作）
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL が出力される
+
+---
+
+## 手動テスト依頼（コード変更完了後、ユーザーへ依頼）
+
+以下は単体テストでカバーしきれない統合動作の確認のため、実機またはローカル起動で確認してほしい項目:
+
+1. **貸出 golden path**: アプリ起動 → 職員証タッチ → 未貸出カードタッチ → 「貸出完了」表示 + 薄いオレンジ背景 + 「ピッ」
+2. **返却 golden path**: 職員証タッチ → 貸出中カードタッチ → 「返却完了」表示 + 薄い水色背景 + 「ピピッ」 + 残額表示
+3. **エラーケース**:
+   - 未登録カード → 「カードが登録されていません。」
+   - 未登録職員証 → 「職員証が登録されていません。」
+   - 貸出中のカードを再貸出 → 「このカードは既に貸出中です。」
+4. **30 秒ルール**: 貸出直後に同じカードを再タッチ → 返却処理に切り替わる
+5. **残高警告**: 設定画面で警告残額を調整し、返却時に警告 UI が出るか
+6. **共有モード**: UNC パス指定で 2 台並行で貸出しても衝突しない
+
+---
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|-----|
+| ValidateXxx がシグネチャ変更で呼び出し側を壊す | public API は変更しないので発生しない。internal 抽出のみ |
+| ヘルパーテストが DbContext 初期化で失敗 | `DbContext(":memory:") + InitializeDatabase()` を既存 `LendingServiceTests` と同じ方式で使用 |
+| 既存テスト件数が減る | Task 11 Step 3 で全件数を確認し、ベースラインから大きく減っていないか目視 |

--- a/docs/superpowers/specs/2026-04-19-issue-1283-lending-service-split-design.md
+++ b/docs/superpowers/specs/2026-04-19-issue-1283-lending-service-split-design.md
@@ -1,0 +1,105 @@
+# Issue #1283: LendingService の巨大メソッド責務分割 設計書
+
+作成日: 2026-04-19
+対象 Issue: [#1283](https://github.com/kuwayamamasayuki/ICCardManager/issues/1283)
+対象ファイル: `ICCardManager/src/ICCardManager/Services/LendingService.cs`
+
+## 背景と問題
+
+`LendingService.cs`（1222 行）の 2 つの主要メソッドが複数責務を抱え込んでおり、部分的なユニットテストが書きにくい。
+
+- `LendAsync()`: 121 行（ロック / 検証 / 残高 fallback / DB 更新 / 状態記録 / エラー変換）
+- `ReturnAsync()`: 182 行（ロック / 検証 / 履歴フィルタ / DB 更新 / 残高解決 / 警告判定 / 状態記録 / エラー変換）
+- `CreateUsageLedgersAsync()`: 380 行（本 Issue の対象外。別 Issue で対応）
+
+## スコープ
+
+### 含む
+
+- `LendAsync()` / `ReturnAsync()` の責務を private ヘルパーメソッドへ抽出
+- 抽出したヘルパーの単体テスト追加
+- public API は一切変更しない（シグネチャ・戻り値・例外・副作用を維持）
+
+### 含まない
+
+- `CreateUsageLedgersAsync()` のさらなる分割（別 Issue とする）
+- 動作仕様の変更
+- ログメッセージ・エラーメッセージの文言変更
+
+## 抽出するヘルパーメソッド
+
+| 新メソッド | 責務 | 元の位置 | 推定行数 |
+|---------|------|--------|---------|
+| `ValidateLendPreconditionsAsync(staffIdm, cardIdm)` | カード存在・未貸出・職員存在の検証。タプル `(Card?, Staff?, string? ErrorMessage)` を返す | LendAsync L315-336 | ~25 |
+| `ResolveInitialBalanceAsync(cardIdm, balance)` | `balance=null` 時に直近 ledger から残高補完（Issue #656） | LendAsync L340-352 | ~15 |
+| `InsertLendLedgerAsync(cardIdm, staffIdm, staffName, balance, now)` | トランザクション内で ledger 挿入 + カード is_lent 更新 | LendAsync L356-390 | ~35 |
+| `ValidateReturnPreconditionsAsync(staffIdm, cardIdm)` | カード存在・貸出中・職員存在の検証 | ReturnAsync L461-482 | ~25 |
+| `ResolveLentRecordAsync(cardIdm)` | 貸出レコード取得 + null チェック。タプル `(Ledger?, string? ErrorMessage)` | ReturnAsync L484-490 | ~10 |
+| `FilterUsageSinceLent(detailList, lentRecord, now)` | 貸出日の 7 日前以降の履歴を抽出（貸出タッチ忘れ対応） | ReturnAsync L500-506 | ~15 |
+| `ResolveReturnBalanceAsync(detailList, createdLedgers, cardIdm)` | 残高解決カスケード（カード → ledger → DB） | ReturnAsync L560-587 | ~30 |
+| `CalculateBalanceWarningAsync(balance)` | `AppSettings.WarningBalance` 取得 + 判定 | ReturnAsync L590-592 | ~10 |
+
+抽出後の `LendAsync` / `ReturnAsync` はそれぞれ ~50-60 行の orchestration 層になる。
+
+## 設計判断
+
+### なぜ private ヘルパー（静的 util クラスや別サービスではない）
+
+- メソッド群は `_dbContext`, `_cardRepository`, `_staffRepository`, `_ledgerRepository`, `_settingsRepository`, `_logger` などインスタンスフィールドを多用するため、別クラスへ移すと DI 構築のコストが上がる
+- 既に静的ユーティリティへ切り出し可能なロジック（履歴解析）は `LendingHistoryAnalyzer` へ移管済み
+- 今回は「巨大メソッドの可読性改善」が目的であり、責務の集約先を変えるリファクタではない
+
+### なぜ ValidateXxx は「例外スロー」ではなくタプル返却
+
+- 既存の `LendAsync`/`ReturnAsync` はキャッチ節でユーザー向けメッセージへ変換するため、ビジネスバリデーション層では例外を投げないのが自然
+- タプル `(Card?, Staff?, string? ErrorMessage)` で "ErrorMessage 非 null なら失敗" と表現し、呼び出し側の早期 return をシンプルに保つ
+
+### なぜ InsertLendLedgerAsync は transaction を内包する
+
+- `_dbContext.ExecuteWithRetryAsync` と `BeginTransactionAsync` は「ひと塊の DB 書込み」として常にセットで使われており、途中で分断するとリトライ境界が壊れる
+- LendAsync 本体からは「貸出レコード挿入という原子的操作」として見えればよい
+
+## テスト戦略
+
+### ベースライン保全
+
+既存のテストファイル群（合計 ~5800 行）が全件 pass することをもって振る舞い不変性を担保する。
+
+- `LendingServiceTests.cs` (4326 行)
+- `LendingServiceEdgeCaseTests.cs` (140 行)
+- `LendingServiceErrorMessageTests.cs` (75 行)
+- `LendingServiceInsufficientBalanceTests.cs` (303 行)
+- `LendingServiceRetouchTimeoutTests.cs` (392 行)
+
+### 新規テスト（抽出ヘルパー向け）
+
+private なので `InternalsVisibleTo`（既設）を利用し、必要に応じてヘルパーを `internal` に昇格させる。各ヘルパーに対し 3-5 ケースの単体テスト追加:
+
+- `ValidateLendPreconditionsAsync`: カード未登録 / 貸出中 / 職員未登録 / 正常
+- `ValidateReturnPreconditionsAsync`: カード未登録 / 未貸出 / 職員未登録 / 正常
+- `ResolveLentRecordAsync`: 貸出レコードなし / 正常
+- `ResolveInitialBalanceAsync`: balance=null で直近 ledger あり / balance=null で ledger なし / balance 指定あり
+- `FilterUsageSinceLent`: 貸出前の履歴除外 / 貸出日と同日 / 7 日前境界値
+- `ResolveReturnBalanceAsync`: カード残高優先 / ledger fallback / DB fallback
+- `CalculateBalanceWarningAsync`: 閾値未満 / 閾値同値 / 閾値超過
+
+テストファイル名: `LendingServiceHelperTests.cs`（新規）
+
+## 進め方
+
+1. **baseline**: 現状のテストが全件 pass することを確認
+2. **抽出**: ヘルパーメソッドを 1 つずつ抽出し、その都度 `dotnet test` を実行
+3. **単体テスト追加**: 抽出完了後、新規ヘルパー向けテストを追加
+4. **最終確認**: build + test を実行し、PR 作成
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|-----|
+| トランザクション境界を壊して atomic 性が崩れる | transaction 内のコードは `InsertLendLedgerAsync` の中に閉じ込める。transaction を跨ぐヘルパーは作らない |
+| ログ順序が変わることで既存テストが falsely fail する | ログメッセージの文言・順序を変更しない。抽出は呼び出し位置のみ変える |
+| lock 取得 / release の流れが分断される | `try-finally` 構造は残し、内側だけを抽出する |
+
+## 非対象（別 Issue 推奨）
+
+- `CreateUsageLedgersAsync` (380 行) の細分化 — 残高不足パターン処理 / チャージ処理 / ポイント還元処理 / 利用グループ処理を segment type ごとに分割可能


### PR DESCRIPTION
## Summary
- `LendAsync` (121行) と `ReturnAsync` (182行) を計 9 つの internal ヘルパーに分割
  - `LendAsync`: 121行 → **62行**
  - `ReturnAsync`: 182行 → **99行**
- public API は一切変更せず、外部呼び出しに影響なし
- 抽出ヘルパー: `ValidateLendPreconditionsAsync`, `ValidateReturnPreconditionsAsync`, `ResolveLentRecordAsync`, `ResolveInitialBalanceAsync`, `InsertLendLedgerAsync`, `FilterUsageSinceLent`, `ResolveReturnBalanceAsync`, `ApplyBalanceWarningAsync`, `PersistReturnAsync`
- 抽出ヘルパー向けの `LendingServiceHelperTests` を 23 件追加

## Related
- Closes #1283
- `CreateUsageLedgersAsync`（380行、別課題）は本 PR の対象外。別 Issue で対応

## Test plan
- [x] 既存 `LendingService*Tests` が全件 pass（141件 → 164件）
- [x] 新規 `LendingServiceHelperTests` が pass（23件）
- [x] ソリューション全体テスト 2975件 pass
- [x] ソリューション全体ビルド成功（エラー 0、警告は既存のみ）
- [ ] 手動テスト: 実機で貸出 → 返却の golden path が動作すること

## 手動テスト依頼
単体テストでカバーしきれない以下は実機確認をお願いします:
1. 貸出 golden path: 職員証 → 未貸出カード → 「貸出完了」+ オレンジ背景 + ピッ音
2. 返却 golden path: 職員証 → 貸出中カード → 「返却完了」+ 水色背景 + ピピッ音 + 残額表示
3. エラーケース（未登録カード/未登録職員/貸出中の再貸出）でメッセージが正しく表示
4. 30 秒ルール: 貸出直後に同じカードを再タッチ → 返却処理に切り替わる
5. 残高警告: 設定値以下で警告 UI が出る
6. 共有モード: UNC パス指定で並行操作しても衝突しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)