### PR TITLE
docs: 操作ヒント色 (#E3F2FD) と返却完了色の用途衝突を整理 (Issue #1399)

### DIFF
--- a/.claude/rules/development-conventions.md
+++ b/.claude/rules/development-conventions.md
@@ -31,6 +31,7 @@
 - 返却時: 薄い水色背景(#E3F2FD、`ReturnBackgroundBrush`) + アイコン + 「ピピッ」
 - エラー時: 薄い赤背景(#FFEBEE、`ErrorBackgroundBrush`) + 「ピー」
 - **色値の Single Source of Truth**: `Resources/Styles/AccessibilityStyles.xaml` のブラシキー（`LendingBackgroundBrush` / `ReturnBackgroundBrush` / `ErrorBackgroundBrush`）を `DynamicResource` で参照すること。色値リテラル（`#FFF3E0` 等）を直接指定しない（Issue #1392）
+- **`ReturnBackgroundBrush` の用途**: 「返却完了」シグナルに加え、ダイアログの情報ヘッダー・操作ヒント・装飾用途でも兼用する。専用の `HintBackgroundBrush` 等は新設しない設計判断。意味の区別は色ではなくアイコン・テキスト・配置で行う（Issue #1399、`docs/design/03_画面設計書.md` §4.1 参照）
 
 ## ICカード関連
 - **用語の使い分け（重要）**: 本システムでは「職員証」と「交通系ICカード」の2種類のICカードを扱う。UI文言・マニュアル・コード内のユーザー向けメッセージでは、交通系ICカードを指す場合は必ず**「交通系ICカード」**と記載し、単に「ICカード」とは書かないこと。「ICカード」だけでは職員証と区別がつかずユーザーが混乱する。ただし「ICカードリーダー」等のハードウェア名称はそのままでよい

--- a/ICCardManager/docs/design/03_画面設計書.md
+++ b/ICCardManager/docs/design/03_画面設計書.md
@@ -1039,12 +1039,13 @@ stateDiagram-v2
 | 用途 | 色コード | 色名 | ブラシキー | 説明 |
 |------|----------|------|-----------|------|
 | 貸出完了 | #FFF3E0 | 薄いオレンジ | `LendingBackgroundBrush` | 暖色系で「外に出る」イメージ |
-| 返却完了 | #E3F2FD | 薄い水色 | `ReturnBackgroundBrush` | 寒色系で「戻る」イメージ |
+| 返却完了 / 情報表示 / 操作ヒント | #E3F2FD | 薄い水色 | `ReturnBackgroundBrush` | 寒色系。返却完了のシグナルに加え、情報ヘッダー・操作ヒント・装飾用途でも兼用される（実装上の運用） |
 | エラー | #FFEBEE | 薄い赤 | `ErrorBackgroundBrush` | 警告・注意 |
 | ヘッダー | #2196F3 | 青 | -（直接指定） | システムカラー |
-| 操作ヒント | #E3F2FD | 薄い青 | （`ReturnBackgroundBrush` と同色値） | 情報表示。返却完了の背景色と同一色値を共有している（実装上）|
 
-> **色値の Single Source of Truth**: 上表の色値は `Resources/Styles/AccessibilityStyles.xaml` のブラシキーで定義されており、View からは `DynamicResource` で参照する。色値そのものを XAML/コードに直接書かないこと（Issue #1392）。
+> **色値の Single Source of Truth**: 上表の色値は `Resources/Styles/AccessibilityStyles.xaml` のブラシキーで定義されており、View からは `DynamicResource` で参照する。色値そのものを XAML/コードに直接書かないこと(Issue #1392)。
+
+> **`ReturnBackgroundBrush` の兼用について(Issue #1399)**: 寒色青 `#E3F2FD` は「返却完了」の他、ダイアログの情報ヘッダー・操作ヒント・各種装飾(`MainWindow.xaml` の操作ヒント帯、`OperationLogDialog.xaml` のタイトルヘッダー、`CardRegistrationModeDialog.xaml` のヒント Border 等)でも `ReturnBackgroundBrush` を共通で参照している。これは「青系の汎用情報色」としての運用上の単純化であり、専用ブラシ(例: `HintBackgroundBrush`)を新設しない設計判断である。各画面における意味の区別は「色」ではなく**アイコン・テキスト・配置・コンテキスト**で行う(4.2.2 多重表現の原則)。なお、`ToastNotificationWindow.xaml.cs` でも `ToastType.Return` と `ToastType.Info` が同色値を共有しており、本方針と一貫している。
 
 ### 4.2 アクセシビリティ対応
 


### PR DESCRIPTION
## Summary

- 設計書 `03_画面設計書.md` §4.1 で同色値 `#E3F2FD` が「返却完了」と「操作ヒント」の 2 用途に重複していた問題（Issue #1399）を整理
- 実装調査の結果、`ReturnBackgroundBrush` は既に情報ヘッダー・操作ヒント・装飾用途で広く兼用されているため、専用 `HintBackgroundBrush` を新設せず **方針 (b)（実態追認・最小変更）** を採用
- 兼用設計の根拠と意味区別の方針（色ではなくアイコン・テキスト・配置で区別）を設計書とルール集に明記

## 調査結果

`ReturnBackgroundBrush` / `#E3F2FD` の使用箇所を全て確認したところ、以下の通り：

| 用途 | 該当箇所 |
|------|----------|
| ヒント・情報ヘッダー・装飾 | XAML の `ReturnBackgroundBrush` 全 12 箇所、Toast の `Info`、`LedgerDetailDialog` の `GroupColor1` |
| 純粋な「返却完了」シグナル | `ToastNotificationWindow.xaml.cs` の `ToastType.Return` 1 箇所のみ |

特に `MainWindow.xaml:858` には XAML コメントとして `<!-- 操作ヒント + デバッグボタン -->` と明示されており、「ReturnBackgroundBrush は実質的に汎用情報色」として運用されている実態が明確。

## 採用方針 (b): 設計書を実態に合わせる

- 色テーブル「返却完了」行と「操作ヒント」行を **「返却完了 / 情報表示 / 操作ヒント」** の単一行に統合
- 「`ReturnBackgroundBrush` の兼用について (Issue #1399)」セクションを設計書に追加し、判断根拠と意味区別の方針を残した
- `.claude/rules/development-conventions.md` の UI/UX 原則にも要約を追加し、ルール集と設計書の整合を保つ

### 採用しなかった案

- **方針 (a)** (`HintBackgroundBrush` 新設): 12 ファイルの XAML 置換が必要となり、同色値で別キーを作ると開発者がどちらを使うか迷う新たな問題が発生するため見送り

## 変更ファイル

- `ICCardManager/docs/design/03_画面設計書.md` — 色テーブル整理、兼用方針の明記
- `.claude/rules/development-conventions.md` — `ReturnBackgroundBrush` の用途を 1 行追加

## Test plan

- [x] `dotnet build` が 0 警告 0 エラーで成功（実装変更なしのため当然だが確認済み）
- [x] 設計書の Markdown レンダリングが崩れていない（テーブル・引用ブロック）
- [ ] レビュー時: `ReturnBackgroundBrush` の兼用方針が文章として明確か確認
- [ ] レビュー時: 「色覚多様性対応」原則（4要素で状態伝達）と矛盾していないか確認

## 関連

- Closes #1399
- 関連: #1392 (UI 背景色のドキュメント整合 / `ReturnBackgroundBrush` ブラシキー化)、#1274 (色覚多様性対応の原則)

🤖 Generated with [Claude Code](https://claude.com/claude-code)