### PR TITLE
fix: リリース時の CHANGELOG 二重記載を根治（bump-version の自動生成と手動キュレーションの重複解消）

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -17,21 +17,7 @@
 - ドリフト監査（CLAUDE-R5-02 / R5-03・superpowers 設計 spec の分裂統合）プロジェクトの設計 spec が `docs/superpowers/specs/`（root・24本）と `ICCardManager/docs/superpowers/specs/`（19本）の2か所に分裂していたため、CLAUDE.md が宣言する正典「設計書は `ICCardManager/docs/` 配下」および Issue #1492（パス整合）の方針に従い、root の spec を `ICCardManager/docs/superpowers/specs/` へ集約した（計43本）。重複していた #1487 は root 側が「静的解析のみ」の旧ドラフト、ICCardManager 側が「csproj 物理除外」の実装済み最終版だったため root 旧ドラフトを破棄。spec への参照（`.claude/rules/migrations.md` / `async-configureawait.md`、`07_テスト設計書`、`docs/superpowers/plans/` 配下のリンク）を新パスへ更新し、CLAUDE.md のディレクトリ構成記述（root `docs/` は superpowers ワークフロー成果物、設計 spec は ICCardManager 配下）を実態へ修正。CHANGELOG の過去リリース記録（歴史的記述）と plans 本体は据え置き。doc 構成の整理のみ・実装挙動の変更なし（ドリフト監査 CLAUDE-R5-02 / CLAUDE-R5-03 / Issue #1492）
 - ドリフト監査（ACA-R4-01・テストの ConfigureAwait 規約の適用範囲明記）`async-configureawait.md` の「テストコードに ConfigureAwait(false) を付けない」規約に対し一部テストが該当文字列を含んでいたが、調査の結果これらは (1) ConfigureAwait を解説するコメント、(2) 本番メソッドを override するテストダブル（本番規約を踏襲）、(3) `Task.Delay`/`Task.WhenAll` 等フレームワーク基本型の await（UI 文脈非依存）であり、規約が狙う「SUT の async API を await するテスト本体」の違反ではないと判明。規約に適用範囲（対象＝テスト本体の SUT await、対象外＝コメント言及・テストダブルの override・フレームワーク基本型 await）を明記して齟齬を解消。doc のみ・テスト変更なし（ドリフト監査 ACA-R4-01 / Issue #1287）
 - ドリフト監査（EM-R5-01 / SHARED-R5-02・規約の役割分担と適用範囲の明記）(a) **例外→文言マッピングの併存（EM-R5-01）**: `ErrorDialogHelper.GetErrorInfo`（致命エラーダイアログ用・`SYS00x` コード付き・「なぜ」1要素）と `ExceptionMessageFormatter.ToUserMessage`（通常エラー用・3要素）で例外種別→文言マッピングが2か所に併存していたため、`error-messages.md` に役割分担表を追記。`GetErrorInfo` が3要素を満たさないのは致命エラー時にエラーコード＋スタックトレースでの原因究明を優先する設計判断であり違反ではない旨、通常エラー経路では `ToUserMessage` を使う旨を明記（現状維持・コード変更なし）。(b) **VACUUM 月次ロックの適用範囲（SHARED-R5-02）**: `business-logic.md` が VACUUM の月次 CAS ロックを共有フォルダモード節にのみ記載していたが、実装（`App.xaml.cs` の `Day>=10` ＋ `TryAcquireMonthlyVacuumLockAsync`）は全モードで動作する（ローカルは競合なしで常に獲得）ため、全モード動作である旨を注記。いずれも doc のみ・実装挙動の変更なし。なお UISSOT-R4-01/R5-01（03 §4.1 は色値とブラシキーの参照カタログで SSOT 原則は明記済み）と BL-R5-03/04（摘要8パターン・タイムアウト遷移は記載済み）は非ドリフトのため変更なし（ドリフト監査 EM-R5-01 / SHARED-R5-02）
-
-**バグ修正**
-- 用語統一CIガードがトースト文言を走査できていなかった問題を是正（TERM-R4-01/R5-01）（#1664）
-- Issue #1614 生 ex.Message の UI 露出残存（職員管理・操作ログエクスポート）を是正（#1614）
-
-**ドキュメント**
-- needs_human 2件（EM-R5-01 / SHARED-R5-02）の方針を規約に明記（#1668）
-- テストの ConfigureAwait 規約に適用範囲を明記（ACA-R4-01）（#1667）
-- ドリフト監査 H グループ（needs_human のうち一意修正可能な doc 2件）を実態へ同期（#1665）
-- ドリフト監査 G グループ（設計書クラス図/シーケンス図 medium/low 3件）を実態へ同期（#1663）
-- ドリフト監査 F グループ（残 SAFE doc-only 6件）を実態へ一括同期（#1662）
-- 事実確認系の doc を実態へ同期（JSON キー casing・PaSoRi 対応機種）（ドリフト監査 E）（#1660）
-- 削除方針の過少記述を実態へ追記（operation_log の6年削除・ledger 個別物理削除経路）（ドリフト監査 C）（#1659）
-- CHANGELOG v2.9.4 の重複エントリを整理（bump-version 自動生成と手動キュレーションの重複）（#1658）
-- 規約・設計書の旧仕様記述を実装へ同期（ヘルスチェックSQL・VACUUM・CA2007・journal_mode）（ドリフト監査 B + A-2）（#1654）
+- CHANGELOG v2.9.4 の重複エントリを整理（bump-version の自動生成エントリと手動キュレーション本文の二重記載を解消）（#1658）
 
 ### v2.9.4 (2026-06-18)
 

--- a/ICCardManager/tools/bump-version.ps1
+++ b/ICCardManager/tools/bump-version.ps1
@@ -233,7 +233,7 @@ $readmeContent = Get-Content $ReadmePath -Raw -Encoding UTF8
 $readmeContent = $readmeContent -replace '最新バージョン: \*\*v[^*]+\*\* \([^)]+\)', "最新バージョン: **v${NewVersion}** (${Today})"
 Write-Success "README.md: v${NewVersion} (${Today})"
 
-# 3c. CHANGELOG.md — 既存 ### Unreleased があれば見出しを vX.Y.Z にリネーム+自動生成エントリを追記、なければ新規挿入
+# 3c. CHANGELOG.md — 既存 ### Unreleased があれば見出しを vX.Y.Z に昇格（手動キュレーション本文を正典とし、自動生成は本文が空の時のみフォールバック採用）、なければ新規挿入
 # Issue: bump-version.ps1 が常に「# 更新履歴」直後にセクションを挿入していたため、
 # 既存の Unreleased セクションが新バージョンと前バージョンの間に孤児化していた（v2.8.0/v2.8.1 で発生）
 $changelogContent = Get-Content $ChangelogPath -Raw -Encoding UTF8
@@ -243,17 +243,26 @@ $unreleasedRegex = [regex]'(?ms)### Unreleased[ \t]*\r?\n(.*?)(?=\r?\n### |\z)'
 $unreleasedMatch = $unreleasedRegex.Match($changelogContent)
 
 if ($unreleasedMatch.Success) {
-    # 既存 Unreleased を統合: 見出しを vX.Y.Z (date) にリネームし、自動生成エントリを末尾に追記
+    # 既存 Unreleased を昇格: 見出しを vX.Y.Z (date) にリネームする。
+    # 運用上、変更内容は PR ごとに ### Unreleased へ手動キュレーションされており、これが正典（SSOT）。
+    # → 手動キュレーション本文がある場合はコミット由来の自動生成エントリを「追記しない」。
+    #   以前は両方を残していたため毎リリースで二重記載が発生していた（v2.9.4 #1658 / v2.9.5 で手動整理した再発バグ）。
+    # 本文が空の Unreleased（見出しだけ先置きされていた）場合に限り、フォールバックとして自動生成エントリを採用する。
     $unreleasedBody = $unreleasedMatch.Groups[1].Value.TrimEnd()
     $newSection = "### v${NewVersion} (${Today})"
     if ($unreleasedBody) {
+        # 手動キュレーション済み → これを正典として採用し、自動生成は破棄（二重記載防止）
         $newSection += "`n${unreleasedBody}"
-    }
-    if ($hasEntries) {
+        Write-Success "CHANGELOG.md: 既存 ### Unreleased を v${NewVersion} へ昇格（手動キュレーション本文を採用。コミット由来の自動生成エントリは二重記載防止のため破棄）"
+    } elseif ($hasEntries) {
+        # Unreleased が空 → フォールバックでコミット由来エントリを採用
         $autoGenBody = ($changelogSection -replace '^### v[^\r\n]+\r?\n', '').TrimEnd()
         if ($autoGenBody) {
             $newSection += "`n${autoGenBody}"
         }
+        Write-Success "CHANGELOG.md: 空の ### Unreleased を v${NewVersion} へ昇格（コミット由来の自動生成エントリを採用）"
+    } else {
+        Write-Success "CHANGELOG.md: ### Unreleased を v${NewVersion} へ昇格"
     }
     # 後続セクションとの間に空行を確保（lookahead が前方の `\n` を1つ食うため）
     $newSection += "`n"
@@ -261,7 +270,6 @@ if ($unreleasedMatch.Success) {
     $changelogContent = $changelogContent.Substring(0, $unreleasedMatch.Index) +
                         $newSection +
                         $changelogContent.Substring($unreleasedMatch.Index + $unreleasedMatch.Length)
-    Write-Success "CHANGELOG.md: 既存 ### Unreleased を v${NewVersion} へ統合（手動キュレーション分は保持。コミット由来エントリと重複している場合はPRで手動整理してください）"
 } else {
     # Unreleased セクションなし → 「# 更新履歴」直後に新規挿入
     $changelogContent = $changelogContent -replace '(# 更新履歴\r?\n)', "`$1`n${changelogSection}`n"


### PR DESCRIPTION
## 概要

リリースのたびに CHANGELOG が「長い版（手動キュレーション）」と「短い版（自動生成）」で**二重記載**される再発バグを根治します。直近では v2.9.4（#1658 で手動整理）と v2.9.5 で発生していました。

## 根本原因

`tools/bump-version.ps1` は既存の `### Unreleased` を `### vX.Y.Z` へ昇格する際、手動キュレーション本文を保持したうえで**コミット由来の自動生成エントリも末尾に追記**していました。本プロジェクトの運用では変更内容を PR ごとに `### Unreleased` へ手動キュレーションしており（リリースノートの正典）、自動生成エントリは丸ごと重複になります。旧コードは成功メッセージで「重複している場合はPRで手動整理してください」と既知の欠陥を自白していました。

## 修正内容

- **`tools/bump-version.ps1`**: 手動キュレーション本文がある場合は自動生成エントリを**破棄**（二重記載防止）。本文が空の `### Unreleased`（見出しだけ先置き）の時だけフォールバックで自動生成を採用。コメント・成功メッセージも実態へ更新。
- **`CHANGELOG.md`**: v2.9.5 の重複した自動生成ブロックを削除し、手動版を正典として残置。短い版にのみ存在した **#1658**（v2.9.4 重複整理）だけ救済してドキュメント節へ1行追加。逆に #1666（superpowers, `chore:` で自動生成対象外）は手動版にのみ存在するため保持。

## 検証

- PowerShell パーサで構文検証済み（`no parse errors`）。
- v2.9.5 セクションがバグ修正2件＋ドキュメント節（末尾 #1658）の単一構成になり、重複ブロックが消えたことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
