### PR TITLE
chore(tools): bump-version.ps1 で既存 ### Unreleased を新バージョンに統合

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -108,4 +108,21 @@ gh release upload vX.Y.Z "installer/output/ICCardManager_Setup_X.Y.Z.exe" --clob
 - **WSL2 パス**: スクリプト呼び出しは `./tools/release.ps1` 形式で。bare path だと Windows 側で解決できない
 - **タグ重複**: 失敗リトライ時、タグ `vX.Y.Z` が既に存在する場合は `-SkipTag` で既存タグをスキップ
 - **ISCC.exe パス**: `settings.local.json` の許可パスと実際のインストール先が一致していること
-- **CHANGELOG.md**: リリーススクリプトが自動生成するため、手動で先に編集すると内容が重複する可能性がある
+- **CHANGELOG.md の `### Unreleased`**: `bump-version.ps1` は既存 `### Unreleased` セクションを検出すると、見出しを `### vX.Y.Z (date)` にリネームし、Unreleased 本文（手動キュレーションされたエントリ）を保持したまま、コミットメッセージから自動生成したエントリを末尾に追記する。**重複エントリが発生する場合があるため、PR レビュー時に手動で整理すること**。Unreleased が存在しない場合は「# 更新履歴」直後に新規セクションを挿入する従来挙動。
+  - 過去の不具合: v2.8.0 / v2.8.1 リリース時に既存 Unreleased が孤児化し、新バージョンと前バージョンの間に挟まる構造になっていた（PR #1451, #1511 で事後修正）。本ロジック追加により自動統合される。
+
+## CHANGELOG.md `### Unreleased` 運用ルール
+
+リリース後に追加する PR が CHANGELOG エントリを記載する場合、必ず **`# 更新履歴` 直下** に `### Unreleased` セクションを作成（または既存セクションに追記）すること。
+最新リリース版セクション（`### vX.Y.Z`）の**下**に `### Unreleased` を置くと、構造が壊れる（次回 `bump-version.ps1` の自動検出にもヒットしない）。
+
+```markdown
+# 更新履歴
+
+### Unreleased            ← 必ずここ（先頭）
+**バグ修正**
+- ...
+
+### v2.8.1 (2026-05-11)   ← 既存リリース版はこの下
+...
+```

--- a/ICCardManager/tools/bump-version.ps1
+++ b/ICCardManager/tools/bump-version.ps1
@@ -228,10 +228,40 @@ $readmeContent = Get-Content $ReadmePath -Raw -Encoding UTF8
 $readmeContent = $readmeContent -replace '最新バージョン: \*\*v[^*]+\*\* \([^)]+\)', "最新バージョン: **v${NewVersion}** (${Today})"
 Write-Success "README.md: v${NewVersion} (${Today})"
 
-# 3c. CHANGELOG.md — 「# 更新履歴」の直後にセクション挿入
+# 3c. CHANGELOG.md — 既存 ### Unreleased があれば見出しを vX.Y.Z にリネーム+自動生成エントリを追記、なければ新規挿入
+# Issue: bump-version.ps1 が常に「# 更新履歴」直後にセクションを挿入していたため、
+# 既存の Unreleased セクションが新バージョンと前バージョンの間に孤児化していた（v2.8.0/v2.8.1 で発生）
 $changelogContent = Get-Content $ChangelogPath -Raw -Encoding UTF8
-$changelogContent = $changelogContent -replace '(# 更新履歴\r?\n)', "`$1`n${changelogSection}`n"
-Write-Success "CHANGELOG.md: セクション挿入"
+
+# 「### Unreleased」セクション（見出し行 + 次の ### 見出し or EOF までの本文）を検出
+$unreleasedRegex = [regex]'(?ms)### Unreleased[ \t]*\r?\n(.*?)(?=\r?\n### |\z)'
+$unreleasedMatch = $unreleasedRegex.Match($changelogContent)
+
+if ($unreleasedMatch.Success) {
+    # 既存 Unreleased を統合: 見出しを vX.Y.Z (date) にリネームし、自動生成エントリを末尾に追記
+    $unreleasedBody = $unreleasedMatch.Groups[1].Value.TrimEnd()
+    $newSection = "### v${NewVersion} (${Today})"
+    if ($unreleasedBody) {
+        $newSection += "`n${unreleasedBody}"
+    }
+    if ($hasEntries) {
+        $autoGenBody = ($changelogSection -replace '^### v[^\r\n]+\r?\n', '').TrimEnd()
+        if ($autoGenBody) {
+            $newSection += "`n${autoGenBody}"
+        }
+    }
+    # 後続セクションとの間に空行を確保（lookahead が前方の `\n` を1つ食うため）
+    $newSection += "`n"
+
+    $changelogContent = $changelogContent.Substring(0, $unreleasedMatch.Index) +
+                        $newSection +
+                        $changelogContent.Substring($unreleasedMatch.Index + $unreleasedMatch.Length)
+    Write-Success "CHANGELOG.md: 既存 ### Unreleased を v${NewVersion} へ統合（手動キュレーション分は保持。コミット由来エントリと重複している場合はPRで手動整理してください）"
+} else {
+    # Unreleased セクションなし → 「# 更新履歴」直後に新規挿入
+    $changelogContent = $changelogContent -replace '(# 更新履歴\r?\n)', "`$1`n${changelogSection}`n"
+    Write-Success "CHANGELOG.md: セクション挿入"
+}
 
 # 3d. ユーザーマニュアル — バージョン + 最終更新日
 $userManualContent = Get-Content $UserManualPath -Raw -Encoding UTF8


### PR DESCRIPTION
## Summary

- v2.8.0 / v2.8.1 リリース時に `### Unreleased` セクションが新バージョンと前バージョンの間に孤児化する不具合が再発していた（事後修正 PR: #1451, #1511）
- 原因は `bump-version.ps1` が常に「# 更新履歴」直後に新セクションを挿入し、既存 Unreleased の存在を考慮していなかったこと
- `bump-version.ps1` に Unreleased 統合ロジックを追加。release skill にも運用ルールを明記

## 動作

### 既存 `### Unreleased` セクションあり
- 見出しを `### vX.Y.Z (date)` にリネーム
- 手動キュレーション本文を保持
- コミットメッセージから自動生成したエントリを末尾に追記（重複があれば PR レビュー時に手動整理）

### `### Unreleased` セクションなし
- 「# 更新履歴」直後に新規セクションを挿入（従来挙動）

## release skill への追記
- 上記の新挙動の説明
- リリース後 PR が CHANGELOG エントリを追加する際、必ず `# 更新履歴` 直下に Unreleased を配置するルール（最新リリース版の下に置くと bump-version の自動検出にヒットせず孤児化する）

## Test plan
- [x] PowerShell 7 構文チェック (`Parser.ParseFile`)
- [x] サンプル入力（既存 Unreleased + 後続 v2.8.1 セクション）で merge ロジックが期待通りに動作することを確認
  - 見出しが `### v2.8.2 (2026-05-12)` にリネームされる
  - 既存「**バグ修正**」「**訂正**」本文が保持される
  - 自動生成「**バグ修正**」が末尾に追記される
  - 後続セクションとの空行が保持される
- [x] Unreleased なしのケースで従来挙動（「# 更新履歴」直後に挿入）が維持されることを確認
- [ ] 実環境での `pwsh.exe -File ./tools/bump-version.ps1 -NewVersion 2.8.2 -DryRun` での挙動確認は次回リリース時に実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)