### PR TITLE
chore: ドキュメント更新自問 Stop hook を追加

### DIFF
--- a/.claude/hooks/check-doc-sync.sh
+++ b/.claude/hooks/check-doc-sync.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Stop hook: テスト/主要サービス変更時にドキュメント同期漏れを検知
+#
+# 仕様:
+#   - exit 2 + stderr: Claude への警告（作業継続を強制）
+#   - exit 0 + stdout: Claude への参考情報（context として注入）
+#   - exit 0 (無出力): 何もしない
+#
+# バイパス方法:
+#   - SKIP_DOC_SYNC_CHECK=1 で即 exit 0
+#   - DOC_SYNC_STRICT=1 で low confidence も exit 2 に昇格
+#
+# ルールの出典: .claude/rules/testing.md「テスト追加・修正時はテスト設計書も同期更新する」
+
+# ---- 早期バイパス ----
+[ "${SKIP_DOC_SYNC_CHECK:-}" = "1" ] && exit 0
+
+# ---- 無限ループ防止 ----
+# stop_hook_active=true のときは Claude が既に hook 応答中。追加アクション禁止。
+INPUT="$(cat || true)"
+if printf '%s' "$INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+  exit 0
+fi
+
+# ---- git リポジトリでなければ何もしない ----
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# ---- 変更ファイル集合を取得 ----
+# -c core.quotepath=false: 日本語ファイル名を octal escape せず UTF-8 のまま出力
+# 1) 未コミット変更（staged + unstaged + untracked）
+#    porcelain 形式は "XY path" または "XY orig -> new"。path に空白含む場合はダブルクォートされる。
+#    先頭 3 文字（XY + スペース）を除去して、外側のダブルクォートも剥がす。
+UNCOMMITTED="$(git -c core.quotepath=false status --porcelain 2>/dev/null \
+  | sed -e 's/^...//' -e 's/^"//' -e 's/"$//' -e 's/.* -> //')" || UNCOMMITTED=""
+
+# 2) ブランチ上のコミット（main..HEAD）
+BASE="$(git merge-base HEAD main 2>/dev/null || true)"
+if [ -n "$BASE" ]; then
+  COMMITTED="$(git -c core.quotepath=false log --name-only --pretty=format: "$BASE"..HEAD 2>/dev/null | sort -u)" || COMMITTED=""
+else
+  COMMITTED=""
+fi
+
+CHANGED="$(printf '%s\n%s\n' "$UNCOMMITTED" "$COMMITTED" | sed '/^$/d' | sort -u)"
+[ -z "$CHANGED" ] && exit 0
+
+# ---- 判定 ----
+has_match() { printf '%s\n' "$CHANGED" | grep -E "$1" >/dev/null 2>&1; }
+
+TEST_DOC='ICCardManager/docs/design/07_テスト設計書\.md'
+CLASS_DOC='ICCardManager/docs/design/05_クラス設計書\.md'
+TEST_SRC='^ICCardManager/tests/.*\.cs$'
+# 主要サービスクラス: 05_クラス設計書.md §5 に挙がっているもの
+SERVICE_SRC='^ICCardManager/src/ICCardManager/Services/(LendingService|ReportService|BackupService|SummaryGenerator|LedgerMergeService|LedgerSplitService)\.cs$'
+
+MISS_TEST_DOC=0
+MISS_CLASS_DOC=0
+has_match "$TEST_SRC"    && ! has_match "$TEST_DOC"  && MISS_TEST_DOC=1
+has_match "$SERVICE_SRC" && ! has_match "$CLASS_DOC" && MISS_CLASS_DOC=1
+
+# ---- 出力 ----
+STRICT="${DOC_SYNC_STRICT:-0}"
+
+if [ "$MISS_TEST_DOC" = "1" ]; then
+  {
+    echo "⚠ ドキュメント同期漏れ検知 (high confidence)"
+    echo "  テストコード (ICCardManager/tests/) を変更しましたが、"
+    echo "  ICCardManager/docs/design/07_テスト設計書.md が未更新です。"
+    echo "  .claude/rules/testing.md の規約に従い、テスト設計書を同期更新してください。"
+    echo "  (意図的にスキップする場合は SKIP_DOC_SYNC_CHECK=1 で再実行)"
+  } >&2
+  exit 2
+fi
+
+if [ "$MISS_CLASS_DOC" = "1" ]; then
+  MSG=$'ℹ ドキュメント同期の可能性あり (low confidence)\n  主要サービスクラスを変更しましたが、\n  ICCardManager/docs/design/05_クラス設計書.md が未更新です。\n  設計に影響する変更か確認し、必要なら同期更新してください。'
+  if [ "$STRICT" = "1" ]; then
+    printf '%s\n' "$MSG" >&2
+    exit 2
+  else
+    printf '%s\n' "$MSG"
+    exit 0
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/check-doc-sync.sh
+++ b/.claude/hooks/check-doc-sync.sh
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-# Stop hook: テスト/主要サービス変更時にドキュメント同期漏れを検知
+# Stop hook: コード変更があれば Claude に「ドキュメント更新は不要か？」と自問させる。
 #
-# 仕様:
-#   - exit 2 + stderr: Claude への警告（作業継続を強制）
-#   - exit 0 + stdout: Claude への参考情報（context として注入）
-#   - exit 0 (無出力): 何もしない
+# 設計方針:
+#   特定のファイル→ドキュメント対応を hook 側で列挙するのではなく、
+#   変更ファイル一覧と確認観点リストを Claude に渡して自己判断させる。
+#   これにより hook の保守が不要になり、新しいドキュメント種別にも自動対応できる。
 #
-# バイパス方法:
+# 動作:
+#   - 変更なし → exit 0（何もしない）
+#   - ドキュメント・workflow 設定のみの変更 → exit 0（自問不要）
+#   - それ以外（コード変更あり）→ exit 2 + stderr で自問プロンプトを注入
+#     → Claude は次ターンで更新要否を判断し、必要なら更新、不要ならその旨述べて stop
+#     → stop_hook_active=true で再発火時は即 exit 0（無限ループ防止）
+#
+# バイパス:
 #   - SKIP_DOC_SYNC_CHECK=1 で即 exit 0
-#   - DOC_SYNC_STRICT=1 で low confidence も exit 2 に昇格
 #
-# ルールの出典: .claude/rules/testing.md「テスト追加・修正時はテスト設計書も同期更新する」
+# ルールの出典:
+#   .claude/rules/testing.md（テスト設計書同期）
+#   memory/feedback_update_docs_with_code.md（コード変更時は設計書も同じPRで更新）
+#   memory/feedback_update_third_party_licenses.md（パッケージ/素材更新時はライセンス更新）
 
 # ---- 早期バイパス ----
 [ "${SKIP_DOC_SYNC_CHECK:-}" = "1" ] && exit 0
 
 # ---- 無限ループ防止 ----
-# stop_hook_active=true のときは Claude が既に hook 応答中。追加アクション禁止。
 INPUT="$(cat || true)"
 if printf '%s' "$INPUT" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
   exit 0
@@ -27,13 +35,9 @@ git rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
 # ---- 変更ファイル集合を取得 ----
 # -c core.quotepath=false: 日本語ファイル名を octal escape せず UTF-8 のまま出力
-# 1) 未コミット変更（staged + unstaged + untracked）
-#    porcelain 形式は "XY path" または "XY orig -> new"。path に空白含む場合はダブルクォートされる。
-#    先頭 3 文字（XY + スペース）を除去して、外側のダブルクォートも剥がす。
 UNCOMMITTED="$(git -c core.quotepath=false status --porcelain 2>/dev/null \
   | sed -e 's/^...//' -e 's/^"//' -e 's/"$//' -e 's/.* -> //')" || UNCOMMITTED=""
 
-# 2) ブランチ上のコミット（main..HEAD）
 BASE="$(git merge-base HEAD main 2>/dev/null || true)"
 if [ -n "$BASE" ]; then
   COMMITTED="$(git -c core.quotepath=false log --name-only --pretty=format: "$BASE"..HEAD 2>/dev/null | sort -u)" || COMMITTED=""
@@ -44,43 +48,37 @@ fi
 CHANGED="$(printf '%s\n%s\n' "$UNCOMMITTED" "$COMMITTED" | sed '/^$/d' | sort -u)"
 [ -z "$CHANGED" ] && exit 0
 
-# ---- 判定 ----
-has_match() { printf '%s\n' "$CHANGED" | grep -E "$1" >/dev/null 2>&1; }
+# ---- ドキュメント/meta ファイル以外の変更を抽出 ----
+# docs/, ICCardManager/docs/, .claude/, ルート直下の *.md は「それ自体がドキュメント」なので除外
+NON_DOC="$(printf '%s\n' "$CHANGED" \
+  | grep -Ev '^(docs/|ICCardManager/docs/|\.claude/)' \
+  | grep -Ev '^[^/]+\.md$' \
+  || true)"
+[ -z "$NON_DOC" ] && exit 0
 
-TEST_DOC='ICCardManager/docs/design/07_テスト設計書\.md'
-CLASS_DOC='ICCardManager/docs/design/05_クラス設計書\.md'
-TEST_SRC='^ICCardManager/tests/.*\.cs$'
-# 主要サービスクラス: 05_クラス設計書.md §5 に挙がっているもの
-SERVICE_SRC='^ICCardManager/src/ICCardManager/Services/(LendingService|ReportService|BackupService|SummaryGenerator|LedgerMergeService|LedgerSplitService)\.cs$'
-
-MISS_TEST_DOC=0
-MISS_CLASS_DOC=0
-has_match "$TEST_SRC"    && ! has_match "$TEST_DOC"  && MISS_TEST_DOC=1
-has_match "$SERVICE_SRC" && ! has_match "$CLASS_DOC" && MISS_CLASS_DOC=1
-
-# ---- 出力 ----
-STRICT="${DOC_SYNC_STRICT:-0}"
-
-if [ "$MISS_TEST_DOC" = "1" ]; then
-  {
-    echo "⚠ ドキュメント同期漏れ検知 (high confidence)"
-    echo "  テストコード (ICCardManager/tests/) を変更しましたが、"
-    echo "  ICCardManager/docs/design/07_テスト設計書.md が未更新です。"
-    echo "  .claude/rules/testing.md の規約に従い、テスト設計書を同期更新してください。"
-    echo "  (意図的にスキップする場合は SKIP_DOC_SYNC_CHECK=1 で再実行)"
-  } >&2
-  exit 2
-fi
-
-if [ "$MISS_CLASS_DOC" = "1" ]; then
-  MSG=$'ℹ ドキュメント同期の可能性あり (low confidence)\n  主要サービスクラスを変更しましたが、\n  ICCardManager/docs/design/05_クラス設計書.md が未更新です。\n  設計に影響する変更か確認し、必要なら同期更新してください。'
-  if [ "$STRICT" = "1" ]; then
-    printf '%s\n' "$MSG" >&2
-    exit 2
-  else
-    printf '%s\n' "$MSG"
-    exit 0
+# ---- 自問プロンプトを stderr で注入（exit 2 で stop をブロック） ----
+{
+  echo "📋 ドキュメント更新の自己確認"
+  echo ""
+  echo "本セッションで以下のコード/設定ファイルが変更されました:"
+  printf '%s\n' "$NON_DOC" | head -30 | sed 's/^/  - /'
+  TOTAL="$(printf '%s\n' "$NON_DOC" | wc -l | tr -d ' ')"
+  if [ "$TOTAL" -gt 30 ]; then
+    echo "  ... 他 $((TOTAL - 30)) 件"
   fi
-fi
+  echo ""
+  echo "応答を終える前に、これらの変更に対応したドキュメント更新が必要か自問してください。"
+  echo "確認観点:"
+  echo "  - テスト追加/修正 → docs/design/07_テスト設計書.md"
+  echo "  - 主要クラスの構造変更 → docs/design/05_クラス設計書.md"
+  echo "  - DB スキーマ変更 → docs/design/02_DB設計書.md"
+  echo "  - 画面/操作フロー変更 → docs/design/03_画面設計書.md / docs/manual/ユーザーマニュアル.md"
+  echo "  - 公開 API / 動作仕様変更 → docs/design/04_機能設計書.md / ICCardManager/CHANGELOG.md"
+  echo "  - 依存パッケージ/素材追加 → ICCardManager/docs/THIRD_PARTY_LICENSES.md"
+  echo "  - シーケンス変化のある API 変更 → docs/design/06_シーケンス図.md"
+  echo ""
+  echo "更新不要と判断した場合は理由を一言添えた上で応答を終えてください。"
+  echo "(意図的にスキップする場合は SKIP_DOC_SYNC_CHECK=1 で再実行)"
+} >&2
 
-exit 0
+exit 2

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -24,3 +24,4 @@
 
 ## テスト追加・修正時
 - テスト設計書（`docs/design/07_テスト設計書.md`）も同期更新すること
+- 本ルールは Claude Code の Stop hook（`.claude/hooks/check-doc-sync.sh`）で機械的に検証される。テスト変更があるのに設計書未更新のまま Claude が応答を終えようとすると警告が出て作業継続が促される。意図的にスキップしたい場合は環境変数 `SKIP_DOC_SYNC_CHECK=1` を設定する

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -24,4 +24,4 @@
 
 ## テスト追加・修正時
 - テスト設計書（`docs/design/07_テスト設計書.md`）も同期更新すること
-- 本ルールは Claude Code の Stop hook（`.claude/hooks/check-doc-sync.sh`）で機械的に検証される。テスト変更があるのに設計書未更新のまま Claude が応答を終えようとすると警告が出て作業継続が促される。意図的にスキップしたい場合は環境変数 `SKIP_DOC_SYNC_CHECK=1` を設定する
+- Stop hook（`.claude/hooks/check-doc-sync.sh`）がコード変更のあるセッション終了時に「ドキュメント更新が必要か」の自己確認プロンプトを注入する。テスト設計書の同期漏れもこの自問で検出されやすくなる。環境変数 `SKIP_DOC_SYNC_CHECK=1` でバイパス可

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,14 @@
       "Bash(git push origin main*)",
       "Bash(git push -u origin main*)"
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": "bash .claude/hooks/check-doc-sync.sh",
+        "timeout": 15
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
Issue #1283 の実装で `07_テスト設計書.md` の同期更新を失念したため、Claude Code の Stop hook で再発防止する。

当初はファイルパターン→ドキュメントの対応を hook 側でルール列挙する設計だったが、ユーザーフィードバックを受けて**「Claude 自身に自問させる」方式**に変更した。これにより:
- hook 自体の保守が不要（新ドキュメント/新対象ファイルに自動対応）
- 判断主体が Claude になるため、変更内容に即した適切な粒度で判断できる
- 観点リストで網羅性を担保（設計書 7 種 / CHANGELOG / THIRD_PARTY_LICENSES / マニュアル）

## 動作

| 状態 | 挙動 |
|------|-----|
| 変更なし | exit 0（何もしない） |
| ドキュメント/workflow のみ変更 | exit 0（自問不要） |
| コード/設定変更あり | **exit 2 + stderr** に自問プロンプトを注入 → Claude は次ターンで更新要否を判断 |
| `stop_hook_active=true` | exit 0（無限ループ防止） |
| `SKIP_DOC_SYNC_CHECK=1` | exit 0（バイパス） |

## 自問プロンプトの例

```
📋 ドキュメント更新の自己確認

本セッションで以下のコード/設定ファイルが変更されました:
  - ICCardManager/tests/ICCardManager.Tests/Services/FooTest.cs
  - ICCardManager/src/ICCardManager/Services/Foo.cs

応答を終える前に、これらの変更に対応したドキュメント更新が必要か自問してください。
確認観点:
  - テスト追加/修正 → docs/design/07_テスト設計書.md
  - 主要クラスの構造変更 → docs/design/05_クラス設計書.md
  - DB スキーマ変更 → docs/design/02_DB設計書.md
  - 画面/操作フロー変更 → docs/design/03_画面設計書.md / ユーザーマニュアル.md
  - 公開 API / 動作仕様変更 → docs/design/04_機能設計書.md / ICCardManager/CHANGELOG.md
  - 依存パッケージ/素材追加 → ICCardManager/docs/THIRD_PARTY_LICENSES.md
  - シーケンス変化のある API 変更 → docs/design/06_シーケンス図.md

更新不要と判断した場合は理由を一言添えた上で応答を終えてください。
```

## 技術的ポイント
- `git -c core.quotepath=false` で日本語ファイル名の octal escape 問題を回避
- settings.json では `bash .claude/hooks/check-doc-sync.sh` 起動（DrvFs の実行権限問題回避）
- 除外条件: `docs/`, `ICCardManager/docs/`, `.claude/`, ルート直下 `*.md`

## 変更ファイル
- `.claude/hooks/check-doc-sync.sh`（新規、~70 行）
- `.claude/settings.json`（`hooks.Stop` セクション追加）
- `.claude/rules/testing.md`（hook の存在を明記）

## Test plan
- [x] 変更なし: exit 0、出力なし
- [x] ドキュメントのみ変更: exit 0、出力なし
- [x] コード変更あり（tests/*.cs 追加）: exit 2、自問プロンプト出力
- [x] `stop_hook_active=true`: exit 0（無限ループ防止）
- [x] `SKIP_DOC_SYNC_CHECK=1`: exit 0（バイパス）
- [ ] 実 Claude Code セッションで E2E: マージ後の次回タスクで自問プロンプトが期待通り届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)