### PR TITLE
chore: SharedModeMonitor のヘルスチェック間隔コメントを実定数 15秒へ是正（ドリフト監査 D1）

### DIFF
--- a/ICCardManager/src/ICCardManager/Services/SharedModeMonitor.cs
+++ b/ICCardManager/src/ICCardManager/Services/SharedModeMonitor.cs
@@ -8,7 +8,7 @@ namespace ICCardManager.Services
     /// 共有フォルダモードでのDB接続監視と同期表示を担当するサービス
     /// </summary>
     /// <remarks>
-    /// MainViewModelから抽出。30秒ごとのDB接続ヘルスチェックと
+    /// MainViewModelから抽出。15秒ごと（HealthCheckIntervalSeconds）のDB接続ヘルスチェックと
     /// 1秒ごとの同期経過時間表示を管理する。
     /// </remarks>
     public class SharedModeMonitor : IDisposable


### PR DESCRIPTION
## 概要

docs↔実装ドリフト監査の `safe_obvious_fix`（D1・コードコメント）。`SharedModeMonitor` のクラス XML コメントが「30秒ごとのDB接続ヘルスチェック」と記すが、実定数は `HealthCheckIntervalSeconds = 15`（Issue #1493 で 30→15 に短縮済み）。コメントのみ是正。

- 検証: `dotnet build`（Debug）成功・0 警告 0 エラー。挙動の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)