### PR TITLE
docs: ExecuteWithRetry の説明をモード別リトライ戦略に整合 (Issue #1396)

### DIFF
--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -504,7 +504,7 @@ classDiagram
 
 - `IsSharedMode`: `DatabaseOptions.Path` が設定されている場合に `true`。共有フォルダモードかどうかを判定する
 - `ConfigurePragmas()`: 接続時に `PRAGMA foreign_keys = ON`、`PRAGMA busy_timeout`（ローカルモード: 5000ms / 共有モード: 15000ms、Issue #1107）を設定。共有モード時は `PRAGMA journal_mode = DELETE` を試行し、失敗時は TRUNCATE → PERSIST の順にフォールバック（`ConfigureJournalMode()`、Issue #1107）
-- `ExecuteWithRetry<T>()`: SQLITE_BUSY/SQLITE_LOCKED発生時に指数バックオフでリトライ（100ms → 500ms → 2000ms、最大3回）
+- `ExecuteWithRetry<T>()`: SQLITE_BUSY/SQLITE_LOCKED発生時に指数バックオフでリトライ。ローカルモードは最大3回（100ms → 500ms → 2000ms）、共有モードは最大5回（200ms → 500ms → 1000ms → 2000ms → 5000ms、ジッター付き、Issue #1107）。詳細は [§5.5b](#55b-接続リーストランザクションスコープissue-1243) 参照
 - `CheckConnectionHealth()`: 軽量クエリで接続の正常性を確認。接続断時は自動再接続を試行
 - `StartHealthCheck()`: 共有フォルダモード時のみ、30秒間隔の定期ヘルスチェックタイマーを開始
 - `Vacuum()`: 戻り値を `bool` に変更。共有モードで他PCが接続中の場合はVACUUMが失敗しうるため、失敗時は `false` を返す（例外にしない）


### PR DESCRIPTION
## Summary

- `ICCardManager/docs/design/05_クラス設計書.md:507` の `ExecuteWithRetry<T>()` 説明を、PR #1107 で導入されたモード別リトライ戦略に整合
- 同一ファイル内 line 653 / `02_DB設計書.md` / `06_シーケンス図.md` / `管理者マニュアル.md` との矛盾を解消
- 深掘り用に §5.5b（接続リース・トランザクションスコープ）への内部リンクを追加

## 背景

実装側 (`DbContext.cs:959-965`) は以下のモード別リトライを行う:

| モード | 回数 | 待機時間 | ジッター |
|--------|-----|----------|--------|
| ローカル | 最大3回 | 100→500→2000ms | なし |
| 共有 | 最大5回 | 200→500→1000→2000→5000ms | あり (`baseDelay/2` を上限) |

しかし line 507 のみ「最大3回」のままで、上から読んだ開発者が共有モードの挙動を誤解する恐れがあった。

## 変更内容

```diff
-- `ExecuteWithRetry<T>()`: SQLITE_BUSY/SQLITE_LOCKED発生時に指数バックオフでリトライ（100ms → 500ms → 2000ms、最大3回）
++ `ExecuteWithRetry<T>()`: SQLITE_BUSY/SQLITE_LOCKED発生時に指数バックオフでリトライ。ローカルモードは最大3回（100ms → 500ms → 2000ms）、共有モードは最大5回（200ms → 500ms → 1000ms → 2000ms → 5000ms、ジッター付き、Issue #1107）。詳細は §5.5b 参照
```

## スコープ

- Issue #1396 の「推奨スコープ: 最小スコープ (line 507 の1行修正のみ)」に従う
- 補足調査メモにあった `07_テスト設計書.md:2978` のテストケース #3 は、直後の #6（ローカルモード）と #7（共有モード）で両モードを明示的にテスト分割しているため、#3 は暗黙的にローカルモード相当として整合しており本PRでは触れない

## Test plan

- [x] 差分が `05_クラス設計書.md` 1ファイル / 1行のみ
- [x] 修正後の文言が同ファイル line 653・`02_DB設計書.md:605-618`・実装値（`LocalRetryDelays` / `SharedRetryDelays`）と一致
- [x] 内部リンク `#55b-接続リーストランザクションスコープissue-1243` が既存見出し (5.5b) と一致

## 関連

- Closes #1396
- Related: #1107 (モード別リトライ戦略の実装), #1391 (busy_timeout 文書整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)