### PR TITLE
fix: インストーラーの概要版マニュアル参照ファイル名を修正

### DIFF
--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -93,7 +93,7 @@ Source: "..\docs\manual\管理者マニュアル.md"; DestDir: "{app}\Docs"; Fla
 ; docx形式
 Source: "..\docs\manual\はじめに.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\ユーザーマニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
-Source: "..\docs\manual\ユーザーマニュアル概要版（修正版）.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
+Source: "..\docs\manual\ユーザーマニュアル概要版.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 Source: "..\docs\manual\管理者マニュアル.docx"; DestDir: "{app}\Docs"; Flags: ignoreversion
 ; PDF形式（Issue #642）
 Source: "..\docs\manual\はじめに.pdf"; DestDir: "{app}\Docs"; Flags: ignoreversion skipifsourcedoesntexist


### PR DESCRIPTION
## Summary
- インストーラー（.iss）が参照する概要版マニュアルのファイル名を修正
- `ユーザーマニュアル概要版（修正版）.docx` → `ユーザーマニュアル概要版.docx`
- convert-to-docx.ps1 が生成する実際のファイル名と一致させる

## Test plan
- [x] `ユーザーマニュアル概要版.docx` が存在することを確認
- [ ] インストーラービルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)