### PR TITLE
fix: 帳票ファイル名のパストラバーサルを修正（CardType/CardNumber サニタイズ） (#1703)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased
 
+**セキュリティ**
+- Issue #1703 月次帳票のファイル名生成におけるパストラバーサル（CWE-22）を修正した。`CardType` / `CardNumber` は CSV 取込（`CsvImportService` は非空チェックのみ）や共有モードの他 PC による DB 直接書き込み経由でパス区切り（`..\` 等）を含みうるが、これらが `ReportService.GetFiscalYearFileName` でファイル名に素通しされ、`Path.Combine` + `workbook.SaveAs` の解決時に選択した出力フォルダの外へ `.xlsx` を書き込み／上書きできる状態だった（例: `物品出納簿_..\..\..\Users\Public\evil_2024年度.xlsx` → `C:\Users\Public` 配下へ流出）。
+  - **対策**: ファイル名生成の単一チョークポイント `ReportService.GetFiscalYearFileName` で `CardType` / `CardNumber` を新設 `FileNameSanitizer.SanitizeComponent`（`Infrastructure/Security`）によりサニタイズし、パス区切り・予約文字・制御文字を `_` へ置換。3 sink（`ReportService` の一括生成・単票生成、`ReportViewModel.CreateReportAsync`）はいずれも本関数を経由するため一括で防御される。sink 側での無害化を主防御とすることで、CSV 取込・共有DB 書き込みの両汚染経路を同時にカバーする（入力側検証だけでは共有DB 経路を塞げないため）。Issue #1267 の `FormulaInjectionSanitizer` と同じ「sink 側でユーザー入力を無害化」パターンを踏襲。
+  - 検証: `FileNameSanitizerTests`（単体20件）／`ReportServiceFileNameSecurityTests`（統合4件）を新設。07_テスト設計書 §1.1a（単体 3,716→3,740・合計 3,742→3,766 件）・§6 UT-SECURITY-006 を同期更新（#1703）
+
 **機能追加**
 - Issue #1676 駅コードマスター（`StationCode.csv`）に、#1674 で見送っていた**再採番を伴う新駅4駅**（高輪ゲートウェイ・新白島・石巻あゆみ野・前潟）を反映した。権威データ源（自動改札機の研究 `ja.ysrl.org` の路線別ページ）の現行コード列と**路線まるごと機械突合**し、再採番後の駅順を確定。`docs/線区駅順コード/StationCode.csv`（マスター）と `src/ICCardManager/Resources/StationCode.csv`（埋め込みリソース）の両方を更新（両ファイルは常に同一）。
   - **新駅追加（4駅）**: 高輪ゲートウェイ（東海道本線 001-006、2020年開業）／新白島（山陽本線 010-104、2015年開業）／石巻あゆみ野（仙石線 035-158、2016年開業）／前潟（田沢湖線 049-130、2023年開業）。

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 3,755件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 3,779件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **3,781件** | 全件パス（最終同期: Issue #1687 バージョン混在の検出と旧バージョンの共有DBブロック、`AppVersionInfoTests`（14件）／`UpdateNotificationServiceTests`（14件）／`DbContextVersionGuardTests`（6件）を新設、`WarningServiceTests` に3件追加、警告エリア折り返しの回帰 `MainWindowWarningAreaLayoutTests`（2件）を追加（+39、UT-050・UT-063〜UT-065a）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,755 + 26 = 3,781 と比較） |
+| **合計** | **3,805件** | 全件パス（最終同期: Issue #1703 帳票ファイル名のパストラバーサル対策、`FileNameSanitizerTests`（20件）／`ReportServiceFileNameSecurityTests`（4件）を新設（+24、UT-SECURITY-006）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,779 + 26 = 3,805 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >
@@ -4417,6 +4417,36 @@ OWASP CSV Injection 対策。セル先頭が `=` / `+` / `-` / `@` / タブ / CR
 - 内部オーバーロード `ValidateBackupPath(path, reachabilityStub, timeoutMs)` をリフレクション経由でテストに露出し、実ネットワークに依存しない決定論的テストを可能にしている
 - 既定チェッカーの実ネットワークテストは RFC 5737 TEST-NET-1 (`192.0.2.1`) を使用。ルーティング不可で接続拒否される想定
 - `Task.Run(() => Directory.Exists(path))` + `Task.Wait(5000)` パターンで明示的タイムアウトを設け、呼び出しスレッドのハングを防止
+
+#### UT-SECURITY-006: 帳票ファイル名のパストラバーサル対策（Issue #1703）
+
+`CardType` / `CardNumber` は CSV 取込（非空チェックのみ）や共有モードの他 PC による DB 直接書き込み経由でパス区切りを含みうる。これらが帳票ファイル名に素通しされると `Path.Combine` + `SaveAs` の解決時に出力フォルダを脱出する（例: `物品出納簿_..\..\..\Users\Public\evil_2024年度.xlsx`）。名前生成の単一チョークポイント `ReportService.GetFiscalYearFileName` でファイル名構成要素をサニタイズし、3 sink（`ReportService` 2 箇所・`ReportViewModel`）を一括で防御する。
+
+**`FileNameSanitizer.SanitizeComponent`（単体）**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | パス区切りの除去 | `x\..\..\..\Users\Public\report` / `../../../etc/passwd` / `..\..\Users\Public\evil` / `a/b\c` | `/` `\` を一切含まず、`Path.GetFileName(結果)==結果` |
+| 2 | 予約文字の置換 | `a:b` / `a*b` / `a?b` / `a"b` / `a<b>c` / `a\|b` | `Path.GetInvalidFileNameChars` 不検出、`:` を含まない |
+| 3 | 制御文字の置換 | `a\tb\nc\0d` | `a_b_c_d` |
+| 4 | 正常値は不変 | `はやかけん` / `nimoca` / `H001` / `SUGOCA-2024` / `職員_A` | 同じ値 |
+| 5 | 冪等性（idempotent） | サニタイズ2回適用 | 1回適用と同じ |
+| 6 | null / 空 | null / "" | 入力をそのまま返す |
+| 7 | SanitizeComponentOrEmpty(null) | null | 空文字列 |
+
+**`ReportService.GetFiscalYearFileName`（統合防御点）**
+
+| No | テストケース | 入力 | 期待結果 |
+|----|-------------|------|---------|
+| 1 | 汚染カード項目でも traversal 不成立 | CardType/CardNumber にパス区切り3パターン | 生成名に `/` `\` を含まず、`Path.Combine(folder, 名前)` が folder 配下に留まる |
+| 2 | 正常カード項目は読みやすい名前を維持 | `はやかけん` / `H001` / 2024 | `物品出納簿_はやかけん_H001_2024年度.xlsx` |
+
+**テストクラス:** `FileNameSanitizerTests`（単体 20件） + `ReportServiceFileNameSecurityTests`（統合 4件）
+
+**設計上の注意:**
+- **sink 側での無害化を主防御**とする。入力側（CSV 取込）検証だけでは共有 DB 書き込み経路を塞げないため、名前生成点で防御することで両経路（CSV・共有DB）を同時にカバーする
+- 危険文字は `_` へ置換（削除ではなく置換）し、`Path.GetInvalidFileNameChars()` にプラットフォーム依存で欠落する区切り文字 `/` `\` `:` を明示的に加える（Linux では `\` が含まれないため）
+- Issue #1267 の `FormulaInjectionSanitizer`（式インジェクション対策）と同じ「sink 側でユーザー入力を無害化」パターンを踏襲
 
 ### 7a.2 結合テスト
 

--- a/ICCardManager/src/ICCardManager/Infrastructure/Security/FileNameSanitizer.cs
+++ b/ICCardManager/src/ICCardManager/Infrastructure/Security/FileNameSanitizer.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace ICCardManager.Infrastructure.Security
+{
+    /// <summary>
+    /// Issue #1703: 帳票ファイル名に埋め込む <c>CardType</c> / <c>CardNumber</c> 等の
+    /// ユーザー入力由来の構成要素からパス区切り・不正ファイル名文字を除去し、
+    /// 出力フォルダ外へのパストラバーサル（<c>..\\</c> 等）を防ぐサニタイザ。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>CardType</c> / <c>CardNumber</c> は CSV 取込（非空チェックのみ）や共有モードの
+    /// 他 PC による DB 直接書き込み経由でパス区切り文字を含みうる。これらが
+    /// <c>string.Format</c> でファイル名に素通しされると <c>Path.Combine</c> +
+    /// <c>SaveAs</c> の解決時に選択フォルダを脱出しうるため、名前生成の単一チョークポイント
+    /// （<c>ReportService.GetFiscalYearFileName</c>）でサニタイズする。入力側検証だけでは
+    /// 共有 DB 書き込み経路を塞げないため、sink 側での無害化を主防御とする。
+    /// </para>
+    /// <para>
+    /// 危険文字は置換文字（<c>_</c>）へ置き換える。<c>Path.GetInvalidFileNameChars()</c> は
+    /// プラットフォーム依存（Linux では <c>\\</c> を含まない）のため、クロスプラットフォームでの
+    /// 堅牢性を確保するべく区切り文字 <c>/</c> <c>\\</c> <c>:</c> を明示的に加える。
+    /// </para>
+    /// <para>
+    /// 本関数は idempotent: 置換文字 <c>_</c> 自体は危険文字ではないため、サニタイズ済みの
+    /// 値を再度渡しても変化しない。
+    /// </para>
+    /// </remarks>
+    public static class FileNameSanitizer
+    {
+        /// <summary>
+        /// 危険文字を置き換える文字。ファイル名として常に有効な <c>_</c> を用いる。
+        /// </summary>
+        public const char ReplacementChar = '_';
+
+        /// <summary>
+        /// ファイル名構成要素として無効・危険な文字集合。
+        /// <see cref="Path.GetInvalidFileNameChars"/> にパス区切り <c>/</c> <c>\\</c> <c>:</c> を加えたもの。
+        /// </summary>
+        private static readonly HashSet<char> InvalidChars = BuildInvalidChars();
+
+        private static HashSet<char> BuildInvalidChars()
+        {
+            var set = new HashSet<char>(Path.GetInvalidFileNameChars())
+            {
+                '/',
+                '\\',
+                ':',
+            };
+            return set;
+        }
+
+        /// <summary>
+        /// ファイル名の 1 構成要素をサニタイズする。危険文字（パス区切り・制御文字・
+        /// 予約文字）を <see cref="ReplacementChar"/> に置換する。
+        /// </summary>
+        /// <param name="value">サニタイズ対象（null / 空はそのまま返す）</param>
+        /// <returns>パス区切りを含まない安全なファイル名構成要素</returns>
+        public static string SanitizeComponent(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
+            char[] buffer = null;
+            for (int i = 0; i < value.Length; i++)
+            {
+                var c = value[i];
+                if (System.Char.IsControl(c) || InvalidChars.Contains(c))
+                {
+                    if (buffer == null)
+                        buffer = value.ToCharArray();
+                    buffer[i] = ReplacementChar;
+                }
+            }
+
+            return buffer == null ? value : new string(buffer);
+        }
+
+        /// <summary>
+        /// null セーフ版。null を渡すと空文字列を返す。
+        /// </summary>
+        public static string SanitizeComponentOrEmpty(string value)
+        {
+            return SanitizeComponent(value ?? string.Empty);
+        }
+    }
+}

--- a/ICCardManager/src/ICCardManager/Services/ReportService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ReportService.cs
@@ -683,9 +683,14 @@ namespace ICCardManager.Services
         /// <returns>ファイル名（例: 物品出納簿_はやかけん_H001_2024年度.xlsx）</returns>
         public static string GetFiscalYearFileName(string cardType, string cardNumber, int fiscalYear)
         {
+            // Issue #1703: CardType / CardNumber は CSV 取込・共有DB 経由でパス区切りを含みうる。
+            // ファイル名構成要素としてサニタイズし、Path.Combine + SaveAs 解決時の
+            // 出力フォルダ外へのパストラバーサルを防ぐ（名前生成の単一チョークポイント）。
+            var safeCardType = FileNameSanitizer.SanitizeComponent(cardType);
+            var safeCardNumber = FileNameSanitizer.SanitizeComponent(cardNumber);
             return string.Format(
                 new OrganizationOptions().ReportLayout.FileNameFormat,
-                cardType, cardNumber, fiscalYear);
+                safeCardType, safeCardNumber, fiscalYear);
         }
 
         /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Security/FileNameSanitizerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Infrastructure/Security/FileNameSanitizerTests.cs
@@ -1,0 +1,98 @@
+using System.IO;
+using FluentAssertions;
+using ICCardManager.Infrastructure.Security;
+using Xunit;
+
+namespace ICCardManager.Tests.Infrastructure.Security;
+
+/// <summary>
+/// Issue #1703: <see cref="FileNameSanitizer"/> の単体テスト。
+/// パス区切り・不正ファイル名文字を除去し、パストラバーサルを防ぐことを検証する。
+/// </summary>
+public class FileNameSanitizerTests
+{
+    #region SanitizeComponent: 危険文字の除去
+
+    [Theory]
+    [InlineData("x\\..\\..\\..\\Users\\Public\\report")]  // Windows 区切り + 親ディレクトリ
+    [InlineData("../../../etc/passwd")]                     // Unix 区切り
+    [InlineData("..\\..\\Users\\Public\\evil")]
+    [InlineData("a/b\\c")]
+    public void SanitizeComponent_WithPathSeparators_RemovesAllSeparators(string input)
+    {
+        var result = FileNameSanitizer.SanitizeComponent(input);
+
+        // パス区切り文字が一切残らない = Path.Combine で結合してもフォルダを脱出できない
+        result.Should().NotContain("/");
+        result.Should().NotContain("\\");
+        // 単一のファイル名構成要素であり、パス構造を持たない
+        Path.GetFileName(result).Should().Be(result);
+    }
+
+    [Theory]
+    [InlineData("a:b")]   // ドライブ指定子/代替データストリーム
+    [InlineData("a*b")]
+    [InlineData("a?b")]
+    [InlineData("a\"b")]
+    [InlineData("a<b>c")]
+    [InlineData("a|b")]
+    public void SanitizeComponent_WithReservedChars_ReplacesWithUnderscore(string input)
+    {
+        var result = FileNameSanitizer.SanitizeComponent(input);
+
+        result.IndexOfAny(Path.GetInvalidFileNameChars()).Should().Be(-1);
+        result.Should().NotContain(":");
+    }
+
+    [Fact]
+    public void SanitizeComponent_WithControlChars_ReplacesThem()
+    {
+        var result = FileNameSanitizer.SanitizeComponent("a\tb\nc\0d");
+
+        result.Should().Be("a_b_c_d");
+    }
+
+    #endregion
+
+    #region SanitizeComponent: 正常値は不変
+
+    [Theory]
+    [InlineData("はやかけん")]
+    [InlineData("nimoca")]
+    [InlineData("H001")]
+    [InlineData("SUGOCA-2024")]
+    [InlineData("職員_A")]
+    public void SanitizeComponent_WithNormalValue_ReturnsUnchanged(string input)
+    {
+        FileNameSanitizer.SanitizeComponent(input).Should().Be(input);
+    }
+
+    #endregion
+
+    #region 冪等性・null / 空
+
+    [Fact]
+    public void SanitizeComponent_IsIdempotent()
+    {
+        var once = FileNameSanitizer.SanitizeComponent("x\\..\\evil");
+        var twice = FileNameSanitizer.SanitizeComponent(once);
+
+        twice.Should().Be(once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SanitizeComponent_WithNullOrEmpty_ReturnsInput(string input)
+    {
+        FileNameSanitizer.SanitizeComponent(input).Should().Be(input);
+    }
+
+    [Fact]
+    public void SanitizeComponentOrEmpty_WithNull_ReturnsEmpty()
+    {
+        FileNameSanitizer.SanitizeComponentOrEmpty(null).Should().Be(string.Empty);
+    }
+
+    #endregion
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceFileNameSecurityTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Services/ReportServiceFileNameSecurityTests.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using FluentAssertions;
+using ICCardManager.Services;
+using Xunit;
+
+namespace ICCardManager.Tests.Services;
+
+/// <summary>
+/// Issue #1703: <see cref="ReportService.GetFiscalYearFileName"/> が、CardType / CardNumber に
+/// パス区切りを含む汚染入力（CSV 取込・共有DB 経由）を受けても、出力フォルダ外への
+/// パストラバーサルを構成しないことを検証する。3 sink（ReportService 2 箇所・ReportViewModel）は
+/// いずれも本関数を経由するため、ここが共通の防御点となる。
+/// </summary>
+public class ReportServiceFileNameSecurityTests
+{
+    [Theory]
+    [InlineData("x\\..\\..\\..\\Users\\Public\\report", "H001")]
+    [InlineData("はやかけん", "..\\..\\..\\Users\\Public\\evil")]
+    [InlineData("../../etc", "../../passwd")]
+    public void GetFiscalYearFileName_WithPathSeparatorsInCardFields_ProducesNoTraversal(
+        string cardType, string cardNumber)
+    {
+        var fileName = ReportService.GetFiscalYearFileName(cardType, cardNumber, 2024);
+
+        // パス区切りを含まない = Path.Combine(outputFolder, fileName) がフォルダを脱出できない
+        fileName.Should().NotContain("/");
+        fileName.Should().NotContain("\\");
+        // 生成名は単一のファイル名であり、パス構造を持たない
+        Path.GetFileName(fileName).Should().Be(fileName);
+
+        // Path.Combine で結合しても意図した出力フォルダ配下に留まる
+        var outputFolder = Path.Combine(Path.GetTempPath(), "iccard-report-test");
+        var combined = Path.GetFullPath(Path.Combine(outputFolder, fileName));
+        combined.Should().StartWith(Path.GetFullPath(outputFolder));
+    }
+
+    [Fact]
+    public void GetFiscalYearFileName_WithNormalCardFields_KeepsReadableName()
+    {
+        var fileName = ReportService.GetFiscalYearFileName("はやかけん", "H001", 2024);
+
+        // 正常な入力は従来どおり読みやすい名前を維持する（既定様式: 物品出納簿_{種別}_{番号}_{年度}年度.xlsx）
+        fileName.Should().Be("物品出納簿_はやかけん_H001_2024年度.xlsx");
+    }
+}


### PR DESCRIPTION
## 概要

Closes #1703

月次帳票のファイル名生成における**パストラバーサル（CWE-22）**を修正します。セキュリティスキャン（Claude Security）で検出した F1〜F3（同一ルート原因の3 sink）を、名前生成の単一チョークポイントで一括対策しました。

## 問題

`CardType` / `CardNumber` は CSV 取込（`CsvImportService` は非空チェックのみ）や共有モードの他 PC による DB 直接書き込み経由で**パス区切り（`..\` 等）を含みうる**。これらが `ReportService.GetFiscalYearFileName` でファイル名に素通しされ、`Path.Combine` + `workbook.SaveAs` の解決時に選択した出力フォルダの**外**へ `.xlsx` を書き込み／上書きできる状態でした。

例: `CardNumber = "..\..\..\Users\Public\evil"` → `物品出納簿_はやかけん_..\..\..\Users\Public\evil_2024年度.xlsx` → `C:\Users\Public` 配下へ流出。

## 対策

名前生成の単一チョークポイント `ReportService.GetFiscalYearFileName` で `CardType` / `CardNumber` を新設 `FileNameSanitizer.SanitizeComponent`（`Infrastructure/Security`）によりサニタイズし、パス区切り・予約文字・制御文字を `_` へ置換します。

- **3 sink を一括防御**: `ReportService`（一括生成 L657・単票生成 L390 の `SaveAs`）と `ReportViewModel.CreateReportAsync`（L446）はいずれも `GetFiscalYearFileName` を経由するため、1関数の修正で全て塞がる
- **sink 側の無害化を主防御**: 入力側（CSV 取込）検証だけでは共有DB 書き込み経路を塞げないため、名前生成点で防御することで CSV・共有DB の両汚染経路を同時にカバー
- **クロスプラットフォーム堅牢性**: `Path.GetInvalidFileNameChars()` にプラットフォーム依存で欠落する区切り文字 `/` `\` `:` を明示的に追加（Linux では `\` が含まれない）
- 既存の `FormulaInjectionSanitizer`（Issue #1267、式インジェクション対策）と同じ「sink 側でユーザー入力を無害化」パターンを踏襲

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `Infrastructure/Security/FileNameSanitizer.cs` | 新設（サニタイザ） |
| `Services/ReportService.cs` | `GetFiscalYearFileName` でサニタイズ適用 |
| `tests/.../FileNameSanitizerTests.cs` | 新設（単体20件） |
| `tests/.../ReportServiceFileNameSecurityTests.cs` | 新設（統合4件） |
| `CHANGELOG.md` / `07_テスト設計書.md` | 同期更新（§1.1a 3,742→3,766・§6 UT-SECURITY-006） |

## テスト

- 新規24件（`FileNameSanitizerTests` 20 + `ReportServiceFileNameSecurityTests` 4）すべてパス
- 既存 `ReportServiceTests` 97件に回帰なし
- 本体ビルド警告0・エラー0

## 補足（スコープ外）

CSV 取込経路（`CsvImportService.Card`）への `ValidateCardNumber`/`ValidateCardType` 適用は、既存の移行データを拒否しうる挙動変更のリスクがあるため本 PR ではスコープ外とし、sink 側修正（両経路をカバー）に絞りました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
