### PR TITLE
docs: CLAUDE.md のディレクトリ構成と参照ドキュメントを実体パスに整合 (Issue #1492)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,20 @@
 ## ディレクトリ構成
 
 ```
-ICCardManager/
-├── src/ICCardManager/      # 本体（Views, ViewModels, Models, Services, Data, Infrastructure, Common）
-├── tests/                  # ユニットテスト・UIテスト
-├── tools/                  # 開発支援ツール・スクリプト
-├── installer/              # InnoSetupインストーラー
-├── docs/design/            # 設計書（01〜08）
-└── docs/manual/            # ユーザー・管理者・開発者マニュアル
+.                                          # リポジトリルート
+├── ICCardManager/                         # 本プロジェクト本体
+│   ├── src/ICCardManager/                 # 本体（Views, ViewModels, Models, Services, Data, Infrastructure, Common）
+│   ├── tests/                             # ユニットテスト・UIテスト
+│   ├── tools/                             # 開発支援ツール・スクリプト
+│   ├── installer/                         # InnoSetupインストーラー
+│   ├── CHANGELOG.md                       # バージョン履歴・変更内容の Single Source of Truth
+│   └── docs/
+│       ├── design/                        # 設計書（01〜08）
+│       ├── manual/                        # ユーザー・管理者・開発者マニュアル
+│       └── 線区駅順コード/                  # 駅コード→駅名マスター
+├── CLAUDE.md                              # 本ファイル（プロジェクト指示書）
+├── docs/                                  # ルート直下。現状は superpowers プラグインキャッシュ等のみ（本プロジェクトの設計書は ICCardManager/docs/ 配下）
+└── tools/                                 # ルート直下の補助スクリプト群（ICCardManager/tools/ とは別物）
 ```
 
 ## よく使うコマンド
@@ -64,10 +71,10 @@ WSL2では "/mnt/c/Program Files/dotnet/dotnet.exe" を使用すること。
 ## 参照ドキュメント
 
 - `ICCardManager/CHANGELOG.md` — **バージョン履歴・変更内容の Single Source of Truth**（TODO.md より優先）
-- `docs/design/` — 設計書一式（01〜08）
-- `docs/manual/` — マニュアル（ユーザー・管理者・開発者）
-- `Resources/Templates/物品出納簿テンプレート.xlsx` — 月次帳票テンプレート
-- `docs/線区駅順コード/StationCode.csv` — 駅コード→駅名マスター（[出典](https://produ.irelang.jp/blog/2017/08/305/)、[新駅参照](https://ja.ysrl.org/atc/station-code.html)）
+- `ICCardManager/docs/design/` — 設計書一式（01〜08）
+- `ICCardManager/docs/manual/` — マニュアル（ユーザー・管理者・開発者）
+- `ICCardManager/src/ICCardManager/Resources/Templates/` — 月次帳票テンプレート（`物品出納簿テンプレート（企業会計部局）.xlsx`、`物品出納簿テンプレート（市長事務部局）.xlsx` の 2 ファイル）
+- `ICCardManager/docs/線区駅順コード/StationCode.csv` — 駅コード→駅名マスター（[出典](https://produ.irelang.jp/blog/2017/08/305/)、[新駅参照](https://ja.ysrl.org/atc/station-code.html)）
 
 ## 非推奨ドキュメント
 

--- a/ICCardManager/docs/superpowers/specs/2026-05-16-issue-1492-claude-md-path-alignment-design.md
+++ b/ICCardManager/docs/superpowers/specs/2026-05-16-issue-1492-claude-md-path-alignment-design.md
@@ -17,7 +17,7 @@
 |---|---|
 | `docs/design/` | `ICCardManager/docs/design/` |
 | `docs/manual/` | `ICCardManager/docs/manual/` |
-| `Resources/Templates/物品出納簿テンプレート.xlsx` | `ICCardManager/src/ICCardManager/Resources/Templates/物品出納簿テンプレート.xlsx` |
+| `Resources/Templates/物品出納簿テンプレート.xlsx` | `ICCardManager/src/ICCardManager/Resources/Templates/`（実体は `物品出納簿テンプレート（企業会計部局）.xlsx` と `物品出納簿テンプレート（市長事務部局）.xlsx` の 2 ファイル。元の単一ファイル名は実在しない） |
 | `docs/線区駅順コード/StationCode.csv` | `ICCardManager/docs/線区駅順コード/StationCode.csv` |
 | ASCII tree のルート `ICCardManager/` | リポジトリルートは `.`。`./docs/`（superpowers のみ）と `./tools/` がルートに別途存在 |
 

--- a/ICCardManager/docs/superpowers/specs/2026-05-16-issue-1492-claude-md-path-alignment-design.md
+++ b/ICCardManager/docs/superpowers/specs/2026-05-16-issue-1492-claude-md-path-alignment-design.md
@@ -1,0 +1,61 @@
+# Issue #1492 — CLAUDE.md のディレクトリ構成記載を実体パスに整合させる
+
+- 起票: 2026-05-08
+- 修正対象: `/CLAUDE.md`
+- 種別: documentation
+- 関連事故: 2026-05-08 リポジトリ全体レビュー時、Claude エージェントが `docs/design/` を探索して空振り
+
+## 1. 背景
+
+`/CLAUDE.md` の §「ディレクトリ構成」と §「参照ドキュメント」では、設計書・マニュアル・テンプレート・駅コード CSV をリポジトリルート直下にあるかのように記述している（例: `docs/design/`、`Resources/Templates/...`）。
+
+実体は `ICCardManager/` サブディレクトリ配下にあり、ルート直下の `./docs/` は superpowers プラグインキャッシュのみが存在する。エージェントが CLAUDE.md の記述通りに探索すると空振りする。
+
+## 2. 実体パスの調査結果
+
+| CLAUDE.md の記述 | 実体パス |
+|---|---|
+| `docs/design/` | `ICCardManager/docs/design/` |
+| `docs/manual/` | `ICCardManager/docs/manual/` |
+| `Resources/Templates/物品出納簿テンプレート.xlsx` | `ICCardManager/src/ICCardManager/Resources/Templates/物品出納簿テンプレート.xlsx` |
+| `docs/線区駅順コード/StationCode.csv` | `ICCardManager/docs/線区駅順コード/StationCode.csv` |
+| ASCII tree のルート `ICCardManager/` | リポジトリルートは `.`。`./docs/`（superpowers のみ）と `./tools/` がルートに別途存在 |
+
+CHANGELOG.md (`ICCardManager/CHANGELOG.md`) は既に正しく記述されているため対象外。
+
+## 3. 修正方針（Approach A: ルート起点で完全整合）
+
+### 3.1 ASCII tree
+
+起点を `.`（リポジトリルート）に変更し、`ICCardManager/` を level-2 ノードとして描画する。
+ルート直下に存在する `./docs/`（superpowers キャッシュ）と `./tools/`（補助スクリプト群）の存在も明示し、混同事故を防ぐ。
+
+### 3.2 「参照ドキュメント」セクション
+
+設計書・マニュアル・テンプレート・駅コード CSV の 4 件すべてに `ICCardManager/` プレフィックスを付与する。
+
+## 4. 検証方法
+
+ドキュメントのみの修正で、ビルド・テスト対象のコードは変更しない。代わりに以下の検証を行う:
+
+1. **ファイル存在チェック**: 修正後の各パスについて、現リポジトリ上で `ls` または `test -e` が成功することを目視確認する。
+2. **diff レビュー**: `git diff main -- CLAUDE.md` で意図通りの差分のみであることを確認する。
+
+## 5. テストの取り扱い
+
+`CLAUDE.md` はビルド対象ではないため単体テストは作成しない。代わりに本 PR の Description に「修正後の各パスが実体と一致していること」を確認した結果を箇条書きで記録する。
+
+## 6. ロールバック
+
+`git revert <commit>` で復元可能。リスクは極小。
+
+## 7. スコープ外
+
+- ルート直下 `./docs/` の整理（superpowers キャッシュは別途）
+- `./tools/` と `ICCardManager/tools/` の役割分担明確化（別 Issue で扱う）
+- 設計書本体（`02_DB設計書.md` 等）の内容更新
+
+## 8. 参考
+
+- Issue #1492
+- 関連既存ファイル: `/CLAUDE.md` §15–25, §64–70


### PR DESCRIPTION
## Summary

Closes #1492

- `/CLAUDE.md` §「ディレクトリ構成」の ASCII tree をリポジトリルート起点に書き換え、`ICCardManager/` をサブディレクトリとして描画
- ルート直下に偶然存在する `./docs/`（superpowers プラグインキャッシュ）と `./tools/` の存在を明示し、Claude エージェントが空振りする事故（2026-05-08 発生）の再発を防止
- §「参照ドキュメント」の 4 件すべてに `ICCardManager/` プレフィックスを付与
- Templates 行は実在しないファイル名「物品出納簿テンプレート.xlsx」を、実体である「物品出納簿テンプレート（企業会計部局）.xlsx」「物品出納簿テンプレート（市長事務部局）.xlsx」の 2 ファイルへ整合

## 実体パス検証結果

修正後の各パスについて `ls`/`test -e` で存在確認済み:

```
OK: ICCardManager/CHANGELOG.md
OK: ICCardManager/docs/design
OK: ICCardManager/docs/manual
OK: ICCardManager/src/ICCardManager/Resources/Templates
OK: ICCardManager/src/ICCardManager/Resources/Templates/物品出納簿テンプレート（企業会計部局）.xlsx
OK: ICCardManager/src/ICCardManager/Resources/Templates/物品出納簿テンプレート（市長事務部局）.xlsx
OK: ICCardManager/docs/線区駅順コード/StationCode.csv
```

## 設計書

- `ICCardManager/docs/superpowers/specs/2026-05-16-issue-1492-claude-md-path-alignment-design.md`

## Test plan

ドキュメントのみの変更のため自動テストは追加していません。レビュー時に以下を確認してください:

- [x] `CLAUDE.md` の ASCII tree がリポジトリルートから読んで正しく実体と一致しているか
- [x] §「参照ドキュメント」の 5 件のパスが、それぞれ実体に存在するか（リポジトリルートで `ls <path>` が成功するか）
- [x] 「物品出納簿テンプレート」の 2 ファイル併記（企業会計部局／市長事務部局）が正しいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
