### PR TITLE
docs: 06_シーケンス図を実装へ整合（サウンドAPI・バックアップ手段・用語）（ドリフト監査 D1/D9）

### DIFF
--- a/ICCardManager/docs/design/06_シーケンス図.md
+++ b/ICCardManager/docs/design/06_シーケンス図.md
@@ -62,13 +62,13 @@ sequenceDiagram
         VM->>VM: 状態を WaitingForIcCard に変更
         VM->>VM: タイムアウトタイマー開始(60秒)
         VM->>VM: 画面表示更新
-    else ICカードの場合（職員証なしで直接タッチ）
+    else 交通系ICカードの場合（職員証なしで直接タッチ）
         VM->>VM: 履歴表示ダイアログを開く
     end
 
     Note over User,Sound: 状態: WaitingForIcCard
 
-    User->>PaSoRi: ICカードをタッチ
+    User->>PaSoRi: 交通系ICカードをタッチ
     PaSoRi->>Reader: カード検出
     Reader->>VM: CardRead イベント発火(IDm)
 
@@ -79,10 +79,10 @@ sequenceDiagram
         VM->>VM: カードの貸出状態を確認
         alt 未貸出（is_lent = 0）
             VM->>VM: 貸出処理を実行
-            VM->>Sound: PlayLend()
+            VM->>Sound: Play(SoundType.Lend)
         else 貸出中（is_lent = 1）
             VM->>VM: 返却処理を実行
-            VM->>Sound: PlayReturn()
+            VM->>Sound: Play(SoundType.Return)
         end
     end
 
@@ -151,7 +151,7 @@ sequenceDiagram
 
     LS-->>VM: LendingResult(Success = true)
 
-    VM->>Sound: PlayLend()
+    VM->>Sound: Play(SoundType.Lend)
     VM->>VM: 画面表示更新（貸出完了）
 ```
 
@@ -227,7 +227,7 @@ sequenceDiagram
 
     LS-->>VM: LendingResult(Success = true)
 
-    VM->>Sound: PlayReturn()
+    VM->>Sound: Play(SoundType.Return)
 
     alt バス利用あり
         VM->>VM: バス停入力ダイアログを表示
@@ -330,12 +330,12 @@ sequenceDiagram
         Note over VM: 前回が貸出なので、返却処理を実行
         VM->>LS: ReturnAsync(staffIdm, cardIdm, [])
         LS-->>VM: LendingResult(Success, OperationType = Return)
-        VM->>Sound: PlayReturn()
+        VM->>Sound: Play(SoundType.Return)
     else LastOperationType == Return
         Note over VM: 前回が返却なので、貸出処理を実行
         VM->>LS: LendAsync(staffIdm, cardIdm)
         LS-->>VM: LendingResult(Success, OperationType = Lend)
-        VM->>Sound: PlayLend()
+        VM->>Sound: Play(SoundType.Lend)
     end
 
     VM->>VM: 画面表示更新
@@ -358,7 +358,7 @@ sequenceDiagram
 
     Note over VM: 未登録のIDmを検出
 
-    VM->>Sound: Play(Warning)
+    VM->>Sound: Play(SoundType.Warning)
     VM->>Reader: ReadBalanceAsync(idm)
     Reader-->>VM: 残高（事前読み取り）
     VM->>Reader: ReadHistoryAsync(idm)
@@ -415,7 +415,7 @@ sequenceDiagram
         end
     end
 
-    alt ユーザーがICカードをタッチ
+    alt ユーザーが交通系ICカードをタッチ
         Timer->>Timer: Stop()
         Note over VM: 正常処理: 貸出/返却を実行
     end
@@ -470,7 +470,7 @@ sequenceDiagram
         LS-->>VM: LendingResult(Success = false, ErrorMessage)
     end
 
-    VM->>Sound: PlayError()
+    VM->>Sound: Play(SoundType.Error)
     VM->>VM: エラーメッセージを表示
     VM->>VM: 背景色を薄い赤に変更
 
@@ -618,7 +618,7 @@ sequenceDiagram
         SR-->>Dialog: Staff?
 
         alt 未登録の職員証
-            Dialog->>Sound: PlayError()
+            Dialog->>Sound: Play(SoundType.Error)
             Dialog->>Dialog: エラーメッセージ表示、再度待ち受け
         else 登録済み職員証
             Dialog->>Dialog: 認証成功 → ダイアログ閉じる
@@ -668,7 +668,7 @@ sequenceDiagram
 
     BS->>BS: Directory.CreateDirectory(backupPath)
     BS->>BS: ファイル名生成（backup_yyyyMMdd_HHmmss.db）
-    BS->>BS: File.Copy(DBファイル → バックアップ先)
+    BS->>BS: SQLite Backup API でバックアップ生成（BackupDatabase）
     BS->>BS: 古いバックアップ削除（30世代超過分）
 
     BS-->>VM: バックアップファイルパス
@@ -680,7 +680,7 @@ sequenceDiagram
     VM->>BS: RestoreFromBackup(backupFilePath)
 
     BS->>BS: バックアップファイル存在確認
-    BS->>DB: CloseConnection()
+    BS->>DB: SuspendConnections()
     Note right of DB: SQLite接続を閉じて<br/>ファイルロックを解除
 
     BS->>BS: 現在のDBを.tempに退避

--- a/ICCardManager/docs/design/06_シーケンス図.md
+++ b/ICCardManager/docs/design/06_シーケンス図.md
@@ -234,7 +234,7 @@ sequenceDiagram
     end
 
     alt 残高警告
-        VM->>Sound: PlayWarning()
+        VM->>Sound: Play(SoundType.Warning)
         VM->>VM: 警告メッセージを表示
     end
 
@@ -626,7 +626,7 @@ sequenceDiagram
     end
 
     alt タイムアウト（60秒経過）
-        Dialog->>Sound: PlayWarning()
+        Dialog->>Sound: Play(SoundType.Warning)
         Dialog->>Dialog: ダイアログ閉じる
         Auth->>Auth: App.IsAuthenticationActive = false
         Auth-->>VM: null（認証失敗）


### PR DESCRIPTION
## 概要

docs↔実装ドリフト監査の `safe_obvious_fix`。06_シーケンス図の記述を実装へ同期（doc のみ）。

## 修正

| 種別 | 修正 |
|---|---|
| サウンドAPI (D1) | 存在しない `PlayLend()`/`PlayReturn()`/`PlayError()`/`Play(Warning)` → 実API `Play(SoundType.Lend/Return/Error/Warning)`（`Infrastructure/Sound/ISoundPlayer.cs`、enum `SoundType`） |
| バックアップ手段 (D5) | §13 `File.Copy` → SQLite Backup API（`BackupService.BackupDatabase`）。01:222/02:584 と整合。リストアの `File.Copy`:687 は実装どおり残置 |
| リストア接続 (D1) | §13 `CloseConnection()` → 実メソッド `SuspendConnections()`（`BackupService.cs:248`） |
| 用語 (D9) | 単独「ICカード」3箇所 → 「交通系ICカード」 |

実装挙動の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)