### PR TITLE
docs: 04_機能設計書を実装へ整合（出力ファイル名・削除SQL・貸出中摘要の全角）（ドリフト監査 D1/D9）

### DIFF
--- a/ICCardManager/docs/design/04_機能設計書.md
+++ b/ICCardManager/docs/design/04_機能設計書.md
@@ -125,7 +125,7 @@ flowchart TD
 |----------|----------|
 | 1 | カードの貸出状態を確認(`is_lent = 0` であること) |
 | 2 | 職員情報を取得 |
-| 3 | 貸出レコード(`ledger`)を作成(`summary = "(貸出中)"`) |
+| 3 | 貸出レコード(`ledger`)を作成(`summary = "（貸出中）"`) |
 | 4 | カードの貸出状態を更新(`is_lent = 1`, `last_lent_at`, `last_lent_staff`) |
 | 5 | 操作ログを記録 |
 | 6 | 音声フィードバック(ピッ) |
@@ -294,7 +294,7 @@ flowchart TD
 | チャージのみ | チャージのみ | 役務費によりチャージ |
 | ポイント還元 | ポイント還元のみ | ポイント還元 |
 | 払い戻し | カード払い戻し時 | 払戻しによる払出 |
-| 貸出中 | 貸出時 | (貸出中) |
+| 貸出中 | 貸出時 | （貸出中） |
 
 ### 5.3 往復判定ロジック
 
@@ -388,7 +388,7 @@ IF consolidatedStart == consolidatedEnd:
 
 | メソッド | 戻り値 |
 |----------|--------|
-| `GetLendingSummary()` | "(貸出中)" |
+| `GetLendingSummary()` | "（貸出中）" |
 | `GetChargeSummary(departmentType)` | "役務費によりチャージ"(部局種別で文言可変) |
 | `GetRefundSummary()` | "払戻しによる払出" |
 | `GetPointRedemptionSummary()` | "ポイント還元" |
@@ -456,7 +456,7 @@ THEN
 
 - ファイル形式: Excel(.xlsx)
 - テンプレート: `Resources/Templates/物品出納簿テンプレート（企業会計部局）.xlsx`・`物品出納簿テンプレート（市長事務部局）.xlsx`（部署設定に応じて TemplateResolver が選択）
-- 出力ファイル名: `物品出納簿_{カード種別}_{管理番号}_{年}年{月}月.xlsx`
+- 出力ファイル名: `物品出納簿_{カード種別}_{管理番号}_{年度}年度.xlsx`（Issue #477: 年度ごとに1ファイル・月はワークシートで分割。例: `物品出納簿_はやかけん_H001_2024年度.xlsx`）
 
 ### 8.2 帳票レイアウト
 
@@ -517,7 +517,7 @@ THEN
 
 ### 8.5 除外データ
 
-- `summary = "(貸出中)"` のレコードは出力しません
+- `summary = "（貸出中）"` のレコードは出力しません
 - 論理削除されたカード・職員も履歴は出力します
 
 ### 8.6 和暦変換
@@ -908,7 +908,7 @@ ReleaseLockReference(cardIdm):
 ### 16.3 実装
 
 ```sql
-DELETE FROM ledger WHERE date < date('now', '-6 years');
+DELETE FROM ledger WHERE date(date) < date('now', '-6 years', 'localtime');
 ```
 
 ### 16.4 最適化


### PR DESCRIPTION
## 概要

docs↔実装ドリフト監査の `safe_obvious_fix`。04_機能設計書を実装へ同期（doc のみ）。

## 修正（メイン実コード確認済み）

| 項目 | 修正 | 根拠 |
|---|---|---|
| RPT-03 | §8.1 出力ファイル名 月単位 `{年}年{月}月` → 年度単位 `{年度}年度` | `ReportService.GetFiscalYearFileName`（Issue #477） |
| R3-04 | §16.3 自動削除SQL例に `date()` ラップ + `localtime` を反映 | `DbContext.cs:1036` |
| RPT-003 | 貸出中摘要 半角 `(貸出中)` → 全角 `（貸出中）`（4箇所） | business-logic.md / 06§3 と一致、除外フィルタは全角完全一致 |

## 対象外（誤検出・要追加検証）

- **RPT-01（繰越摘要文字列）はメイン検証で doc が実装と一致（誤検出）と判明** → 修正せず。
- RPT-002（§8.3 累計説明）/ R3-03（§16.2 operation_log 列挙）/ R3-05（JSON casing）は要追加検証のため別途。

実装挙動の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)