### PR TITLE
fix: Issue #1584 マップトドライブ検出の日本語共有名対応 (ASCII→UTF-8)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Unreleased
 
 **バグ修正**
-- Issue #1584 インストーラーのマップトドライブ検出で、日本語を含む共有名（例: `\\10.250.3.16\道路_建設推進課`）が `?` に化けて昇格セッションへの再マッピングが失敗する問題を修正。`Win32_MappedLogicalDisk.ProviderName` を一時ファイル経由で受け渡す際の `Out-File -Encoding ASCII` が non-ASCII を `?` に lossy 置換していたため、`-Encoding UTF8`（PowerShell 5.1 は BOM 付き UTF-8 を書き出し、Inno Setup の `LoadStringsFromFile` が BOM を自動検出して Unicode デコードする）に変更（#1584）
+- Issue #1584 インストーラーのマップトドライブ検出で、日本語を含む共有名（例: `\\10.250.3.16\道路_建設推進課`）が `?` に化けて昇格セッションへの再マッピングが失敗する問題を修正。`Win32_MappedLogicalDisk.ProviderName` を一時ファイル経由で受け渡す際の `Out-File -Encoding ASCII` が non-ASCII を `?` に lossy 置換していたため、`-Encoding UTF8`（PowerShell 5.1 は BOM 付き UTF-8 を書き出し、Inno Setup の `LoadStringsFromFile` が BOM を自動検出して Unicode デコードする）に変更（#1595）
 
 
 ### v2.9.2 (2026-05-28)

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 更新履歴
 
+### Unreleased
+
+**バグ修正**
+- Issue #1584 インストーラーのマップトドライブ検出で、日本語を含む共有名（例: `\\10.250.3.16\道路_建設推進課`）が `?` に化けて昇格セッションへの再マッピングが失敗する問題を修正。`Win32_MappedLogicalDisk.ProviderName` を一時ファイル経由で受け渡す際の `Out-File -Encoding ASCII` が non-ASCII を `?` に lossy 置換していたため、`-Encoding UTF8`（PowerShell 5.1 は BOM 付き UTF-8 を書き出し、Inno Setup の `LoadStringsFromFile` が BOM を自動検出して Unicode デコードする）に変更（#1584）
+
+
 ### v2.9.2 (2026-05-28)
 
 **ドキュメント**

--- a/ICCardManager/installer/ICCardManager.iss
+++ b/ICCardManager/installer/ICCardManager.iss
@@ -265,7 +265,12 @@ begin
   ProviderPrefix := 'ProviderName=';
 
   ExecAsOriginalUser(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
-    '-NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance Win32_MappedLogicalDisk | ForEach-Object { ''DeviceID='' + $_.DeviceID; ''ProviderName='' + $_.ProviderName; '''' } | Out-File -FilePath ''' + OutFile + ''' -Encoding ASCII"',
+    // -Encoding UTF8: PowerShell 5.1 は BOM 付き UTF-8 で書き出す。Inno Setup の
+    // LoadStringsFromFile は BOM を自動検出して Unicode にデコードするため、
+    // 日本語を含む共有名（例: \\server\道路_建設推進課）も正しく扱える。
+    // ASCII を指定すると non-ASCII 文字が ? に lossy 置換され、後段の net use が
+    // 不正なパスで失敗する（Issue #1584）。
+    '-NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance Win32_MappedLogicalDisk | ForEach-Object { ''DeviceID='' + $_.DeviceID; ''ProviderName='' + $_.ProviderName; '''' } | Out-File -FilePath ''' + OutFile + ''' -Encoding UTF8"',
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
   if not FileExists(OutFile) then Exit;


### PR DESCRIPTION
## 背景

PR #1589 (v2.9.1) でインストーラーのマップトドライブ検出を `wmic` から PowerShell + `Get-CimInstance Win32_MappedLogicalDisk` に置換したが、**日本語を含む共有名**を使用している環境では依然としてマップトドライブが昇格セッションに引き継がれず、共有フォルダ DB 配置ができない状態が報告された。

## 根本原因

該当環境（FINE ドメイン、`\\10.250.3.16\道路_建設推進課` 等の日本語 UNC 共有名）で診断スクリプトを実行した結果、以下が判明:

| 検出経路 | 結果 |
|---|---|
| `Win32_MappedLogicalDisk` を直接 `Get-CimInstance` で読む | ✅ 日本語含めて正しく取得 |
| `Win32_MappedLogicalDisk` → `Out-File -Encoding ASCII` → ファイル読込（**インストーラー実コマンド**） | ❌ `ProviderName: \\10.250.3.16\??_?????` のように `?` に化ける |

`Out-File -Encoding ASCII` は **non-ASCII 文字を破棄せず `?` に lossy 置換する** ため、後段の `net use K: "\\10.250.3.16\??_?????" /persistent:no` が不正パスで失敗していた。

開発者環境 (`\\DESKTOP-4HFLR8J\tmp`) では全 ASCII のため `?` 化が起きず、ローカル再現できなかった。

## 修正内容

`ICCardManager/installer/ICCardManager.iss:268` の `-Encoding ASCII` を `-Encoding UTF8` に変更（1行）。

- **PowerShell 5.1 の `Out-File -Encoding UTF8` は常に BOM 付き UTF-8 で書き出す**
- **Inno Setup の `LoadStringsFromFile` は BOM を自動検出して Unicode にデコードする**（同ファイル `ReadConfigFile` 周辺コメント参照）

両者を組み合わせることで日本語共有名が破壊されず受け渡される。次の保守者が誤って ASCII に戻さないよう、5 行のコメント（理由・連携仕様・lossy 置換特性）を追加。

## 検証

- 被影響ユーザー (PC065073, Windows 11 Pro 10.0.26100, PS 5.1.26100.1882) の診断スクリプト出力で根本原因を確認済み（手元保管）
- 開発者環境 (V: → `\\DESKTOP-4HFLR8J\tmp`) で診断スクリプト全 10 セクション正常動作確認済み
- 設計書側にマップトドライブ実装の記述はなく、CHANGELOG のみ同期更新

## Test plan

- [x] CI ビルドが通る
- [ ] 被影響ユーザー (FINE ドメイン / 日本語共有名) に修正版インストーラーを渡し、BrowseForFolder ダイアログで K:, L:, M:, R:, S: ドライブが表示されることを確認
- [x] 開発者環境 (ASCII 共有名) で従来通り動作することを確認（リグレッション防止）

## 関連

- 既存 Issue: #1584
- 前段 PR: #1589 (wmic → PowerShell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)