### PR TITLE
feat: マイグレーション冪等性の強化と二重実行テスト追加 (Issue #1285)

### DIFF
--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,43 @@
+# マイグレーション作成規約
+
+## 冪等性（二重実行安全）の必須化
+
+新規マイグレーション (`IMigration` 実装) の `Up()` は**必ず冪等**に書くこと。共有モードで複数 PC が同時起動した場合や、`schema_migrations` テーブルが部分破損した場合に備える（Issue #1285）。
+
+## 冪等パターン
+
+| 操作 | 書き方 |
+|------|--------|
+| テーブル作成 | `CREATE TABLE IF NOT EXISTS ...` |
+| インデックス作成 | `CREATE INDEX IF NOT EXISTS ...` / `CREATE UNIQUE INDEX IF NOT EXISTS ...` |
+| 列追加 | `MigrationHelpers.AddColumnIfNotExists(conn, tx, "table", "column", "TYPE DEFAULT ...")` |
+| 行追加 | `INSERT OR IGNORE INTO ...` |
+| 行更新 | `UPDATE ... WHERE <条件が同じ入力で同じ結果を出す>` |
+
+## 禁止パターン
+
+- 素の `ALTER TABLE ... ADD COLUMN`（SQLite では `IF NOT EXISTS` が一部バージョンで非サポート）
+- 素の `CREATE TABLE` / `CREATE INDEX`（必ず `IF NOT EXISTS` を付ける）
+- 素の `INSERT`（主キー重複で失敗するため `INSERT OR IGNORE` を使う）
+
+## 新規マイグレーション追加手順
+
+1. `ICCardManager/src/ICCardManager/Data/Migrations/Migration_0NN_<説明>.cs` を作成
+2. `IMigration` を実装
+   - `Version` は既存最大 +1
+   - `Description` は日本語で要約
+3. `Up()` は上記「冪等パターン」に従って書く
+4. `Down()` は可能ならロールバック、不可能なら空実装 + 理由コメント
+5. `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs` に `Migration_0NN_<name>_Up_IsIdempotent` を追加
+   - 先行マイグレーションを順に `RunMigrationOnce` して DB を準備し、対象を `RunMigrationTwice` で実行
+6. スキーマに列追加した場合は `docs/design/02_DB設計書.md` の該当テーブルに反映
+
+## 自動検出
+
+`MigrationRunner.DiscoverMigrations()` が Reflection で `IMigration` 実装クラスを自動検出するため、**手動登録は不要**。`Version` プロパティ順に適用される。
+
+## 参考
+
+- 設計書: `docs/superpowers/specs/2026-04-19-issue-1285-migration-idempotency-design.md`
+- ヘルパー実装: `ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs`
+- テスト例: `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs`

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 **リファクタリング**
 - `LendingService.LendAsync` / `ReturnAsync` を責務ごとに internal ヘルパーメソッドへ分割し、可読性とテスト容易性を向上（`LendAsync` 121行 → 62行、`ReturnAsync` 182行 → 99行）。抽出したヘルパー: `ValidateLendPreconditionsAsync` / `ValidateReturnPreconditionsAsync` / `ResolveLentRecordAsync` / `ResolveInitialBalanceAsync` / `InsertLendLedgerAsync` / `FilterUsageSinceLent` / `ResolveReturnBalanceAsync` / `ApplyBalanceWarningAsync` / `PersistReturnAsync`。public API は一切変更せず、既存テストは全件 pass。抽出ヘルパー向けの `LendingServiceHelperTests`（23件）を追加（#1283）
+- DB マイグレーションの冪等性（二重実行安全性）を担保。`MigrationHelpers.AddColumnIfNotExists` を新設し、非冪等だった 5 つの `ALTER TABLE ADD COLUMN` 型マイグレーション（#002/#003/#005/#006/#009）を冪等化。共有モードで複数 PC が初回起動時にマイグレーション競合した場合や、`schema_migrations` テーブル部分破損時の再適用エラーを防止。全 9 マイグレーションの二重実行テスト (`MigrationIdempotencyTests`, 9件) と `MigrationHelpers` 単体テスト (7件) を追加。`.claude/rules/migrations.md` に冪等性チェックリストを新設し、開発者ガイド §3.5 を自動検出ロジック (`DiscoverMigrations()`) に合わせて更新（#1285）
 - `CsvImportService.Ledger.cs`（1031行 → 520行）と `Detail.cs`（1042行 → 761行）を責務分割。(1) Import/Preview 間で重複していた利用履歴行パース ~200 行を `LedgerCsvRowParser` に共通化、(2) 利用履歴詳細の 13 列パースを `LedgerDetailCsvRowParser` に抽出、(3) Detail の「履歴ID空欄→新規 Ledger 自動作成」ロジックを `NewLedgerFromSegmentsBuilder` に責務分離（Issue #906/#918/#1053 関連のロジック）、(4) 検証系 helper 4 メソッドを `CsvImportService.LedgerValidation.cs` partial に分離。public API は一切変更せず、既存 94 件のテストは全件 pass。抽出クラス向けの単体テスト 21 件を追加（`LedgerCsvRowParserTests` / `LedgerDetailCsvRowParserTests` / `NewLedgerFromSegmentsBuilderTests`）（#1284）
 
 ### v2.7.0 (2026-04-15)

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -1530,6 +1530,32 @@ Issue #1283 で `LendAsync` / `ReturnAsync` から責務ごとに切り出され
 
 **テストクラス:** `DbContextMigrationTests`
 
+#### UT-MIG-IDEMPOTENCY: マイグレーション冪等性テスト（Issue #1285）
+
+Issue #1285 で追加。`MigrationHelpers` および全 9 マイグレーションの二重実行安全性を検証。共有モードで複数 PC が同時に初回起動する場合や、`schema_migrations` テーブルが部分破損した状態でも再適用でエラーが出ないことを担保する。
+
+**テストクラス:** `MigrationHelpersTests` (7件) / `MigrationIdempotencyTests` (9件)
+
+##### MigrationHelpersTests
+
+| No | 対象 | テストケース | 期待結果 |
+|----|------|-------------|---------|
+| 1 | `HasColumn` | 既存列 | true |
+| 2 | `HasColumn` | 存在しない列 | false |
+| 3 | `HasColumn` | 大小文字違い | true（OrdinalIgnoreCase） |
+| 4 | `HasColumn` | 不正テーブル名（SQL インジェクション） | ArgumentException |
+| 5 | `AddColumnIfNotExists` | 新規列 | 列が追加される |
+| 6 | `AddColumnIfNotExists` | 既存列 | no-op、例外なし |
+| 7 | `AddColumnIfNotExists` | 同 tx 内で 2 回呼び出し | 2 回目は no-op |
+
+##### MigrationIdempotencyTests
+
+| No | 対象 Migration | 実行パターン | 期待結果 |
+|----|--------------|------------|---------|
+| 1〜9 | Migration_001〜009 | 先行 Migration を Once で準備、対象を Twice | 例外なし |
+
+各テストは独立に DB をセットアップし、対象より若い version の Migration を順に適用した後、対象を 2 回連続で `Up()` 実行する。
+
 ---
 
 ### 2.25 データ保持期限（6年自動削除）

--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -622,9 +622,28 @@ sequenceDiagram
 **新規マイグレーションの追加手順**:
 
 1. `IMigration` インターフェースを実装するクラスを作成
-2. `Version` プロパティに一意のバージョン番号を設定
-3. `Up()` メソッドにスキーマ変更を実装
-4. `MigrationRunner.GetAllMigrations()` に登録
+2. `Version` プロパティに一意のバージョン番号（既存最大 +1）を設定
+3. `Up()` メソッドに冪等なスキーマ変更を実装（下記「冪等性ガイドライン」参照）
+4. `Down()` メソッドに可能な範囲で逆操作を実装（SQLite 制約で不可な場合は空実装 + 理由コメント）
+5. `MigrationIdempotencyTests` に対応するテストを追加
+6. `docs/design/02_DB設計書.md` の該当テーブルに反映
+
+登録は不要: `MigrationRunner.DiscoverMigrations()` が Reflection で `IMigration` 実装クラスを自動検出する。
+
+#### 冪等性ガイドライン（Issue #1285）
+
+全マイグレーションの `Up()` は**二重実行しても例外を出さないこと**（共有モード運用や `schema_migrations` 部分破損に備える）。
+
+| 操作 | 書き方 |
+|------|--------|
+| テーブル作成 | `CREATE TABLE IF NOT EXISTS ...` |
+| インデックス作成 | `CREATE INDEX IF NOT EXISTS ...` |
+| 列追加 | `MigrationHelpers.AddColumnIfNotExists(conn, tx, "table", "column", "TYPE DEFAULT ...")` |
+| 行追加 | `INSERT OR IGNORE INTO ...` |
+
+素の `ALTER TABLE ADD COLUMN` は SQLite で非冪等のため禁止。`MigrationHelpers.AddColumnIfNotExists` を利用する。全マイグレーションは `MigrationIdempotencyTests` で二重実行安全性を検証している。
+
+詳細な規約は `.claude/rules/migrations.md` を参照。
 
 ---
 

--- a/ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Data.SQLite;
+
+namespace ICCardManager.Data.Migrations
+{
+    /// <summary>
+    /// マイグレーション実装で冪等な SQL 操作を提供するヘルパー（Issue #1285）。
+    /// </summary>
+    /// <remarks>
+    /// SQLite の <c>ALTER TABLE ADD COLUMN</c> は二重実行時に "duplicate column" エラーを出すため、
+    /// <c>PRAGMA table_info()</c> で事前に列の有無を確認する方式で冪等化する。
+    /// </remarks>
+    internal static class MigrationHelpers
+    {
+        /// <summary>
+        /// 指定テーブルに指定列が存在するかを返す。
+        /// </summary>
+        public static bool HasColumn(
+            SQLiteConnection connection,
+            SQLiteTransaction transaction,
+            string table,
+            string column)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (string.IsNullOrWhiteSpace(table)) throw new ArgumentException("table must be non-empty", nameof(table));
+            if (string.IsNullOrWhiteSpace(column)) throw new ArgumentException("column must be non-empty", nameof(column));
+
+            // PRAGMA は識別子のパラメータ化をサポートしないため、表名は文字列リテラル前提。
+            // 外部入力でないことを前提とするが、念のため不正文字を拒否する。
+            if (table.IndexOfAny(new[] { '\'', '"', ';', ' ' }) >= 0)
+            {
+                throw new ArgumentException($"invalid table name: {table}", nameof(table));
+            }
+
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = $"PRAGMA table_info({table})";
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                // PRAGMA table_info の 2 列目（index 1）が column name
+                var name = reader.GetString(1);
+                if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 列が存在しない場合のみ <c>ALTER TABLE ... ADD COLUMN</c> を実行する（冪等）。
+        /// </summary>
+        /// <param name="typeAndConstraints">例: <c>"INTEGER DEFAULT 0"</c>, <c>"TEXT"</c></param>
+        public static void AddColumnIfNotExists(
+            SQLiteConnection connection,
+            SQLiteTransaction transaction,
+            string table,
+            string column,
+            string typeAndConstraints)
+        {
+            if (HasColumn(connection, transaction, table, column))
+            {
+                return;
+            }
+
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = $"ALTER TABLE {table} ADD COLUMN {column} {typeAndConstraints}";
+            command.ExecuteNonQuery();
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_002_AddPointRedemption.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_002_AddPointRedemption.cs
@@ -20,9 +20,10 @@ namespace ICCardManager.Data.Migrations
 
         public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
         {
-            // ledger_detailテーブルにis_point_redemptionカラムを追加
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ledger_detail ADD COLUMN is_point_redemption INTEGER DEFAULT 0");
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ledger_detail", "is_point_redemption", "INTEGER DEFAULT 0");
         }
 
         public void Down(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs
@@ -22,10 +22,11 @@ namespace ICCardManager.Data.Migrations
 
         public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
         {
-            // ledger_detailテーブルにgroup_idカラムを追加
+            // Issue #1285: AddColumnIfNotExists で冪等化
             // NULL = 自動判定、同じ値 = 同一グループ（乗り継ぎ）として扱う
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ledger_detail ADD COLUMN group_id INTEGER");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ledger_detail", "group_id", "INTEGER");
         }
 
         public void Down(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_005_AddStartingPageNumber.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_005_AddStartingPageNumber.cs
@@ -17,10 +17,11 @@ namespace ICCardManager.Data.Migrations
 
         public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
         {
-            // ic_cardテーブルに starting_page_number カラムを追加
+            // Issue #1285: AddColumnIfNotExists で冪等化
             // デフォルト値は1
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN starting_page_number INTEGER DEFAULT 1");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "starting_page_number", "INTEGER DEFAULT 1");
         }
 
         public void Down(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_006_AddRefundedStatus.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_006_AddRefundedStatus.cs
@@ -18,13 +18,13 @@ namespace ICCardManager.Data.Migrations
 
         public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
         {
-            // ic_cardテーブルに is_refunded カラムを追加（デフォルト: 0 = 未払戻）
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN is_refunded INTEGER DEFAULT 0");
-
-            // ic_cardテーブルに refunded_at カラムを追加（払戻日時）
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN refunded_at TEXT");
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "is_refunded", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "refunded_at", "TEXT");
         }
 
         public void Down(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/ICCardManager/src/ICCardManager/Data/Migrations/Migration_009_AddCarryoverTotals.cs
+++ b/ICCardManager/src/ICCardManager/Data/Migrations/Migration_009_AddCarryoverTotals.cs
@@ -19,12 +19,16 @@ namespace ICCardManager.Data.Migrations
 
         public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
         {
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN carryover_income_total INTEGER DEFAULT 0");
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN carryover_expense_total INTEGER DEFAULT 0");
-            ExecuteNonQuery(connection, transaction,
-                "ALTER TABLE ic_card ADD COLUMN carryover_fiscal_year INTEGER");
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_income_total", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_expense_total", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_fiscal_year", "INTEGER");
         }
 
         public void Down(SQLiteConnection connection, SQLiteTransaction transaction)

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Data.SQLite;
+using FluentAssertions;
+using ICCardManager.Data.Migrations;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Migrations
+{
+    /// <summary>
+    /// Issue #1285: MigrationHelpers の冪等 SQL 操作の単体テスト。
+    /// </summary>
+    public class MigrationHelpersTests : IDisposable
+    {
+        private readonly SQLiteConnection _connection;
+
+        public MigrationHelpersTests()
+        {
+            _connection = new SQLiteConnection("Data Source=:memory:");
+            _connection.Open();
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)";
+            cmd.ExecuteNonQuery();
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void HasColumn_ExistingColumn_ReturnsTrue()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "name").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasColumn_MissingColumn_ReturnsFalse()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "nope").Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasColumn_CaseInsensitive()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "NAME").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasColumn_InvalidTableName_Throws()
+        {
+            using var tx = _connection.BeginTransaction();
+            Action act = () => MigrationHelpers.HasColumn(_connection, tx, "t; DROP TABLE t;", "x");
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_NewColumn_IsAdded()
+        {
+            using (var tx = _connection.BeginTransaction())
+            {
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra", "INTEGER DEFAULT 0");
+                tx.Commit();
+            }
+
+            using var tx2 = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx2, "t", "extra").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_ExistingColumn_NoOp()
+        {
+            using (var tx = _connection.BeginTransaction())
+            {
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra", "INTEGER DEFAULT 0");
+                tx.Commit();
+            }
+
+            using var tx2 = _connection.BeginTransaction();
+            Action act = () =>
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx2, "t", "extra", "INTEGER DEFAULT 0");
+            act.Should().NotThrow();
+            tx2.Commit();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_TwiceInSameTransaction_NoOp()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra2", "TEXT");
+            Action act = () =>
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra2", "TEXT");
+            act.Should().NotThrow();
+            tx.Commit();
+        }
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Data.SQLite;
+using FluentAssertions;
+using ICCardManager.Data.Migrations;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Migrations
+{
+    /// <summary>
+    /// Issue #1285: 全マイグレーションの Up() が二重実行に対して安全（冪等）であることを検証。
+    /// </summary>
+    /// <remarks>
+    /// MigrationRunner は schema_migrations でバージョン管理するが、共有モードでの競合や
+    /// 部分適用状態を想定し、各マイグレーション自体の Up() が二重適用でも例外を投げないことを担保する。
+    /// テストは MigrationRunner を介さず、Migration のインスタンスを作って直接 Up() を 2 回呼ぶ。
+    /// </remarks>
+    public class MigrationIdempotencyTests : IDisposable
+    {
+        private readonly SQLiteConnection _connection;
+
+        public MigrationIdempotencyTests()
+        {
+            _connection = new SQLiteConnection("Data Source=:memory:");
+            _connection.Open();
+            // Initial migration で土台となる全テーブルを作成
+            RunMigrationOnce(new Migration_001_Initial());
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        private void RunMigrationOnce(IMigration migration)
+        {
+            using var tx = _connection.BeginTransaction();
+            migration.Up(_connection, tx);
+            tx.Commit();
+        }
+
+        private Action RunMigrationTwice(IMigration migration)
+        {
+            return () =>
+            {
+                using (var tx1 = _connection.BeginTransaction())
+                {
+                    migration.Up(_connection, tx1);
+                    tx1.Commit();
+                }
+                using (var tx2 = _connection.BeginTransaction())
+                {
+                    migration.Up(_connection, tx2);
+                    tx2.Commit();
+                }
+            };
+        }
+
+        [Fact]
+        public void Migration_001_Initial_Up_IsIdempotent()
+        {
+            // コンストラクタで既に一度適用済み。追加で 1 回実行しても例外が出ないこと
+            using var tx = _connection.BeginTransaction();
+            Action act = () => new Migration_001_Initial().Up(_connection, tx);
+            act.Should().NotThrow();
+            tx.Commit();
+        }
+
+        [Fact]
+        public void Migration_002_AddPointRedemption_Up_IsIdempotent()
+        {
+            Action act = RunMigrationTwice(new Migration_002_AddPointRedemption());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_003_AddTripGroupId_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            Action act = RunMigrationTwice(new Migration_003_AddTripGroupId());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_004_AddPerformanceIndexes_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            Action act = RunMigrationTwice(new Migration_004_AddPerformanceIndexes());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_005_AddStartingPageNumber_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            Action act = RunMigrationTwice(new Migration_005_AddStartingPageNumber());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_006_AddRefundedStatus_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            Action act = RunMigrationTwice(new Migration_006_AddRefundedStatus());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_007_AddMergeHistory_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            Action act = RunMigrationTwice(new Migration_007_AddMergeHistory());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_008_AddCardTypeNumberUniqueIndex_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            RunMigrationOnce(new Migration_007_AddMergeHistory());
+            Action act = RunMigrationTwice(new Migration_008_AddCardTypeNumberUniqueIndex());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_009_AddCarryoverTotals_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            RunMigrationOnce(new Migration_007_AddMergeHistory());
+            RunMigrationOnce(new Migration_008_AddCardTypeNumberUniqueIndex());
+            Action act = RunMigrationTwice(new Migration_009_AddCarryoverTotals());
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-04-19-issue-1285-migration-idempotency.md
+++ b/docs/superpowers/plans/2026-04-19-issue-1285-migration-idempotency.md
@@ -1,0 +1,877 @@
+# Issue #1285: マイグレーション冪等性ガイドライン実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 非冪等な 5 マイグレーション（002/003/005/006/009）を `MigrationHelpers.AddColumnIfNotExists` 経由で冪等化し、9 マイグレーション全てに二重実行テストを追加する。開発者ガイドと `.claude/rules/migrations.md` で冪等性ガイドラインを文書化。
+
+**Architecture:** `internal static MigrationHelpers` クラスを新設して `PRAGMA table_info()` ベースの列存在チェックを提供。既存 Migration の `ExecuteNonQuery("ALTER TABLE ADD COLUMN ...")` をヘルパー呼び出しに置換する。`IMigration` インターフェースや `MigrationRunner` は変更しない。
+
+**Tech Stack:** C# 10 / .NET Framework 4.8 / System.Data.SQLite / xUnit / FluentAssertions
+
+---
+
+## 事前確認
+
+- ブランチ: `feat/issue-1285-migration-idempotency`（main から分岐、spec commit 済み）
+- 対象ファイル:
+  - `ICCardManager/src/ICCardManager/Data/Migrations/Migration_002_AddPointRedemption.cs`
+  - `ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs`
+  - `ICCardManager/src/ICCardManager/Data/Migrations/Migration_005_AddStartingPageNumber.cs`
+  - `ICCardManager/src/ICCardManager/Data/Migrations/Migration_006_AddRefundedStatus.cs`
+  - `ICCardManager/src/ICCardManager/Data/Migrations/Migration_009_AddCarryoverTotals.cs`
+- 既存テスト: 全体 2996 件 pass、Migration 系 32 件 pass
+- Test コマンド: `"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal`
+
+## File Structure
+
+### 新規作成
+
+| パス | 役割 |
+|-----|------|
+| `ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs` | `HasColumn` / `AddColumnIfNotExists` を提供する internal static クラス |
+| `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs` | ヘルパーの単体テスト |
+| `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs` | 各マイグレーション（9 個）の二重実行テスト |
+| `.claude/rules/migrations.md` | 冪等性チェックリスト（開発規約） |
+
+### 変更
+
+- `Migration_002_AddPointRedemption.cs` (ALTER TABLE を helper 経由に)
+- `Migration_003_AddTripGroupId.cs` (同上)
+- `Migration_005_AddStartingPageNumber.cs` (同上)
+- `Migration_006_AddRefundedStatus.cs` (同上)
+- `Migration_009_AddCarryoverTotals.cs` (同上)
+- `ICCardManager/docs/manual/開発者ガイド.md` §3.5（自動検出・冪等性ガイドライン）
+- `ICCardManager/docs/design/05_クラス設計書.md`（MigrationHelpers 追記、任意）
+- `ICCardManager/docs/design/07_テスト設計書.md`（新規テスト追記）
+- `ICCardManager/CHANGELOG.md`（Unreleased リファクタリング）
+- `CLAUDE.md`（`.claude/rules/migrations.md` への参照追加、任意）
+
+---
+
+## Task 1: Baseline 確認
+
+**Files:** 参照のみ
+
+- [ ] **Step 1: ブランチ確認**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/issue-1285-migration-idempotency`
+
+- [ ] **Step 2: 既存マイグレーションテスト pass 確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal
+```
+Expected: `成功! -失敗: 0、合格: 32`（件数は 30〜32 程度）
+
+---
+
+## Task 2: MigrationHelpers クラスと単体テスト
+
+**Files:**
+- Create: `ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs`
+- Create: `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs`
+
+- [ ] **Step 1: MigrationHelpers 本体を作成**
+
+ファイル `ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs`:
+
+```csharp
+using System;
+using System.Data.SQLite;
+
+namespace ICCardManager.Data.Migrations
+{
+    /// <summary>
+    /// マイグレーション実装で冪等な SQL 操作を提供するヘルパー（Issue #1285）。
+    /// </summary>
+    /// <remarks>
+    /// SQLite の <c>ALTER TABLE ADD COLUMN</c> は二重実行時に "duplicate column" エラーを出すため、
+    /// <c>PRAGMA table_info()</c> で事前に列の有無を確認する方式で冪等化する。
+    /// </remarks>
+    internal static class MigrationHelpers
+    {
+        /// <summary>
+        /// 指定テーブルに指定列が存在するかを返す。
+        /// </summary>
+        public static bool HasColumn(
+            SQLiteConnection connection,
+            SQLiteTransaction transaction,
+            string table,
+            string column)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (string.IsNullOrWhiteSpace(table)) throw new ArgumentException("table must be non-empty", nameof(table));
+            if (string.IsNullOrWhiteSpace(column)) throw new ArgumentException("column must be non-empty", nameof(column));
+
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            // PRAGMA は識別子のパラメータ化をサポートしないため、単純な検証のみで埋め込む。
+            // table はマイグレーション実装が文字列リテラルで渡す前提（外部入力ではない）。
+            if (table.IndexOfAny(new[] { '\'', '"', ';', ' ' }) >= 0)
+            {
+                throw new ArgumentException($"invalid table name: {table}", nameof(table));
+            }
+            command.CommandText = $"PRAGMA table_info({table})";
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                // PRAGMA table_info の 2 列目（index 1）が column name
+                var name = reader.GetString(1);
+                if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 列が存在しない場合のみ <c>ALTER TABLE ... ADD COLUMN</c> を実行する（冪等）。
+        /// </summary>
+        /// <param name="typeAndConstraints">例: <c>"INTEGER DEFAULT 0"</c>, <c>"TEXT"</c></param>
+        public static void AddColumnIfNotExists(
+            SQLiteConnection connection,
+            SQLiteTransaction transaction,
+            string table,
+            string column,
+            string typeAndConstraints)
+        {
+            if (HasColumn(connection, transaction, table, column))
+            {
+                return;
+            }
+
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = $"ALTER TABLE {table} ADD COLUMN {column} {typeAndConstraints}";
+            command.ExecuteNonQuery();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: MigrationHelpersTests を作成**
+
+ファイル `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs`:
+
+```csharp
+using System;
+using System.Data.SQLite;
+using FluentAssertions;
+using ICCardManager.Data.Migrations;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Migrations
+{
+    /// <summary>
+    /// Issue #1285: MigrationHelpers の冪等 SQL 操作の単体テスト。
+    /// </summary>
+    public class MigrationHelpersTests : IDisposable
+    {
+        private readonly SQLiteConnection _connection;
+
+        public MigrationHelpersTests()
+        {
+            _connection = new SQLiteConnection("Data Source=:memory:");
+            _connection.Open();
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)";
+            cmd.ExecuteNonQuery();
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void HasColumn_ExistingColumn_ReturnsTrue()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "name").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasColumn_MissingColumn_ReturnsFalse()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "nope").Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasColumn_CaseInsensitive()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx, "t", "NAME").Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasColumn_InvalidTableName_Throws()
+        {
+            using var tx = _connection.BeginTransaction();
+            Action act = () => MigrationHelpers.HasColumn(_connection, tx, "t; DROP TABLE t;", "x");
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_NewColumn_IsAdded()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra", "INTEGER DEFAULT 0");
+            tx.Commit();
+
+            using var tx2 = _connection.BeginTransaction();
+            MigrationHelpers.HasColumn(_connection, tx2, "t", "extra").Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_ExistingColumn_NoOp()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra", "INTEGER DEFAULT 0");
+            tx.Commit();
+
+            using var tx2 = _connection.BeginTransaction();
+            Action act = () =>
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx2, "t", "extra", "INTEGER DEFAULT 0");
+            act.Should().NotThrow();
+            tx2.Commit();
+        }
+
+        [Fact]
+        public void AddColumnIfNotExists_TwiceInSameCall_NoOp()
+        {
+            using var tx = _connection.BeginTransaction();
+            MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra2", "TEXT");
+            Action act = () =>
+                MigrationHelpers.AddColumnIfNotExists(_connection, tx, "t", "extra2", "TEXT");
+            act.Should().NotThrow();
+            tx.Commit();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: ビルド + テスト**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~MigrationHelpersTests" --nologo --verbosity minimal 2>&1 | tail -3
+```
+Expected: 合格 7 件
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs \
+       ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationHelpersTests.cs
+git commit -m "$(cat <<'EOF'
+feat: MigrationHelpers に冪等 ALTER TABLE ヘルパーを追加 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Migration_002 冪等化
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Data/Migrations/Migration_002_AddPointRedemption.cs`
+
+- [ ] **Step 1: Up() を helper 呼び出しに置換**
+
+L21-26 の `Up` メソッド本体を以下に置換:
+
+```csharp
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ledger_detail", "is_point_redemption", "INTEGER DEFAULT 0");
+        }
+```
+
+不要になった `ExecuteNonQuery` ヘルパーは Down() で使い続けるため残す。using は既にある想定。
+
+- [ ] **Step 2: 既存テスト pass 確認**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal 2>&1 | tail -3
+```
+Expected: 失敗 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Data/Migrations/Migration_002_AddPointRedemption.cs
+git commit -m "$(cat <<'EOF'
+refactor: Migration_002 を冪等化 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Migration_003 冪等化
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs`
+
+- [ ] **Step 1: Up() を helper 呼び出しに置換**
+
+`Up` メソッド本体を以下に置換:
+
+```csharp
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            // NULL = 自動判定、同じ値 = 同一グループ（乗り継ぎ）として扱う
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ledger_detail", "group_id", "INTEGER");
+        }
+```
+
+- [ ] **Step 2: テスト**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal 2>&1 | tail -3
+```
+Expected: 失敗 0
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add ICCardManager/src/ICCardManager/Data/Migrations/Migration_003_AddTripGroupId.cs
+git commit -m "$(cat <<'EOF'
+refactor: Migration_003 を冪等化 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Migration_005 冪等化
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Data/Migrations/Migration_005_AddStartingPageNumber.cs`
+
+- [ ] **Step 1: Up() を helper 呼び出しに置換**
+
+```csharp
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "starting_page_number", "INTEGER DEFAULT 1");
+        }
+```
+
+- [ ] **Step 2: テスト + コミット**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal 2>&1 | tail -3
+# Expected: 失敗 0
+
+git add ICCardManager/src/ICCardManager/Data/Migrations/Migration_005_AddStartingPageNumber.cs
+git commit -m "$(cat <<'EOF'
+refactor: Migration_005 を冪等化 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Migration_006 冪等化
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Data/Migrations/Migration_006_AddRefundedStatus.cs`
+
+- [ ] **Step 1: Up() を helper 呼び出しに置換**
+
+```csharp
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "is_refunded", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "refunded_at", "TEXT");
+        }
+```
+
+- [ ] **Step 2: テスト + コミット**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal 2>&1 | tail -3
+
+git add ICCardManager/src/ICCardManager/Data/Migrations/Migration_006_AddRefundedStatus.cs
+git commit -m "$(cat <<'EOF'
+refactor: Migration_006 を冪等化 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Migration_009 冪等化
+
+**Files:**
+- Modify: `ICCardManager/src/ICCardManager/Data/Migrations/Migration_009_AddCarryoverTotals.cs`
+
+- [ ] **Step 1: Up() を helper 呼び出しに置換**
+
+```csharp
+        public void Up(SQLiteConnection connection, SQLiteTransaction transaction)
+        {
+            // Issue #1285: AddColumnIfNotExists で冪等化
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_income_total", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_expense_total", "INTEGER DEFAULT 0");
+            MigrationHelpers.AddColumnIfNotExists(
+                connection, transaction,
+                "ic_card", "carryover_fiscal_year", "INTEGER");
+        }
+```
+
+- [ ] **Step 2: テスト + コミット**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~Migration" --nologo --verbosity minimal 2>&1 | tail -3
+
+git add ICCardManager/src/ICCardManager/Data/Migrations/Migration_009_AddCarryoverTotals.cs
+git commit -m "$(cat <<'EOF'
+refactor: Migration_009 を冪等化 (Issue #1285)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: 全マイグレーション二重実行テスト
+
+**Files:**
+- Create: `ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs`
+
+- [ ] **Step 1: テストファイルを作成**
+
+```csharp
+using System;
+using System.Data.SQLite;
+using FluentAssertions;
+using ICCardManager.Data.Migrations;
+using Xunit;
+
+namespace ICCardManager.Tests.Data.Migrations
+{
+    /// <summary>
+    /// Issue #1285: 全マイグレーションの Up() が二重実行に対して安全（冪等）であることを検証。
+    /// </summary>
+    /// <remarks>
+    /// MigrationRunner は schema_migrations でバージョン管理するが、共有モードでの競合や
+    /// 部分適用状態を想定し、各マイグレーション自体の Up() が二重適用でも例外を投げないことを担保する。
+    /// テストは MigrationRunner を介さず、Migration のインスタンスを作って直接 Up() を 2 回呼ぶ。
+    /// </remarks>
+    public class MigrationIdempotencyTests : IDisposable
+    {
+        private readonly SQLiteConnection _connection;
+
+        public MigrationIdempotencyTests()
+        {
+            _connection = new SQLiteConnection("Data Source=:memory:");
+            _connection.Open();
+            // Initial migration で土台となる全テーブルを作成
+            RunMigrationOnce(new Migration_001_Initial());
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        private void RunMigrationOnce(IMigration migration)
+        {
+            using var tx = _connection.BeginTransaction();
+            migration.Up(_connection, tx);
+            tx.Commit();
+        }
+
+        private Action RunMigrationTwice(IMigration migration)
+        {
+            return () =>
+            {
+                using (var tx1 = _connection.BeginTransaction())
+                {
+                    migration.Up(_connection, tx1);
+                    tx1.Commit();
+                }
+                using (var tx2 = _connection.BeginTransaction())
+                {
+                    migration.Up(_connection, tx2);
+                    tx2.Commit();
+                }
+            };
+        }
+
+        [Fact]
+        public void Migration_001_Initial_Up_IsIdempotent()
+        {
+            // 001 は base class でも既に一度実行済み。2 回目を実行しても例外が出ないことを確認
+            using var tx = _connection.BeginTransaction();
+            Action act = () => new Migration_001_Initial().Up(_connection, tx);
+            act.Should().NotThrow();
+            tx.Commit();
+        }
+
+        [Fact]
+        public void Migration_002_AddPointRedemption_Up_IsIdempotent()
+        {
+            Action act = RunMigrationTwice(new Migration_002_AddPointRedemption());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_003_AddTripGroupId_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            Action act = RunMigrationTwice(new Migration_003_AddTripGroupId());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_004_AddPerformanceIndexes_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            Action act = RunMigrationTwice(new Migration_004_AddPerformanceIndexes());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_005_AddStartingPageNumber_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            Action act = RunMigrationTwice(new Migration_005_AddStartingPageNumber());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_006_AddRefundedStatus_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            Action act = RunMigrationTwice(new Migration_006_AddRefundedStatus());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_007_AddMergeHistory_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            Action act = RunMigrationTwice(new Migration_007_AddMergeHistory());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_008_AddCardTypeNumberUniqueIndex_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            RunMigrationOnce(new Migration_007_AddMergeHistory());
+            Action act = RunMigrationTwice(new Migration_008_AddCardTypeNumberUniqueIndex());
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Migration_009_AddCarryoverTotals_Up_IsIdempotent()
+        {
+            RunMigrationOnce(new Migration_002_AddPointRedemption());
+            RunMigrationOnce(new Migration_003_AddTripGroupId());
+            RunMigrationOnce(new Migration_004_AddPerformanceIndexes());
+            RunMigrationOnce(new Migration_005_AddStartingPageNumber());
+            RunMigrationOnce(new Migration_006_AddRefundedStatus());
+            RunMigrationOnce(new Migration_007_AddMergeHistory());
+            RunMigrationOnce(new Migration_008_AddCardTypeNumberUniqueIndex());
+            Action act = RunMigrationTwice(new Migration_009_AddCarryoverTotals());
+            act.Should().NotThrow();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: テスト実行**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --filter "FullyQualifiedName~MigrationIdempotencyTests" --nologo --verbosity minimal 2>&1 | tail -5
+```
+
+Expected: 9 件 pass
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add ICCardManager/tests/ICCardManager.Tests/Data/Migrations/MigrationIdempotencyTests.cs
+git commit -m "$(cat <<'EOF'
+test: 全マイグレーションの二重実行テストを追加 (Issue #1285)
+
+Migration_001〜009 の Up() が冪等であることを検証。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: 開発規約ファイルと開発者ガイド
+
+**Files:**
+- Create: `.claude/rules/migrations.md`
+- Modify: `ICCardManager/docs/manual/開発者ガイド.md` §3.5（L586-629 付近）
+
+- [ ] **Step 1: `.claude/rules/migrations.md` を作成**
+
+```markdown
+# マイグレーション作成規約
+
+## 冪等性（二重実行安全）の必須化
+
+新規マイグレーション (`IMigration` 実装) の `Up()` は**必ず冪等**に書くこと。共有モードで複数 PC が同時起動した場合や、`schema_migrations` テーブルが部分破損した場合に備える。
+
+## 冪等パターン
+
+| 操作 | 書き方 |
+|------|--------|
+| テーブル作成 | `CREATE TABLE IF NOT EXISTS ...` |
+| インデックス作成 | `CREATE INDEX IF NOT EXISTS ...` / `CREATE UNIQUE INDEX IF NOT EXISTS ...` |
+| 列追加 | `MigrationHelpers.AddColumnIfNotExists(conn, tx, "table", "column", "TYPE DEFAULT ...")` |
+| 行追加 | `INSERT OR IGNORE INTO ...` |
+| 行更新 | `UPDATE ... WHERE <条件が同じ入力で同じ結果を出す>` |
+
+## 禁止パターン
+
+- 素の `ALTER TABLE ... ADD COLUMN`（SQLite では IF NOT EXISTS がサポートされない）
+- 素の `CREATE TABLE` / `CREATE INDEX`（IF NOT EXISTS を付ける）
+- 素の `INSERT`（二重実行で PK 重複エラー）
+
+## 新規マイグレーション追加手順
+
+1. `ICCardManager/src/ICCardManager/Data/Migrations/Migration_0NN_<説明>.cs` を作成
+2. `IMigration` を実装（`Version` は既存最大 +1、`Description` は日本語で要約）
+3. `Up()` は冪等パターンで書く
+4. `Down()` は可能ならロールバック、不可能なら空実装 + コメント
+5. `MigrationIdempotencyTests` に `Migration_0NN_<name>_Up_IsIdempotent` を追加（先行マイグレーションを順に `RunMigrationOnce` してから `RunMigrationTwice`）
+6. `docs/design/02_DB設計書.md` に列追加を反映
+
+## 自動検出
+
+`MigrationRunner.DiscoverMigrations()` が Reflection で `IMigration` 実装を自動検出するため、**手動登録は不要**。
+
+## 参考
+
+- 設計書: `docs/superpowers/specs/2026-04-19-issue-1285-migration-idempotency-design.md`
+- ヘルパー: `ICCardManager/src/ICCardManager/Data/Migrations/MigrationHelpers.cs`
+```
+
+- [ ] **Step 2: 開発者ガイド §3.5 を更新**
+
+`ICCardManager/docs/manual/開発者ガイド.md` の §3.5 マイグレーション節（L586-629 付近）を読み、以下を反映:
+
+1. 「`GetAllMigrations()` に手動登録」の記述を「自動検出 (`DiscoverMigrations()` via Reflection)」に修正
+2. 新規マイグレーション作成時の冪等性チェックリスト追加（`.claude/rules/migrations.md` への参照含む）
+3. `MigrationHelpers.AddColumnIfNotExists` の使い方を例示
+
+具体的には、§3.5 の末尾に以下のような節を追加:
+
+```markdown
+#### 冪等性ガイドライン（Issue #1285）
+
+全マイグレーションの `Up()` は二重実行しても例外を出さないこと（共有モード運用や部分適用状態に備える）。
+
+- `ALTER TABLE ADD COLUMN` は `MigrationHelpers.AddColumnIfNotExists(...)` を使う
+- `CREATE TABLE` / `CREATE INDEX` は `IF NOT EXISTS` を付ける
+- `INSERT` は `INSERT OR IGNORE` を使う
+
+詳細は `.claude/rules/migrations.md` 参照。全マイグレーションは `MigrationIdempotencyTests` で二重実行安全性を検証している。
+
+登録は手動ではなく、`MigrationRunner.DiscoverMigrations()` が Reflection で自動検出する。
+```
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .claude/rules/migrations.md ICCardManager/docs/manual/開発者ガイド.md
+git commit -m "$(cat <<'EOF'
+docs: マイグレーション冪等性ガイドラインを追加 (Issue #1285)
+
+- .claude/rules/migrations.md 新設
+- 開発者ガイド §3.5 を自動検出ロジックに更新し、冪等性チェックリストを追加
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: 全体ビルド・テスト + CHANGELOG + 設計書
+
+**Files:**
+- Modify: `ICCardManager/CHANGELOG.md`
+- Modify: `ICCardManager/docs/design/07_テスト設計書.md`
+
+- [ ] **Step 1: 全体ビルドとテスト**
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" build ICCardManager/ICCardManager.sln --nologo --verbosity minimal 2>&1 | tail -5
+```
+Expected: エラー 0
+
+```bash
+"/mnt/c/Program Files/dotnet/dotnet.exe" test ICCardManager/tests/ICCardManager.Tests/ICCardManager.Tests.csproj --nologo --verbosity minimal 2>&1 | tail -3
+```
+Expected: 失敗 0、合格は 2996 + 新規 7 + 9 = 3012 件程度
+
+- [ ] **Step 2: CHANGELOG 更新**
+
+`ICCardManager/CHANGELOG.md` の `[Unreleased]` の **リファクタリング** セクションに追記:
+
+```markdown
+- DB マイグレーションの冪等性（二重実行安全性）を担保。`MigrationHelpers.AddColumnIfNotExists` を新設し、非冪等だった 5 つの `ALTER TABLE ADD COLUMN` 型マイグレーション（#002/#003/#005/#006/#009）を冪等化。共有モードで複数 PC が初回起動時にマイグレーション競合した場合や、`schema_migrations` テーブル部分破損時の再適用エラーを防止。全 9 マイグレーションの二重実行テスト (`MigrationIdempotencyTests`) と `MigrationHelpers` 単体テスト (7 件) を追加。`.claude/rules/migrations.md` に冪等性チェックリストを新設し、開発者ガイド §3.5 を自動検出ロジック (`DiscoverMigrations()`) に合わせて更新（#1285）
+```
+
+- [ ] **Step 3: 07_テスト設計書.md を更新**
+
+`ICCardManager/docs/design/07_テスト設計書.md` のマイグレーション関連セクションを探し（`grep -n "Migration" ICCardManager/docs/design/07_テスト設計書.md`）、以下のテスト追加を記載:
+
+```markdown
+#### UT-MIG-IDEMPOTENCY: マイグレーション二重実行テスト（Issue #1285）
+
+| No | テストケース | 期待結果 |
+|----|-------------|---------|
+| 1 | Migration_001〜009 の各 Up() を 2 回連続実行 | 例外なし |
+| 2 | MigrationHelpers.HasColumn（既存列） | true |
+| 3 | MigrationHelpers.HasColumn（存在しない列） | false |
+| 4 | MigrationHelpers.HasColumn（大小文字違い） | true |
+| 5 | MigrationHelpers.HasColumn（不正テーブル名） | ArgumentException |
+| 6 | AddColumnIfNotExists（新規列） | 列が追加される |
+| 7 | AddColumnIfNotExists（既存列） | no-op、例外なし |
+| 8 | AddColumnIfNotExists（同 tx 内で 2 回呼び出し） | 2 回目は no-op |
+
+**テストクラス**: `MigrationHelpersTests` / `MigrationIdempotencyTests`
+```
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add ICCardManager/CHANGELOG.md ICCardManager/docs/design/07_テスト設計書.md
+git commit -m "$(cat <<'EOF'
+docs: CHANGELOG とテスト設計書を Issue #1285 で更新
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Push と PR 作成
+
+- [ ] **Step 1: push**
+
+```bash
+git push -u origin feat/issue-1285-migration-idempotency
+```
+
+- [ ] **Step 2: PR 作成**
+
+```bash
+gh pr create --title "feat: マイグレーション冪等性の強化と二重実行テスト追加 (Issue #1285)" --body "$(cat <<'EOF'
+## Summary
+- 非冪等だった 5 マイグレーション (`#002`, `#003`, `#005`, `#006`, `#009`) を `MigrationHelpers.AddColumnIfNotExists` 経由で冪等化
+- `PRAGMA table_info()` ベースの列存在判定で SQLite 全バージョンに対応
+- 全 9 マイグレーションの二重実行テスト (`MigrationIdempotencyTests`, 9 件) と `MigrationHelpers` 単体テスト (7 件) を追加
+- `.claude/rules/migrations.md` 新設 + 開発者ガイド §3.5 を自動検出ロジックに合わせて更新
+
+## Related
+- Closes #1285
+
+## 冪等化した Migration
+| # | Migration | 対象 |
+|---|-----------|------|
+| 002 | AddPointRedemption | `ledger_detail.is_point_redemption` |
+| 003 | AddTripGroupId | `ledger_detail.group_id` |
+| 005 | AddStartingPageNumber | `ic_card.starting_page_number` |
+| 006 | AddRefundedStatus | `ic_card.is_refunded` / `refunded_at` |
+| 009 | AddCarryoverTotals | `ic_card.carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` |
+
+## Test plan
+- [x] `MigrationHelpersTests` 7 件 pass
+- [x] `MigrationIdempotencyTests` 9 件 pass
+- [x] 既存 `MigrationRunnerTests` / `Migration001InitialTests` / `DbContextMigrationTests` 全 pass
+- [x] ソリューション全体テスト pass、ビルド 0 error
+- [ ] 手動テスト: 既存 DB に対しアプリを起動し、マイグレーションが問題なく完了することを確認
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL
+
+---
+
+## 手動テスト依頼
+
+1. **既存 DB でアプリ起動**: 既に v2.7 相当のマイグレーション適用済み DB でアプリを起動 → マイグレーションが発動せず正常起動
+2. **新規 DB 初期化**: 空 DB（`ProgramData\ICCardManager\app.db` を削除）でアプリ起動 → 全 9 マイグレーションが 1 回で完走
+3. **共有モード**: UNC 共有フォルダに DB を置き、2 台の PC でほぼ同時にアプリを起動 → 片方が適用中にもう片方が起動してもエラーにならない（トランザクション競合は MigrationRunner 側の既存実装で処理）
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|-----|
+| `PRAGMA table_info` がトランザクション内で動かない | Task 2 Step 3 テストで検証。SQLite は read 系 PRAGMA を tx 内で許容 |
+| 既存 DB の既適用カラムに対し `AddColumnIfNotExists` が no-op → ユーザー影響 | 実装は idempotent なので no-op 自体が正しい動作 |
+| `Migration_008` の重複解消 UPDATE が再実行で無駄に走る | 実装上既に冪等（同じ入力で同じ結果）。テストで検証 |
+| `Down()` の非冪等性が残る | Down() は本 Issue スコープ外。管理者が手動で適用する場面のみで使われる想定 |
+
+## 非対象
+
+- `MigrationRunner` のリファクタ
+- `IMigration` インターフェース変更
+- Migration_002/003 の Down() における `CREATE TABLE backup` の冪等化（下位互換のため別 Issue 推奨）

--- a/docs/superpowers/specs/2026-04-19-issue-1285-migration-idempotency-design.md
+++ b/docs/superpowers/specs/2026-04-19-issue-1285-migration-idempotency-design.md
@@ -1,0 +1,167 @@
+# Issue #1285: マイグレーション冪等性ガイドライン策定と既存 Migration 検査 設計書
+
+作成日: 2026-04-19
+対象 Issue: [#1285](https://github.com/kuwayamamasayuki/ICCardManager/issues/1285)
+
+## 背景と問題
+
+`MigrationRunner` はバージョン管理テーブル `schema_migrations` を介して各マイグレーションを 1 回だけ適用するよう設計されているが、**個々の `Migration.Up()` 実装が冪等（二重実行安全）である保証がない**。
+
+### 既存マイグレーション 9 個の冪等性ステータス
+
+| # | クラス | 主な操作 | 冪等性 |
+|---|--------|---------|-------|
+| 001 | Initial | `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` + `INSERT OR IGNORE` | ✓ |
+| 002 | AddPointRedemption | `ALTER TABLE ADD COLUMN` | ✗ |
+| 003 | AddTripGroupId | `ALTER TABLE ADD COLUMN` | ✗ |
+| 004 | AddPerformanceIndexes | `CREATE INDEX IF NOT EXISTS` | ✓ |
+| 005 | AddStartingPageNumber | `ALTER TABLE ADD COLUMN` | ✗ |
+| 006 | AddRefundedStatus | `ALTER TABLE ADD COLUMN` x2 | ✗ |
+| 007 | AddMergeHistory | `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` | ✓ |
+| 008 | AddCardTypeNumberUniqueIndex | `CREATE UNIQUE INDEX IF NOT EXISTS` + 重複解消 UPDATE | ✓（重複解消も冪等） |
+| 009 | AddCarryoverTotals | `ALTER TABLE ADD COLUMN` x3 | ✗ |
+
+### 実害シナリオ
+
+- **共有モード**: 複数 PC が初回起動で同一 DB に対し同時にマイグレーション適用 → 片方が中途失敗後、もう一方が部分適用済み状態に遭遇してエラー
+- **DB 部分破損/手動編集**: `schema_migrations` テーブルが失われた状態で再適用するとエラー
+- **テスト環境**: マイグレーションを段階的に手動検証するときに再適用したくなる
+
+### ドキュメントの負債
+
+- `docs/manual/開発者ガイド.md §3.5`: `GetAllMigrations()` の手動登録と書かれているが実装は Reflection で自動検出 → **内容が古い**
+- 新規マイグレーション作成時のテンプレートや冪等性チェックリストが存在しない
+
+## スコープ
+
+### 含む
+
+1. `MigrationHelpers` 静的クラス新設（`AddColumnIfNotExists` / `HasColumn`）
+2. 非冪等の 5 マイグレーション（002, 003, 005, 006, 009）の修正
+3. `MigrationHelpers` 単体テスト
+4. 全 9 マイグレーションに対する二重実行テスト
+5. 開発者ガイド §3.5 改訂（自動検出ロジック反映、冪等性ガイドライン追加）
+6. `.claude/rules/migrations.md` 新規作成（開発規約）
+
+### 含まない
+
+- `MigrationRunner` 本体の refactor
+- `IMigration` インターフェース変更
+- Migration_008 の重複解消ロジック改良
+- 過去に適用済みの DB への影響（`schema_migrations` で既に弾かれる）
+
+## 設計
+
+### MigrationHelpers API
+
+```csharp
+namespace ICCardManager.Data.Migrations
+{
+    /// <summary>
+    /// マイグレーション実装で冪等な SQL 操作を提供するヘルパー。
+    /// Issue #1285: ALTER TABLE ADD COLUMN の二重実行安全化など。
+    /// </summary>
+    internal static class MigrationHelpers
+    {
+        /// <summary>
+        /// PRAGMA table_info を使って列の存在を確認する。
+        /// </summary>
+        public static bool HasColumn(
+            SQLiteConnection conn, SQLiteTransaction tx,
+            string table, string column);
+
+        /// <summary>
+        /// 列が存在しない場合のみ ADD COLUMN を実行する（冪等）。
+        /// </summary>
+        /// <param name="typeAndConstraints">例: "INTEGER DEFAULT 0 NOT NULL"</param>
+        public static void AddColumnIfNotExists(
+            SQLiteConnection conn, SQLiteTransaction tx,
+            string table, string column, string typeAndConstraints);
+    }
+}
+```
+
+### 既存マイグレーションの修正パターン
+
+**Before (Migration_002):**
+```csharp
+var cmd = connection.CreateCommand();
+cmd.Transaction = transaction;
+cmd.CommandText = @"
+    ALTER TABLE ledger_detail ADD COLUMN is_point_redemption INTEGER DEFAULT 0 NOT NULL
+";
+cmd.ExecuteNonQuery();
+```
+
+**After:**
+```csharp
+MigrationHelpers.AddColumnIfNotExists(
+    connection, transaction,
+    "ledger_detail", "is_point_redemption", "INTEGER DEFAULT 0 NOT NULL");
+```
+
+### なぜ `PRAGMA table_info()` 方式か
+
+- SQLite 3.35.0+ は `ALTER TABLE ADD COLUMN IF NOT EXISTS` をサポートしないバージョンがまだ多い（`System.Data.SQLite` が同梱するバージョン依存）
+- `PRAGMA table_info(<table>)` は全バージョンで利用可能
+- エラーハンドリング型（try/catch "duplicate column"）より意図が明示的
+
+### テスト戦略
+
+#### `MigrationHelpersTests` (~6 件)
+- `HasColumn` が存在する列で true を返す
+- `HasColumn` が存在しない列で false を返す
+- `HasColumn` が存在しないテーブルでも例外を投げず false を返す（あるいは実装の契約に応じて決定）
+- `AddColumnIfNotExists` が新規列を追加
+- `AddColumnIfNotExists` が既存列に対し no-op
+- `AddColumnIfNotExists` を 2 回連続実行しても例外なし
+
+#### `MigrationIdempotencyTests` (9 件)
+各マイグレーション（001〜009）に対し:
+```csharp
+[Fact]
+public void Migration_00X_Up_IsIdempotent()
+{
+    // 1 回目適用
+    migration.Up(conn, tx1); tx1.Commit();
+    // 2 回目適用（例外が出ないことが合格）
+    using var tx2 = conn.BeginTransaction();
+    Action act = () => migration.Up(conn, tx2);
+    act.Should().NotThrow();
+    tx2.Commit();
+    // スキーマが正しく保たれていることを検証（任意の SELECT or PRAGMA）
+}
+```
+
+Migration_008 は重複解消 UPDATE が 2 回目も実行されるが、べき等（同じ入力に対し同じ結果）。テストでは UPDATE 実行回数ではなく「最終状態が変わらない」ことを検証。
+
+### 開発者ガイド §3.5 改訂方針
+
+1. 自動検出ロジック（`DiscoverMigrations()`, Reflection）を正しく記述
+2. 冪等性チェックリスト追加:
+   - `CREATE TABLE IF NOT EXISTS` を使う
+   - `CREATE INDEX IF NOT EXISTS` を使う
+   - `ALTER TABLE ADD COLUMN` は `MigrationHelpers.AddColumnIfNotExists` 経由で
+   - `INSERT` は `INSERT OR IGNORE` か `INSERT ... WHERE NOT EXISTS`
+   - データ更新は「同じ入力に対し同じ結果」を意識
+3. `.claude/rules/migrations.md` への参照
+
+### `.claude/rules/migrations.md` 新設
+
+- ファイル作成: 上記の冪等性チェックリストを開発規約として格納
+- 既存の `testing.md` / `git-workflow.md` / `error-messages.md` と同じ体裁
+
+## リスクと対策
+
+| リスク | 対策 |
+|-------|-----|
+| 既存 DB（本番）への影響 | `schema_migrations` で既に適用済みの場合スキップされるので影響なし。新規インストールと部分適用時のみ挙動変化 |
+| `PRAGMA table_info()` が transaction scope で動作するか | SQLite は read 系 PRAGMA を transaction 内で実行可能。テストで確認 |
+| Migration_008 の重複解消が再実行される | 既に冪等な実装。テストで明示的に検証 |
+| `.claude/rules/migrations.md` を hook が検出しない | hook はコード変更に対する自問なので問題なし |
+
+## 非対象（別 Issue 候補）
+
+- `MigrationRunner` のリファクタ（402 行で適切なサイズ）
+- マイグレーション UP/DOWN の並列実行サポート
+- マイグレーション失敗時のロールバック自動化（既にトランザクション境界で対応済み）


### PR DESCRIPTION
## Summary
- 非冪等だった 5 マイグレーション（#002/#003/#005/#006/#009）を `MigrationHelpers.AddColumnIfNotExists` 経由で冪等化
- `PRAGMA table_info()` ベースの列存在判定で SQLite 全バージョンに対応
- 全 9 マイグレーションの二重実行テスト (`MigrationIdempotencyTests`, 9件) と `MigrationHelpers` 単体テスト (7件) を追加
- `.claude/rules/migrations.md` 新設 + 開発者ガイド §3.5 を自動検出ロジックに合わせて更新

## Related
- Closes #1285

## 冪等化した Migration

| # | Migration | 対象 |
|---|-----------|------|
| 002 | AddPointRedemption | `ledger_detail.is_point_redemption` |
| 003 | AddTripGroupId | `ledger_detail.group_id` |
| 005 | AddStartingPageNumber | `ic_card.starting_page_number` |
| 006 | AddRefundedStatus | `ic_card.is_refunded` / `refunded_at` |
| 009 | AddCarryoverTotals | `ic_card.carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` |

## 実害シナリオへの対処
- **共有モード**: 複数 PC 同時初回起動でのマイグレーション競合で、片方が部分適用状態になった後にもう片方が起動してもエラーにならない
- **DB 部分破損**: `schema_migrations` テーブルが失われた状態で再適用してもエラーにならない

## Issue 記載との差分

Issue は「CI テスト追加」を含むが、xUnit 単体テストで同等の検証（Migration_001〜009 の二重実行）を実現したため、追加の CI 設定は不要。既存 GitHub Actions で `dotnet test` が実行されるため、この新規テストも自動的に CI で走る。

## Test plan
- [x] `MigrationHelpersTests` 7件 pass
- [x] `MigrationIdempotencyTests` 9件 pass
- [x] 既存 `MigrationRunnerTests` / `Migration001InitialTests` / `DbContextMigrationTests` 全 pass
- [x] ソリューション全体テスト 3012件 pass、ビルド 0 error
- [ ] 手動テスト: 既存 DB でアプリ起動 → マイグレーション競合が発生しない
- [ ] 手動テスト: 新規 DB（app.db 削除後）でアプリ起動 → 全 9 マイグレーションが完走

## リスクと対策

| リスク | 対策 |
|-------|-----|
| 既存 DB への影響 | `schema_migrations` で既適用のものはスキップされるため影響なし |
| `Migration_008` の重複解消 UPDATE が再実行で無駄に走る | 実装上既に冪等。テストで検証済み |
| `Down()` の非冪等性が残る | 本 Issue スコープ外。管理者が手動実行する場面のみ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)