### PR TITLE
docs: 開発者ガイドの CommunityToolkit.Mvvm バージョン表記を 8.4.2 に更新 (Issue #1393)

### DIFF
--- a/ICCardManager/docs/manual/開発者ガイド.md
+++ b/ICCardManager/docs/manual/開発者ガイド.md
@@ -65,7 +65,7 @@ graph LR
 | フレームワーク | .NET Framework | 4.8 | `<TargetFramework>net48</TargetFramework>` |
 | プラットフォームターゲット | x86 | - | felicalib.dll が x86 のため |
 | UIフレームワーク | WPF | - | `<UseWPF>true</UseWPF>` |
-| MVVMツールキット | CommunityToolkit.Mvvm | 8.2.2 | `[ObservableProperty]` / `[RelayCommand]` ソースジェネレータ |
+| MVVMツールキット | CommunityToolkit.Mvvm | 8.4.2 | `[ObservableProperty]` / `[RelayCommand]` ソースジェネレータ。最新版は `csproj` を参照 |
 | データベース | System.Data.SQLite.Core | 1.0.119 | SQLite 3 系 |
 | ICカード | FelicaLib.DotNet | 1.2.67 | + `felicalib.dll`（ネイティブ） |
 | Excel出力 | ClosedXML | 0.105.0 | |
@@ -730,7 +730,7 @@ public partial class MyViewModel : ViewModelBase
 ```
 
 **プロパティ変更通知**:
-- `[ObservableProperty]` 属性を使用（`CommunityToolkit.Mvvm` 8.2.2 のソースジェネレータ）
+- `[ObservableProperty]` 属性を使用（`CommunityToolkit.Mvvm` 8.4.2 のソースジェネレータ）
 - 複雑なロジックが必要な場合は `SetProperty()` を直接使用
 
 **コマンド**:


### PR DESCRIPTION
## 概要

Issue #1393 のドキュメント表記ズレを修正。

開発者ガイドの 2 箇所で CommunityToolkit.Mvvm のバージョンが `8.2.2` のままになっており、`ICCardManager.csproj` 上の実バージョン `8.4.2` と乖離していた。新規開発者が古いバージョンの公式ドキュメントを参照してしまうのを防ぐため、表記を実装側に揃える。

## 変更内容

`ICCardManager/docs/manual/開発者ガイド.md`
- L68（技術スタック表）: `8.2.2` → `8.4.2`、備考に「最新版は `csproj` を参照」を追記（再発防止注記）
- L733（プロパティ変更通知の説明）: `8.2.2` → `8.4.2`

## 影響範囲

- ドキュメントのみの変更。コード・設定・テストへの影響なし。
- context7 で MVVM Toolkit の現行ドキュメントを確認済み。`[ObservableProperty]` / `[RelayCommand]` ソースジェネレータの基本 API は 8.2 系→8.4 系で破壊的変更なく、本文の説明はそのままで問題ない。

## テスト計画

- [x] `git --no-pager diff` で意図した 2 行のみ変更されていることを確認
- [x] 開発者ガイド全体で `8.2.2` の残存がないこと（grep で 0 件）を確認
- [x] csproj の `CommunityToolkit.Mvvm` バージョン (`8.4.2`) と一致していることを確認
- [ ] レビュアー: 開発者ガイドの該当 2 行が想定通りに表示されるか目視確認

## 関連 Issue

Closes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)