### PR TITLE
chore: Stop hook を matcher レス形式へ移行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,9 +11,13 @@
   "hooks": {
     "Stop": [
       {
-        "type": "command",
-        "command": "bash .claude/hooks/check-doc-sync.sh",
-        "timeout": 15
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-doc-sync.sh",
+            "timeout": 15
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の Stop hook エントリを、Claude Code の現行スキーマに合わせて matcher レス形式（外側オブジェクト + 内側 `hooks: [...]` 配列）へ移行
- コマンド・タイムアウトは変更なし。振る舞いは完全に同等

## Before / After

\`\`\`diff
   "Stop": [
     {
-      "type": "command",
-      "command": "bash .claude/hooks/check-doc-sync.sh",
-      "timeout": 15
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash .claude/hooks/check-doc-sync.sh",
+          "timeout": 15
+        }
+      ]
     }
   ]
\`\`\`

## Test plan

- [x] ビルド影響なし（設定ファイルのみ変更）
- [x] セッション終了時に `check-doc-sync.sh` がこれまで通り実行されること（手動確認: 任意のコードを変更したセッションを終了し、ドキュメント自己確認プロンプトが表示されるか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)