### PR TITLE
fix: Service 層のリポジトリ呼び出しを直列化し SQLITE_MISUSE を防止 (Issue #1452)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **バグ修正**
 - 月次帳票（物品出納簿）の4月計および5月以降の年度累計の「受入金額」欄に、前年度からの繰越分が計上されない不具合を修正。「前年度より繰越」レコードは DB に保存されず `CarryoverRowData` として表示用に合成されるため、月計・累計の集計に明示的に加算されていなかった。`ReportDataBuilder` で `fiscalYearCarryoverIncome` を変数化し、4月計の Income と5月以降の累計 Income に加算するように修正。これにより紙の出納簿様式での「受入 − 払出 = 残額」が成立するようになった。`IsMidYearCarryoverSummary` による集計除外フィルタは紙出納簿移行カード（Issue #510）の二重計上防止のため引き続き維持する（#1494）
+- `DashboardService.BuildDashboardAsync` および `MainViewModel.HandleCardInStaffWaitingStateAsync` で `Task.WhenAll` により複数のリポジトリ呼び出しを並列起動していた箇所を直列 await に変更。これらは内部で同一の `SQLiteConnection` 上で `SQLiteCommand` を並列実行する経路であり、`System.Data.SQLite` の前提（同一接続上の並列コマンド非保証）を破ることで `SQLITE_MISUSE` または不定動作の原因となっていた。Service 層の `ConfigureAwait(false)` 規約により継続が ThreadPool に逃げるため「WPF Dispatcher による直列化」は成立せず、性能最適化（Issue #504）の正しさのリグレッションだった。直列化により正しさを回復。回帰テストとして `DashboardServiceTests.BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと` を追加（#1452）
 
 ### v2.8.0 (2026-05-03)
 

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **バグ修正**
 - 月次帳票（物品出納簿）の4月計および5月以降の年度累計の「受入金額」欄に、前年度からの繰越分が計上されない不具合を修正。「前年度より繰越」レコードは DB に保存されず `CarryoverRowData` として表示用に合成されるため、月計・累計の集計に明示的に加算されていなかった。`ReportDataBuilder` で `fiscalYearCarryoverIncome` を変数化し、4月計の Income と5月以降の累計 Income に加算するように修正。これにより紙の出納簿様式での「受入 − 払出 = 残額」が成立するようになった。`IsMidYearCarryoverSummary` による集計除外フィルタは紙出納簿移行カード（Issue #510）の二重計上防止のため引き続き維持する（#1494）
-- `DashboardService.BuildDashboardAsync` および `MainViewModel.HandleCardInStaffWaitingStateAsync` で `Task.WhenAll` により複数のリポジトリ呼び出しを並列起動していた箇所を直列 await に変更。これらは内部で同一の `SQLiteConnection` 上で `SQLiteCommand` を並列実行する経路であり、`System.Data.SQLite` の前提（同一接続上の並列コマンド非保証）を破ることで `SQLITE_MISUSE` または不定動作の原因となっていた。Service 層の `ConfigureAwait(false)` 規約により継続が ThreadPool に逃げるため「WPF Dispatcher による直列化」は成立せず、性能最適化（Issue #504）の正しさのリグレッションだった。直列化により正しさを回復。回帰テストとして `DashboardServiceTests.BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと` を追加（#1452）
+- `DashboardService.BuildDashboardAsync` および `MainViewModel.HandleCardInStaffWaitingStateAsync` で `Task.WhenAll` により複数のリポジトリ呼び出しを並列起動していた箇所を直列 await に変更（**Issue #504 で導入されたデータ取得並列化を撤回**）。これらは内部で同一の `SQLiteConnection` 上で `SQLiteCommand` を並列実行する経路であり、`System.Data.SQLite` の前提（同一接続上の並列コマンド非保証）を破ることで `SQLITE_MISUSE` または不定動作の原因となっていた。Service 層の `ConfigureAwait(false)` 規約により継続が ThreadPool に逃げるため「WPF Dispatcher による直列化」は成立せず、ViewModel 層でも `SQLiteCommand` 自体が内部で別スレッドにディスパッチされ得るため UI スレッド単独実行は保証されない。直列化により正しさを回復。`DbContext.LeaseConnectionAsync` の XML doc に「Service / ViewModel 層で `Task.WhenAll` 並列起動禁止」の規律を明記して回帰防止。回帰テストとして `DashboardServiceTests.BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと` を追加（#1452）
 
 ### v2.8.0 (2026-05-03)
 

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -2215,6 +2215,7 @@ Model層に追加されたドメインロジック（自身のプロパティの
 | 20 | 空balances辞書で全カード FallbackBalance（Issue #1261） | 3枚 + balances空、閾値=1000 | 全て CurrentBalance=0, LastUsageDate=null, IsBalanceWarning=true |
 | 21 | 警告残高=0 境界（Issue #1261） | balance=0/1/1000, 閾値=0 | 残高0のみ警告、1以上は警告対象外 |
 | 22 | 長期貸出中カードの可視化（Issue #1261 返却期限超過相当） | 60日前から貸出中 | IsLent=true、LentStaffName 復元、カード表示される |
+| 23 | リポジトリ呼び出しがオーバーラップしないこと（Issue #1452 回帰） | 4 リポジトリの保持区間を計測 | maxConcurrentCalls=1（直列化されており同一接続上の SQLITE_MISUSE が発生しない） |
 
 **テストクラス:** `DashboardServiceTests`
 

--- a/ICCardManager/src/ICCardManager/Data/DbContext.cs
+++ b/ICCardManager/src/ICCardManager/Data/DbContext.cs
@@ -308,10 +308,27 @@ namespace ICCardManager.Data
         /// 接続リースを非同期で取得する。using文で使用すること。
         /// </summary>
         /// <remarks>
-        /// セマフォは取得しない。WPFのUIスレッドでは全ての非同期操作がDispatcherで
-        /// 直列化されるため、非同期コード間の競合は発生しない。
-        /// バックグラウンドスレッドからのDBアクセスにはLeaseConnection()（同期版）を使用すること。
-        /// 書き込み操作はBeginTransactionAsync()でセマフォ保護される。
+        /// <para>
+        /// セマフォは取得せず、同一の <see cref="SQLiteConnection"/> インスタンスを返す。
+        /// 書き込み操作は <see cref="BeginTransactionAsync"/> でセマフォ保護される。
+        /// バックグラウンドスレッドからの同期 DB アクセスには <see cref="LeaseConnection"/>（同期版）を使用すること。
+        /// </para>
+        /// <para>
+        /// <b>重要（Issue #1452）— 並列起動禁止:</b>
+        /// 本メソッドはセマフォを取得しないため、複数のリポジトリ呼び出しを <c>Task.WhenAll</c> 等で
+        /// 並列起動すると、同一の <see cref="SQLiteConnection"/> 上で <see cref="SQLiteCommand"/> が
+        /// 並列実行される。<c>System.Data.SQLite</c> の <see cref="SQLiteConnection"/> は同一接続上の
+        /// 並列コマンド実行を保証していないため、<c>SQLITE_MISUSE</c> または不定動作の原因となる。
+        /// Service / ViewModel 層は **必ず直列 await** で呼び出すこと。
+        /// </para>
+        /// <para>
+        /// 並列化前提のレビュー観点（誤解されやすいので注記）:
+        /// (1) Service 層は <c>ConfigureAwait(false)</c> 規約により継続が ThreadPool に逃げるため、
+        ///     UI Dispatcher による暗黙の直列化は成立しない。
+        /// (2) ViewModel 層は <c>ConfigureAwait(false)</c> を付けないが、<see cref="SQLiteCommand"/>
+        ///     自体は内部で別スレッドにディスパッチされ得るため、UI スレッド単独で実行される保証はない。
+        ///     よって ViewModel 経路でも <c>Task.WhenAll</c> での並列起動は同様にリスクがある。
+        /// </para>
         /// </remarks>
         public virtual Task<ConnectionLease> LeaseConnectionAsync(CancellationToken ct = default)
         {

--- a/ICCardManager/src/ICCardManager/Services/DashboardService.cs
+++ b/ICCardManager/src/ICCardManager/Services/DashboardService.cs
@@ -41,18 +41,15 @@ namespace ICCardManager.Services
         /// <returns>ソート済みのダッシュボードアイテムと警告しきい値</returns>
         public async Task<DashboardResult> BuildDashboardAsync(DashboardSortOrder sortOrder)
         {
-            // Issue #504: データ取得を並列化して高速化
-            var settingsTask = _settingsRepository.GetAppSettingsAsync();
-            var cardsTask = _cardRepository.GetAllAsync();
-            var balancesTask = _ledgerRepository.GetAllLatestBalancesAsync();
-            var staffTask = _staffRepository.GetAllAsync();
-
-            await Task.WhenAll(settingsTask, cardsTask, balancesTask, staffTask).ConfigureAwait(false);
-
-            var settings = await settingsTask.ConfigureAwait(false);
-            var cards = await cardsTask.ConfigureAwait(false);
-            var balances = await balancesTask.ConfigureAwait(false);
-            var staffDict = (await staffTask.ConfigureAwait(false)).ToDictionary(s => s.StaffIdm, s => s.Name);
+            // Issue #1452: 同一の SQLiteConnection 上で SQLiteCommand が並列実行されると
+            // SQLITE_MISUSE 不定動作の原因となるため、リポジトリ呼び出しは直列化する。
+            // 旧: Task.WhenAll で並列起動（Issue #504 の高速化）→ SQLite の前提を破る正しさのリグレッション。
+            // 新: 直列 await により単一接続上の同時コマンド実行を防ぐ。
+            var settings = await _settingsRepository.GetAppSettingsAsync().ConfigureAwait(false);
+            var cards = await _cardRepository.GetAllAsync().ConfigureAwait(false);
+            var balances = await _ledgerRepository.GetAllLatestBalancesAsync().ConfigureAwait(false);
+            var staffDict = (await _staffRepository.GetAllAsync().ConfigureAwait(false))
+                .ToDictionary(s => s.StaffIdm, s => s.Name);
 
             var dashboardItems = new List<CardBalanceDashboardItem>();
 

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -776,15 +776,10 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private async Task HandleCardInStaffWaitingStateAsync(string idm)
     {
-        // 職員証とカードを並列で検索（高速化）
-        var staffTask = _staffRepository.GetByIdmAsync(idm);
-        var cardTask = _cardRepository.GetByIdmAsync(idm);
-
-        await Task.WhenAll(staffTask, cardTask);
-
-        // awaitを使用してデッドロックを防止（Task.WhenAll後でも.Resultは避ける）
-        var staff = await staffTask;
-        var card = await cardTask;
+        // Issue #1452: 同一の SQLiteConnection 上で SQLiteCommand が並列実行されると
+        // SQLITE_MISUSE 不定動作の原因となるため、リポジトリ呼び出しは直列化する。
+        var staff = await _staffRepository.GetByIdmAsync(idm);
+        var card = await _cardRepository.GetByIdmAsync(idm);
 
         // 職員証かどうか確認
         if (staff != null)

--- a/ICCardManager/tests/ICCardManager.Tests/Services/DashboardServiceTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/DashboardServiceTests.cs
@@ -547,4 +547,63 @@ public class DashboardServiceTests
     }
 
     #endregion
+
+    #region Issue #1452: 単一接続上の並列コマンド実行防止（回帰テスト）
+
+    [Fact]
+    public async Task BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと()
+    {
+        // Issue #1452: 同一の SQLiteConnection 上で SQLiteCommand が並列実行されると
+        // SQLITE_MISUSE 不定動作の原因となる。BuildDashboardAsync が Task.WhenAll で
+        // 4 リポジトリを並列起動していたため、本テストでリポジトリ呼び出しの保持区間が
+        // オーバーラップしないこと（最大同時実行数 ≦ 1）を検証する。
+
+        var activeCalls = 0;
+        var maxConcurrentCalls = 0;
+        var lockObj = new object();
+
+        async Task<T> InstrumentedAsync<T>(T value)
+        {
+            lock (lockObj)
+            {
+                activeCalls++;
+                if (activeCalls > maxConcurrentCalls)
+                    maxConcurrentCalls = activeCalls;
+            }
+            // 並列があれば検出されるよう少し滞留させる
+            await Task.Delay(20).ConfigureAwait(false);
+            lock (lockObj)
+            {
+                activeCalls--;
+            }
+            return value;
+        }
+
+        _settingsRepositoryMock
+            .Setup(s => s.GetAppSettingsAsync())
+            .Returns(() => InstrumentedAsync(new AppSettings { WarningBalance = 1000 }));
+        _cardRepositoryMock
+            .Setup(c => c.GetAllAsync())
+            .Returns(() => InstrumentedAsync<IEnumerable<IcCard>>(new List<IcCard>
+            {
+                new IcCard { CardIdm = "0102030405060708", CardType = "はやかけん", CardNumber = "H-001" }
+            }));
+        _ledgerRepositoryMock
+            .Setup(l => l.GetAllLatestBalancesAsync())
+            .Returns(() => InstrumentedAsync(
+                new Dictionary<string, (int Balance, DateTime? LastUsageDate)>()));
+        _staffRepositoryMock
+            .Setup(s => s.GetAllAsync())
+            .Returns(() => InstrumentedAsync<IEnumerable<Staff>>(new List<Staff>()));
+
+        // Act
+        await _service.BuildDashboardAsync(DashboardSortOrder.CardName);
+
+        // Assert
+        maxConcurrentCalls.Should().Be(1,
+            "BuildDashboardAsync は同一 SQLiteConnection 上の SQLITE_MISUSE を防ぐため、" +
+            "リポジトリ呼び出しを直列化する（Issue #1452）");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- `DashboardService.BuildDashboardAsync` および `MainViewModel.HandleCardInStaffWaitingStateAsync` の `Task.WhenAll` で複数リポジトリを並列起動していた箇所を **直列 await** に変更
- 同一の `SQLiteConnection` 上で `SQLiteCommand` が並列実行されることによる `SQLITE_MISUSE` 不定動作リスクを解消
- 回帰テスト `BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと` を追加

Closes #1452

## 背景

Issue #1452 は `DbContext.LeaseConnectionAsync` がセマフォを取得せずに同一の `SQLiteConnection` インスタンスを返すため、`Task.WhenAll` 経由で並列実行されると `System.Data.SQLite` の前提（同一接続上の並列コマンド非保証）を破る正しさのリグレッションを指摘していた。

旧 `LeaseConnectionAsync` の doc コメントは「WPF UI スレッドの Dispatcher で直列化される」と主張していたが、Service 層は `ConfigureAwait(false)` 規約により継続が ThreadPool に逃げるため、この前提は成立しない。

## 採用した方針（Issue 内提案2）

Service 層の並列起動を直列 await に戻すことで、SQLite の前提を破る経路を排除。

```csharp
// 旧: 並列起動（Task.WhenAll）
var settingsTask = _settingsRepository.GetAppSettingsAsync();
var cardsTask = _cardRepository.GetAllAsync();
var balancesTask = _ledgerRepository.GetAllLatestBalancesAsync();
var staffTask = _staffRepository.GetAllAsync();
await Task.WhenAll(settingsTask, cardsTask, balancesTask, staffTask).ConfigureAwait(false);

// 新: 直列 await（Issue #1452）
var settings = await _settingsRepository.GetAppSettingsAsync().ConfigureAwait(false);
var cards = await _cardRepository.GetAllAsync().ConfigureAwait(false);
var balances = await _ledgerRepository.GetAllLatestBalancesAsync().ConfigureAwait(false);
var staffDict = (await _staffRepository.GetAllAsync().ConfigureAwait(false))
    .ToDictionary(s => s.StaffIdm, s => s.Name);
```

## 検討した別案と却下理由

**提案1（`LeaseConnectionAsync` でセマフォ取得）**: 当初この方針を試行したが、`SettingsRepository.SaveAppSettingsAsync` などで `BeginTransactionAsync` スコープ内から `SetAsync` → `LeaseConnectionAsync` のネストが発生しており、セマフォ追加によりデッドロックが発生した（テストが27分hangし `--blame-hang-timeout` で初めて検出）。AsyncLocal によるリエントラントは async メソッド境界で値変更が呼び出し元に伝播しないため原理的に実装不可。コードベース全体（8箇所以上の `BeginTransactionAsync`）を refactor する案も検討したが影響範囲が大きすぎる。

**提案2（本PR採用）**: Service 層の並列起動を直列化。最小修正で SQLITE_MISUSE リスクを解消。Issue #504 の性能最適化は失われるが、ダッシュボード表示は通常 1 秒未満で完結するため体感影響は限定的。

## 影響範囲

- `Services/DashboardService.cs`: `BuildDashboardAsync` の 4並列リポジトリ呼び出しを直列化
- `ViewModels/MainViewModel.cs`: `HandleCardInStaffWaitingStateAsync` の 2並列リポジトリ呼び出しを直列化（職員証/カード判定パス、性能影響は微少）

## Test plan

- [x] `dotnet build` 成功（警告0、エラー0）
- [x] 全テスト合格（**3108件**、リグレッションなし）
- [x] 新規回帰テスト `BuildDashboardAsync_リポジトリ呼び出しがオーバーラップしないこと` 合格（最大同時実行数 ≦ 1 を計測検証）
- [ ] 手動検証：ダッシュボード画面の表示が体感的に遅くなっていないか確認（カード10枚程度の規模では問題なし想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)