### PR TITLE
docs: 02_DB設計書のマイグレーション履歴表・インデックス・SQL例を実装へ同期（ドリフト監査 D1/D5/D2）

### DIFF
--- a/ICCardManager/docs/design/02_DB設計書.md
+++ b/ICCardManager/docs/design/02_DB設計書.md
@@ -231,6 +231,7 @@ erDiagram
 - `idx_ledger_date` ON ledger(date)
 - `idx_ledger_summary` ON ledger(summary)
 - `idx_ledger_card_date` ON ledger(card_idm, date)
+- `idx_ledger_card_id` ON ledger(card_idm, id DESC)
 - `idx_ledger_lender` ON ledger(lender_idm)
 
 **外部キー:**
@@ -378,13 +379,13 @@ erDiagram
 | No. | クラス | 概要 | DEFAULT値 | 関連Issue |
 |-----|--------|------|-----------|-----------|
 | 001 | Migration_001_Initial | 初期スキーマ(staff / ic_card / ledger / ledger_detail / operation_log / settings)作成 | (Migration_001 の CREATE TABLE 内で個別定義) | - |
-| 002 | Migration_002_AddPointRedemption | `ledger_detail.is_point_redemption` カラム追加 | — (NULL許容) | - |
+| 002 | Migration_002_AddPointRedemption | `ledger_detail.is_point_redemption` カラム追加 | `is_point_redemption = 0` | #378 |
 | 003 | Migration_003_AddTripGroupId | `ledger_detail.group_id` カラム追加(乗継統合) | — (NULL許容) | #484 |
-| 004 | Migration_004_AddPerformanceIndexes | パフォーマンス向上用のインデックス追加(`idx_card_lent_deleted`, `idx_ledger_card_id` など) | — (インデックスのみ) | - |
+| 004 | Migration_004_AddPerformanceIndexes | パフォーマンス向上用のインデックス追加(`idx_card_lent_deleted`, `idx_ledger_card_id` など) | — (インデックスのみ) | #504 |
 | 005 | Migration_005_AddStartingPageNumber | `ic_card.starting_page_number` カラム追加(帳票開始ページ番号) | `starting_page_number = 1` | #510 |
 | 006 | Migration_006_AddRefundedStatus | `ic_card.is_refunded` / `refunded_at` カラム追加(払戻管理) | `is_refunded = 0` / `refunded_at` は NULL | #530 |
 | 007 | Migration_007_AddMergeHistory | `ledger_merge_history` テーブル追加(統合履歴とundo) | テーブル定義内に記載 | #548 |
-| 008 | Migration_008_AddCardTypeNumberUniqueIndex | `idx_card_type_number_active` UNIQUE 部分インデックス追加 | — (インデックスのみ) | - |
+| 008 | Migration_008_AddCardTypeNumberUniqueIndex | `idx_card_type_number_active` UNIQUE 部分インデックス追加 | — (インデックスのみ) | #1106 |
 | 009 | Migration_009_AddCarryoverTotals | `ic_card.carryover_income_total` / `carryover_expense_total` / `carryover_fiscal_year` カラム追加(年度途中導入時の累計初期値) | `carryover_income_total = 0` / `carryover_expense_total = 0` / `carryover_fiscal_year` は NULL | #1215 |
 
 > **DEFAULT 値の読み方**:
@@ -449,7 +450,7 @@ erDiagram
 ```sql
 -- 職員の論理削除
 UPDATE staff
-SET is_deleted = 1, deleted_at = datetime('now')
+SET is_deleted = 1, deleted_at = datetime('now', 'localtime')
 WHERE staff_idm = ?;
 
 -- 有効な職員のみ取得


### PR DESCRIPTION
## 概要

docs↔実装ドリフト監査の `safe_obvious_fix`。02_DB設計書を実マイグレーション/実クエリへ同期（doc のみ）。

## 修正（メイン実コード確認済み）

| 項目 | 修正 | 根拠 |
|---|---|---|
| DD-01 | §4 履歴表 Migration_002 の DEFAULT「— (NULL許容)」→ `is_point_redemption = 0` | `Migration_002`:26 `INTEGER DEFAULT 0` |
| MIG-02 | §4 履歴表 関連Issue欄に 002→#378 / 004→#504 / 008→#1106 を補完 | 各 Migration の remarks |
| DBDESIGN-02 | §3.3 ledger インデックス一覧に `idx_ledger_card_id` を追加（§5.1 には既載で分裂） | `Migration_004`:27 |
| DBDESIGN-03 | §10 論理削除SQL例 `datetime('now')` → `datetime('now', 'localtime')` | `CardRepository`:372 / `StaffRepository`:203 |

実装挙動の変更なし。JSON整形例（DBDRIFT-01）・ヘルスチェックSQL（SM-01、#1110 の意図）は別所見として分離。

🤖 Generated with [Claude Code](https://claude.com/claude-code)