### PR TITLE
docs: 03_画面設計書 §4.1 ヘッダー色を SSOT 実態へ是正（HeaderBackgroundBrush）（ドリフト監査 D1）

### DIFF
--- a/ICCardManager/docs/design/03_画面設計書.md
+++ b/ICCardManager/docs/design/03_画面設計書.md
@@ -1104,7 +1104,7 @@ stateDiagram-v2
 | エラー | #FFEBEE | 薄い赤 | `ErrorBackgroundBrush` | 警告・注意 |
 | 補足ヒント文（前景） | #795548 | 茶（マテリアル Brown 700） | `HintForegroundBrush` | 「💡 ヒント」「⚠ 注意」等の説明文の文字色。背景色とは別に前景色のみキー化（Issue #1461） |
 | 行ハイライト（登録・更新・復元後） | #FFF9C4 | 薄い黄 | `RowHighlightColor`（Color リソース） | `DataGridHighlightHelper` が該当行を一瞬ハイライト→フェードアウトする際の色。`ColorAnimation` は Brush ではなく Color を補間するため、例外的に `SolidColorBrush` ではなく `<Color>` リソースで定義（Issue #1613） |
-| ヘッダー | #2196F3 | 青 | -（直接指定） | システムカラー |
+| ヘッダー | #2196F3 | 青 | `HeaderBackgroundBrush` | システムカラー。`AccessibilityStyles.xaml` で SSOT 化（`DynamicResource` 参照） |
 
 > **色値の Single Source of Truth**: 上表の色値は `Resources/Styles/AccessibilityStyles.xaml` のブラシキー（アニメーション用途のみ `Color` リソース）で定義されており、View からは `DynamicResource` で参照する。色値そのものを XAML/コードに直接書かないこと(Issue #1392、Issue #1461、Issue #1613)。コードビハインドからは `Application.Current.TryFindResource("KeyName") as Brush`（または `FindResource`）で取得すること(`new SolidColorBrush(Color.FromRgb(...))` 禁止)。ViewModel/DTO で行ごとに色を切り替える場合は色値文字列ではなく**リソースキー名**を返し、XAML 側で `ResourceKeyToBrushConverter` 経由でブラシ解決する。
 


### PR DESCRIPTION
## 概要

docs↔実装ドリフト監査の `safe_obvious_fix`（D1）。03 §4.1 色表がヘッダー色 #2196F3 を「-（直接指定）」と記すが、実際は `AccessibilityStyles.xaml:53` の `HeaderBackgroundBrush` として SSOT 化済み。ブラシキーを明記し、他行（`ReturnBackgroundBrush` 等）と表記を揃えた。

doc のみ・実装挙動の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)