### PR TITLE
fix: Issue #1614 生 ex.Message の UI 露出残存（職員管理・操作ログエクスポート）を是正

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+**バグ修正**
+- Issue #1614 例外メッセージ品質ガイドライン違反（生 `ex.Message` の UI 露出）の残存を是正した。`StaffManageViewModel`（職員の保存／削除の catch、計2箇所）と `OperationLogSearchViewModel`（操作ログのエクスポートの catch）が、捕捉した例外の生 `ex.Message` を `StatusMessage`／`ShowError` ダイアログへ直接出していた。`ex.Message` は SQLite エラー等の英語・技術用語を含みうるため職員には解読不能で、内部実装の露出にもなる。各 catch を `ExceptionMessageFormatter.ToUserMessage(ex, 操作名)` 経由の「何が／なぜ／どうすれば」3要素文言へ差し替え、技術的詳細は `ErrorDialogHelper.LogException(ex, 操作名)`（両 VM とも `ILogger` 未注入のためファイルログ機構を使用）へ逃がした。回帰防止として、生の技術詳細を漏らさず操作名を含み「～ください。」で終わることを固定する単体テストを3件追加（`StaffManageViewModelTests` 2件・`OperationLogSearchViewModelTests` 1件）。なお `MainViewModel` の仮想タッチエラー（`#if DEBUG` 限定のデバッグ機能で一般ユーザーに露出しない）、起動時致命エラーとクラッシュ診断用の `StackTrace` 表示（意図的）はスコープ外。07_テスト設計書 §1.1a（3,563→3,566件）を同期更新（#1614）
+
 **ドキュメント**
 - ドリフト監査（B グループ）規約・設計書の旧仕様記述を実装の正仕様へ同期した。(a) **ヘルスチェック SQL**: `02_DB設計書 §10`・`04_機能設計書`・`05_クラス設計書` が `SELECT 1` と例示していたが、実装 `DbContext.CheckConnection()` は `SELECT COUNT(*) FROM sqlite_master`（Issue #1110: 定数の `SELECT 1` では実ファイルアクセスが発生せず切断を検出できないため sqlite_master 読み取りを強制）へ修正。(b) **VACUUM 実行タイミング**: `business-logic.md`・`04_機能設計書`・`00a_技術スタック用語集` が「月初」と記していたが、実装 `App.xaml.cs` は `today.Day >= 10`（毎月10日以降の最初の起動時）でのみ試行するため「10日以降の初回起動時」へ修正。(c) **CA2007 適用範囲**: `async-configureawait.md` が「Service 層のみ対象」と記していたが、`.editorconfig` は `src/ICCardManager` 配下全体を `suggestion`（ViewModels / Views / tests のみ `none`）とするため実態へ修正。いずれも doc のみの修正で実装挙動の変更なし（SEQ-AUTH-01 / ドリフト監査 B）
 - ドリフト監査（A-2 / SHARED-R5-01）`journal_mode` の記述を実態へ同期した。`business-logic.md` / `02_DB設計書 §10` が「共有モード時: journal_mode=DELETE」と共有限定で記していたが、実装 `DbContext.ConfigurePragmas` は `IsSharedMode` で分岐せず**全接続に DELETE→TRUNCATE→PERSIST を試行**する（WAL は SMB 上で問題を起こすため使わない）。doc を「journal_mode=DELETE は全接続に適用（主目的は共有モードの安全性）、busy_timeout のみモード別」へ修正。doc のみ・実装挙動の変更なし（SHARED-R5-01）

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 3,563件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 3,566件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **3,589件** | 全件パス（最終同期: SEQ-AUTH-01 で履歴統合・分割に職員認証ゲートを追加し、認証キャンセル時に統合/分割を実行しないことを固定する単体テストを 2 件追加（`MergeHistoryLedgers_認証キャンセル時_統合を実行しない` / `SaveWithFullSplit_認証キャンセル時_分割せず中止メッセージを表示する`、`--list-tests` 換算 +2 件）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,563 + 26 = 3,589 と比較） |
+| **合計** | **3,592件** | 全件パス（最終同期: Issue #1614 で `StaffManageViewModel`（職員の保存／削除）・`OperationLogSearchViewModel`（操作ログのエクスポート）の catch が生の `ex.Message` を UI へ露出していたのを `ExceptionMessageFormatter.ToUserMessage` 経由の 3 要素文言へ是正し、生の技術詳細を漏らさず操作名を含み「～ください。」で終わることを固定する単体テストを 3 件追加（`SaveAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail` / `DeleteAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail` / `ExportToExcelFileAsync_失敗時_生の例外メッセージを漏らさず3要素文言を表示すること`、`--list-tests` 換算 +3 件）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,566 + 26 = 3,592 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >

--- a/ICCardManager/src/ICCardManager/ViewModels/OperationLogSearchViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/OperationLogSearchViewModel.cs
@@ -419,8 +419,10 @@ public partial class OperationLogSearchViewModel : ViewModelBase
             }
             catch (Exception ex)
             {
-                errorMessage = ex.Message;
-                SetStatus($"エクスポートエラー: {ex.Message}", true);
+                // Issue #1614: 生の ex.Message を UI に出さず、3要素準拠の文言を表示。技術詳細はログへ逃がす。
+                ErrorDialogHelper.LogException(ex, "操作ログのエクスポート");
+                errorMessage = ExceptionMessageFormatter.ToUserMessage(ex, "操作ログのエクスポート");
+                SetStatus(errorMessage, true);
             }
         }
 
@@ -428,7 +430,7 @@ public partial class OperationLogSearchViewModel : ViewModelBase
         // スコープ内で表示するとMessageBoxがモーダルで待機する間プログレスバーが残り続ける。
         if (errorMessage != null)
         {
-            _dialogService.ShowError($"エクスポートに失敗しました。\n\n{errorMessage}", "エクスポートエラー");
+            _dialogService.ShowError(errorMessage, "エクスポートエラー");
         }
         else if (exportedCount.HasValue)
         {

--- a/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/StaffManageViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using ICCardManager.Common;
 using ICCardManager.Common.Messages;
 using ICCardManager.Data.Repositories;
 using ICCardManager.Dtos;
@@ -404,11 +405,10 @@ namespace ICCardManager.ViewModels
             }
             catch (Exception ex)
             {
-                StatusMessage = $"エラー: {ex.Message}";
+                // Issue #1614: 生の ex.Message を UI に出さず、3要素準拠の文言を表示。技術詳細はログへ逃がす。
+                ErrorDialogHelper.LogException(ex, "職員の保存");
+                StatusMessage = ExceptionMessageFormatter.ToUserMessage(ex, "職員の保存");
                 IsStatusError = true;
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine($"[StaffManageViewModel] SaveAsync エラー: {ex}");
-#endif
             }
         }
 
@@ -458,11 +458,10 @@ namespace ICCardManager.ViewModels
             }
             catch (Exception ex)
             {
-                StatusMessage = $"エラー: {ex.Message}";
+                // Issue #1614: 生の ex.Message を UI に出さず、3要素準拠の文言を表示。技術詳細はログへ逃がす。
+                ErrorDialogHelper.LogException(ex, "職員の削除");
+                StatusMessage = ExceptionMessageFormatter.ToUserMessage(ex, "職員の削除");
                 IsStatusError = true;
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine($"[StaffManageViewModel] DeleteAsync エラー: {ex}");
-#endif
             }
         }
 

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/OperationLogSearchViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/OperationLogSearchViewModelTests.cs
@@ -744,6 +744,39 @@ public class OperationLogSearchViewModelTests
         _viewModel.IsBusy.Should().BeFalse();
     }
 
+    /// <summary>
+    /// エクスポート失敗時、生の <c>ex.Message</c> を ShowError／StatusMessage に漏らさず、
+    /// 3要素準拠（操作名を含み「～ください。」で終わる）の文言を表示すること（Issue #1614）。
+    /// </summary>
+    [Fact]
+    public async Task ExportToExcelFileAsync_失敗時_生の例外メッセージを漏らさず3要素文言を表示すること()
+    {
+        // Arrange
+        const string rawTechnicalDetail = "Object reference not set to an instance of an object.";
+        var tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"op_{Guid.NewGuid()}.xlsx");
+        _repoMock
+            .Setup(r => r.SearchAllAsync(It.IsAny<OperationLogSearchCriteria>()))
+            .ThrowsAsync(new InvalidOperationException(rawTechnicalDetail));
+
+        string? shownMessage = null;
+        _dialogServiceMock
+            .Setup(d => d.ShowError(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((message, _) => shownMessage = message);
+
+        // Act
+        await _viewModel.ExportToExcelFileAsync(tempPath);
+
+        // Assert - ダイアログ
+        shownMessage.Should().NotBeNull();
+        shownMessage.Should().NotContain(rawTechnicalDetail);   // 生の技術詳細が漏れない
+        shownMessage.Should().Contain("操作ログのエクスポート");  // 「何が」= 操作名
+        shownMessage.Should().EndWith("ください。");             // 行動指示で終わる
+
+        // Assert - ステータスバー
+        _viewModel.StatusMessage.Should().NotContain(rawTechnicalDetail);
+        _viewModel.StatusMessage.Should().Contain("操作ログのエクスポート");
+    }
+
     #endregion
 
     #region Issue #1548/#1507: PageNumberDisplay / PageInfo 依存通知

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/StaffManageViewModelTests.cs
@@ -377,6 +377,33 @@ public class StaffManageViewModelTests
         _viewModel.StatusMessage.Should().Contain("失敗");
     }
 
+    /// <summary>
+    /// 保存中に例外が発生した場合、生の <c>ex.Message</c> を漏らさず
+    /// 3要素準拠（操作名を含み「～ください。」で終わる）の文言を表示すること（Issue #1614）。
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail()
+    {
+        // Arrange
+        const string rawTechnicalDetail = "SQLite Error 19: UNIQUE constraint failed";
+        _viewModel.StartNewStaff();
+        _viewModel.EditStaffIdm = "FFFF000000000001";
+        _viewModel.EditName = "田中太郎";
+
+        _staffRepositoryMock.Setup(r => r.GetByIdmAsync("FFFF000000000001", true)).ReturnsAsync((Staff?)null);
+        _staffRepositoryMock.Setup(r => r.InsertAsync(It.IsAny<Staff>()))
+            .ThrowsAsync(new Exception(rawTechnicalDetail));
+
+        // Act
+        await _viewModel.SaveAsync();
+
+        // Assert
+        _viewModel.IsStatusError.Should().BeTrue();
+        _viewModel.StatusMessage.Should().NotContain(rawTechnicalDetail);   // 生の技術詳細が漏れない
+        _viewModel.StatusMessage.Should().Contain("職員の保存");             // 「何が」= 操作名
+        _viewModel.StatusMessage.Should().EndWith("ください。");             // 行動指示で終わる
+    }
+
     #endregion
 
     #region 削除テスト
@@ -443,6 +470,31 @@ public class StaffManageViewModelTests
 
         // Assert
         _viewModel.StatusMessage.Should().Contain("失敗");
+    }
+
+    /// <summary>
+    /// 削除中に例外が発生した場合、生の <c>ex.Message</c> を漏らさず
+    /// 3要素準拠（操作名を含み「～ください。」で終わる）の文言を表示すること（Issue #1614）。
+    /// </summary>
+    [Fact]
+    public async Task DeleteAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail()
+    {
+        // Arrange
+        const string rawTechnicalDetail = "SQLite Error 5: database is locked";
+        var staff = new StaffDto { StaffIdm = "FFFF000000000001", Name = "田中太郎" };
+        _viewModel.SelectedStaff = staff;
+
+        _staffRepositoryMock.Setup(r => r.DeleteAsync("FFFF000000000001"))
+            .ThrowsAsync(new Exception(rawTechnicalDetail));
+
+        // Act
+        await _viewModel.DeleteAsync();
+
+        // Assert
+        _viewModel.IsStatusError.Should().BeTrue();
+        _viewModel.StatusMessage.Should().NotContain(rawTechnicalDetail);   // 生の技術詳細が漏れない
+        _viewModel.StatusMessage.Should().Contain("職員の削除");             // 「何が」= 操作名
+        _viewModel.StatusMessage.Should().EndWith("ください。");             // 行動指示で終わる
     }
 
     #endregion


### PR DESCRIPTION
## 概要

ドリフト監査（D グループ／EM-01）で確認した、エラーメッセージ品質ガイドライン（`.claude/rules/error-messages.md` / Issue #1614）違反の**残存**を是正します。

捕捉した例外の生 `ex.Message` を UI へ直接出していた箇所が ViewModel 層に残っていました。`ex.Message` は SQLite エラー等の英語・技術用語を含みうるため、職員には解読不能で内部実装の露出にもなります。

## 対象（期待 vs 実際）

| 箇所 | 修正前（実際） | 修正後（期待） |
|------|----------------|----------------|
| `StaffManageViewModel.SaveAsync` catch | `StatusMessage = $"エラー: {ex.Message}"` | `ToUserMessage(ex, "職員の保存")` + `LogException` |
| `StaffManageViewModel.DeleteAsync` catch | `StatusMessage = $"エラー: {ex.Message}"` | `ToUserMessage(ex, "職員の削除")` + `LogException` |
| `OperationLogSearchViewModel.ExportToExcelFileAsync` catch | `errorMessage = ex.Message` → `ShowError($"…\n\n{errorMessage}")` / `SetStatus($"…{ex.Message}")` | `ToUserMessage(ex, "操作ログのエクスポート")` + `LogException` |

## 実装方針

- 各 catch を `ExceptionMessageFormatter.ToUserMessage(ex, 操作名)` 経由の「何が／なぜ／どうすれば」3要素文言へ差し替え。
- 技術詳細（`ex.Message`・スタックトレース）は `ErrorDialogHelper.LogException(ex, 操作名)` でファイルログへ逃がす（両 VM とも `ILogger` 未注入のため、error-messages.md の指示どおりファイルログ機構を使用）。
- `StaffManageViewModel` に `using ICCardManager.Common;` を追加（`OperationLogSearchViewModel` は既存）。

## スコープ外（意図的・非バグと判定）

- **`MainViewModel` 仮想タッチエラー**（`MessageBox.Show(...{ex.Message}...)`）: メソッド全体が `#if DEBUG` 限定のデバッグ機能で、一般ユーザーには露出しない。
- **起動時致命エラー（`App.xaml.cs`）・クラッシュ診断用 `StackTrace` 表示（`ErrorDialogHelper`）**: 障害解析のため意図的に技術詳細を表示している。
- **`AppException` の `UserFriendlyMessage` 尊重**: 整備済みのユーザー向け文言をそのまま使う設計（`ToUserMessage` も同様に尊重）。

## テスト

回帰防止の単体テストを **3件追加**（いずれも「生の技術詳細を漏らさない／操作名を含む／『～ください。』で終わる」を検証）:

- `StaffManageViewModelTests.SaveAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail`
- `StaffManageViewModelTests.DeleteAsync_WhenExceptionThrown_ShouldShowUserFriendlyMessageWithoutRawDetail`
- `OperationLogSearchViewModelTests.ExportToExcelFileAsync_失敗時_生の例外メッセージを漏らさず3要素文言を表示すること`

検証結果:
- 本体ビルド: 警告0・エラー0
- 追加3テスト: 合格
- 関連2テストクラス（StaffManage / OperationLogSearch）: 81件 合格・回帰なし
- Release 構成 `--list-tests` 実測: 3,566件（3,563 +3）→ `07_テスト設計書` §1.1a を同期更新（CI `test-count-sync` 整合）

## ドキュメント

- `CHANGELOG.md` `### Unreleased` に追記
- `docs/design/07_テスト設計書.md` §1.1a（3,563→3,566件・合計3,592件）を同期更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)
