### PR TITLE
chore: mermaid-filter.err を .gitignore に追加

### DIFF
--- a/ICCardManager/.gitignore
+++ b/ICCardManager/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 *.tmp
 *.temp
 *.log
+mermaid-filter.err
 
 # デバッグシンボル（本番環境不要）
 *.pdb


### PR DESCRIPTION
## Summary
- `mermaid-filter.err`（Pandoc 用 Mermaid 図変換フィルターが生成する 0 バイトのエラーログ）を `ICCardManager/.gitignore` に追加
- リリーススクリプト `release.ps1` の作業ツリー clean チェックで毎回 untracked として検出され、リリース前に手動削除が必要だった問題を解消

## 背景
v2.8.0 リリース時に `release.ps1` の前提条件チェック「作業ツリーにコミットされていない変更があります」で停止し、`mermaid-filter.err` の手動削除が必要となった。マニュアル変換 (`installer/build-installer.ps1`) で再発生する性質のため `.gitignore` に登録する。

## 変更内容
`ICCardManager/.gitignore` の「一時ファイル」セクション（`*.tmp` / `*.temp` / `*.log` の並び）に `mermaid-filter.err` を1行追加。

## Test plan
- [ ] `ICCardManager/` 配下で `installer/build-installer.ps1` 等を実行し、`mermaid-filter.err` が再生成された後 `git status` で untracked に出ないことを確認
- [ ] CI（dotnet build / test）がグリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)