### PR TITLE
docs: 共有モード busy_timeout の文書記述を実装(15000ms)に整合 (Issue #1391)

### DIFF
--- a/.claude/rules/business-logic.md
+++ b/.claude/rules/business-logic.md
@@ -37,7 +37,7 @@ THEN
 ## 共有フォルダモード（複数PC共有DB）
 - DBパスは `C:\ProgramData\ICCardManager\database_config.txt` で指定（空欄/未作成=ローカルデフォルト）。インストーラーの「データベースの保存先」ページまたは設定画面（F5）から設定
 - UNCパス（`\\server\share\iccard.db`）指定時に自動的に共有モードとして動作
-- 共有モード時: journal_mode=DELETE（WALはネットワーク非推奨）、busy_timeout=5000ms
+- 共有モード時: journal_mode=DELETE（WALはネットワーク非推奨。DELETE設定不可時は TRUNCATE → PERSIST の順にフォールバック、Issue #1107）、busy_timeout=15000ms（SMB遅延と最大20台の同時アクセスを考慮、Issue #1107。ローカルモード時は5000ms）
 - キャッシュTTLを短縮し他PCの変更を早期反映
 - 30秒ごとの接続ヘルスチェック＋自動再接続
 - ステータスバーに「共有モード」表示、ネットワーク切断時は警告表示

--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -516,7 +516,7 @@ DELETE FROM operation_log WHERE date(timestamp) < date('now', '-6 years', 'local
 PRAGMA foreign_keys = ON;
 ```
 
-> `DbContext.ConfigurePragmas()` が接続確立時に必ず実行します（同時に `PRAGMA busy_timeout = 5000` と共有モード時は `PRAGMA journal_mode = DELETE` も設定）。SQLite は外部キー制約をデフォルトで無効化しているため、明示的に有効化する必要があります(よくあるハマりどころ)。
+> `DbContext.ConfigurePragmas()` が接続確立時に必ず実行します。同時に `PRAGMA busy_timeout` をモード別に設定（ローカルモード: 5000ms / 共有モード: 15000ms。共有モードは SMB 遅延と最大 20 台の同時アクセスを考慮、Issue #1107）し、共有モード時は `PRAGMA journal_mode = DELETE` を試行します（DELETE 設定不可時は TRUNCATE → PERSIST の順にフォールバックし、いずれも失敗した場合は警告ログを記録、Issue #1107）。SQLite は外部キー制約をデフォルトで無効化しているため、明示的に有効化する必要があります(よくあるハマりどころ)。
 
 ### 9.2 推奨される接続取得方法
 

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -503,7 +503,7 @@ classDiagram
 **共有フォルダモード対応:**
 
 - `IsSharedMode`: `DatabaseOptions.Path` が設定されている場合に `true`。共有フォルダモードかどうかを判定する
-- `ConfigurePragmas()`: 接続時に `PRAGMA foreign_keys = ON`、`PRAGMA busy_timeout = 5000`、`PRAGMA journal_mode = DELETE` を設定
+- `ConfigurePragmas()`: 接続時に `PRAGMA foreign_keys = ON`、`PRAGMA busy_timeout`（ローカルモード: 5000ms / 共有モード: 15000ms、Issue #1107）を設定。共有モード時は `PRAGMA journal_mode = DELETE` を試行し、失敗時は TRUNCATE → PERSIST の順にフォールバック（`ConfigureJournalMode()`、Issue #1107）
 - `ExecuteWithRetry<T>()`: SQLITE_BUSY/SQLITE_LOCKED発生時に指数バックオフでリトライ（100ms → 500ms → 2000ms、最大3回）
 - `CheckConnectionHealth()`: 軽量クエリで接続の正常性を確認。接続断時は自動再接続を試行
 - `StartHealthCheck()`: 共有フォルダモード時のみ、30秒間隔の定期ヘルスチェックタイマーを開始

--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -387,7 +387,7 @@ using var scope = await _dbContext.BeginTransactionAsync();
 await scope.CommitAsync();
 ```
 
-`ConnectionLease` が内部でセマフォによる排他を行い、複数スレッドから安全にアクセスできる。共有モードでも `busy_timeout=5000` と組み合わせて耐障害性を確保している。
+`ConnectionLease` が内部でセマフォによる排他を行い、複数スレッドから安全にアクセスできる。共有モードでは `busy_timeout=15000ms`（SMB 遅延と最大 20 台の同時アクセスを考慮、Issue #1107。ローカルモードは 5000ms）と組み合わせて耐障害性を確保している。
 
 ---
 
@@ -969,7 +969,7 @@ UNCパス（`\\` で始まるパス）が指定された場合、自動的に共
 | PRAGMA | 値 | 理由 |
 |--------|-----|------|
 | journal_mode | DELETE | WALモードはネットワークファイルシステムで非推奨のため |
-| busy_timeout | 5000 | 複数PC同時アクセス時のロック待機（5秒） |
+| busy_timeout | 15000 | 複数PC同時アクセス時のロック待機（15秒。SMB遅延と最大20台の同時アクセスを考慮、Issue #1107。ローカルモードは5000ms） |
 | synchronous | NORMAL | ネットワーク越しのI/O性能を考慮 |
 
 #### キャッシュTTLの調整


### PR DESCRIPTION
## 概要

ドキュメント記述（`busy_timeout=5000ms`）と実装（`SharedBusyTimeoutMs = 15000`）の不整合を解消します。Issue #1391 対応。

## 変更経緯の調査結果

`git log -S 'SharedBusyTimeoutMs'` および PR #1107 (`fix: 共有モードのSQLite耐障害性を改善`) のコミットメッセージで、5000→15000 への分離は **明確な技術的根拠（SMB 遅延・最大 20 台の同時アクセス）に基づく意図的な設計判断** だったことを確認しました。したがって Issue 提示の選択肢のうち **(a) 文書を実装に合わせる** を採用しました。

> 引用 (commit eef3da6):
> > busy_timeout: ローカル5000ms / 共有15000msに分離（SMB遅延・最大20台考慮）

PR #1107 で `02_DB設計書.md` の表形式の値（596行目）と `管理者マニュアル.md` は更新されたものの、散在する他のドキュメントへの波及更新が漏れた典型的なドキュメントドリフトでした。

## 修正内容

| ファイル | 変更内容 |
|---------|---------|
| `.claude/rules/business-logic.md` | 共有モード行を 15000ms に修正、ローカル時 5000ms とフォールバック仕様も併記 |
| `ICCardManager/docs/design/02_DB設計書.md` §9.1 | `ConfigurePragmas()` 説明文をモード別の値・フォールバック仕様に整合 |
| `ICCardManager/docs/design/05_クラス設計書.md` §5.5 | 同上、`ConfigureJournalMode()` への言及を追加 |
| `ICCardManager/docs/manual/開発者ガイド.md` | §コネクションリースの記述（390行目）と §共有モードPRAGMA設定の表（972行目）を 15000ms に統一 |

Issue 推奨アクション 3 に従い、`journal_mode` のフォールバック仕様（DELETE → TRUNCATE → PERSIST、PR #1107 由来）も同箇所に併記して将来のドリフトを抑制しました。

## フォローアップ Issue

調査中に発見した別の文書ドリフトを Issue #1396 として起票しました。

- **Issue #1396**: `05_クラス設計書.md:507` の `ExecuteWithRetry` 説明（「最大3回」）が PR #1107 のリトライ戦略（モード別: ローカル3回・共有5回 + ジッター）と乖離。同じファイル内の line 653 とも矛盾している状態。本 PR のスコープ外として別 Issue 化。

## テスト

実装側の変更はないため、新規ユニットテストは追加していません。既存の `DbContextResilienceTests.cs` が `LocalBusyTimeoutMs` / `SharedBusyTimeoutMs` 定数を経由して実装値の整合性を担保しています（`L51`, `L65`, `L381`）。

## Test plan
- [x] 修正後 `grep -rn 'busy_timeout' --include='*.md'` で全箇所を再点検し、5000ms と 15000ms が必ずモード（ローカル/共有）と一緒に記載されていることを確認
- [x] 実装変更なしのためビルド・テストへの影響なし（既存テストは `internal const` を介して整合済み）
- [ ] レビュアー: ドキュメントの日本語表現の自然さの確認

Closes #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
