### PR TITLE
docs: トースト表示位置の「画面右上」断定コメントを実装（ToastPosition 設定）と整合させる (#1697)

### DIFF
--- a/.claude/rules/development-conventions.md
+++ b/.claude/rules/development-conventions.md
@@ -38,6 +38,10 @@
 - **色値の Single Source of Truth**: `Resources/Styles/AccessibilityStyles.xaml` のブラシキー（`LendingBackgroundBrush` / `ReturnBackgroundBrush` / `ErrorBackgroundBrush` / `HintForegroundBrush` 等）を `DynamicResource` で参照すること。色値リテラル（`#FFF3E0` 等）を直接指定しない（Issue #1392、#1461）。コードビハインドでは `Application.Current.TryFindResource("KeyName") as Brush` で取得する（`new SolidColorBrush(Color.FromRgb(...))` 禁止）。ViewModel/DTO で行ごとに色を切り替える場合は色値文字列ではなく**リソースキー名**を返し、XAML 側で `ResourceKeyToBrushConverter` 経由でブラシ解決する
 - **`ReturnBackgroundBrush` の用途**: 「返却完了」シグナルに加え、ダイアログの情報ヘッダー・操作ヒント・装飾用途でも兼用する。専用の `HintBackgroundBrush` 等は新設しない設計判断。意味の区別は色ではなくアイコン・テキスト・配置で行う（Issue #1399、`docs/design/03_画面設計書.md` §4.1 参照）
 - **`HintForegroundBrush` の用途**: 「💡 ヒント」「⚠ 注意」等の補足説明文の文字色（マテリアル Brown 700 / `#795548`）。背景ブラシに関する Issue #1399 の方針とは独立した「前景色」キー（Issue #1461）
+- **設定で変更できる項目をコメントで断定しない**（Issue #1697）。設定項目が後から追加されると、それ以前に書かれた「常に◯◯」という前提のコメントが実装と乖離したまま残る。**コメントは PR 本文・設計書・マニュアルへの記述の元ネタとして参照される**ため、放置すると誤記述が下流へ伝播する（トースト表示位置設定 `AppSettings.ToastPosition` 追加後も「画面右上に表示」というコメントが残り、PR #1696 の本文へ「画面右上に表示される」と伝播した実例がある）。
+  - 書き方: 「設定された画面隅（`ToastPosition`。既定は右上）に表示」のように**「設定に従う」＋「既定値」**の形にする。既定値の説明として具体値に言及するのは正当（`AppSettings` の enum コメント、設定画面の ToolTip 等）
+  - 回帰は規約テストで固定する（`ToastPositionCommentConventionTests` が参考実装）。「断定表現の不在」だけでなく**「実装が全選択肢を分岐していること」も併せて検証**する。前者だけだと実装が固定値へ退化した際に逆方向の乖離が生まれるため
+  - 検査対象が汎用ファイル（`MainViewModel` 等）に及ぶ場合は、対象機能のキーワードを含む行に絞る。「メイン画面右下の警告エリア」のような**別機能の正当な記述を誤検出する**（実際に発生）
 
 ## ICカード関連
 - **用語の使い分け（重要）**: 本システムでは「職員証」と「交通系ICカード」の2種類のICカードを扱う。UI文言・マニュアル・コード内のユーザー向けメッセージでは、交通系ICカードを指す場合は必ず**「交通系ICカード」**と記載し、単に「ICカード」とは書かないこと。「ICカード」だけでは職員証と区別がつかずユーザーが混乱する。ただし「ICカードリーダー」等のハードウェア名称、および「ICカード管理」等の画面・機能名（固有名詞）はそのままでよい（用語ガード `UserFacingTextConventionTests` の `AllowedCompounds` がこれらの複合語を許容する）

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Unreleased
 
+**ドキュメント**
+- Issue #1697 トースト通知の表示位置を「画面右上」と断定するコード内コメントを、実装（設定 `AppSettings.ToastPosition`: 右上/左上/右下/左下、既定は右上）と整合する記述へ修正した。表示位置設定が追加される前の前提が残っており、このコメントを根拠に PR 本文へ「画面右上に表示される」という不正確な記述が伝播した実例（Issue #1683 / PR #1696）があったため、誤記述の伝播経路を断つ。
+  - 修正箇所: `IToastNotificationService` / `ToastNotificationService` / `ToastNotificationWindow`（クラス remarks とコンストラクタ内コメント）／`ToastLayoutCalculator.MaxWidth`／`MainViewModel` の貸出・返却トースト呼び出し前コメント2箇所。`ToastNotificationWindow.PositionToast()` は既に `ToastPosition` の4隅を分岐しており**実装は正しく、古いのはコメントのみ**であることを確認した。あわせて `ToastLayoutCalculator` の「タイル配置される前提」も実装（同一座標に単発表示。タイル配置は未実装）に合わせて修正した。
+  - 既定値の説明として「右上」に言及している箇所（`AppSettings` の enum コメント・`SettingsViewModel`・設定画面 ToolTip・画面設計書・ユーザーマニュアル）は正しいため変更なし。
+  - 再発防止として `ToastPositionCommentConventionTests`（3件）を新設。トースト関連ソースが特定の隅を断定していないこと・`PositionToast` が `ToastPosition` 全メンバーを分岐していること・既定値が `TopRight` であることを静的に固定する。`MainViewModel` は「トースト」「Toast」を含む行のみ検査し、メイン画面の警告エリア（画面右下）等の正当な記述を誤検出しない。07_テスト設計書 §1.1a（単体 3,909→3,912・合計 3,935→3,938 件）・§2.52 UT-TOAST-POSITION-001 を同期更新（#1697）
+
 **セキュリティ**
 - Issue #1703 月次帳票のファイル名生成におけるパストラバーサル（CWE-22）を修正した。`CardType` / `CardNumber` は CSV 取込（`CsvImportService` は非空チェックのみ）や共有モードの他 PC による DB 直接書き込み経由でパス区切り（`..\` 等）を含みうるが、これらが `ReportService.GetFiscalYearFileName` でファイル名に素通しされ、`Path.Combine` + `workbook.SaveAs` の解決時に選択した出力フォルダの外へ `.xlsx` を書き込み／上書きできる状態だった（例: `物品出納簿_..\..\..\Users\Public\evil_2024年度.xlsx` → `C:\Users\Public` 配下へ流出）。
   - **対策**: ファイル名生成の単一チョークポイント `ReportService.GetFiscalYearFileName` で `CardType` / `CardNumber` を新設 `FileNameSanitizer.SanitizeComponent`（`Infrastructure/Security`）によりサニタイズし、パス区切り・予約文字・制御文字を `_` へ置換。3 sink（`ReportService` の一括生成・単票生成、`ReportViewModel.CreateReportAsync`）はいずれも本関数を経由するため一括で防御される。sink 側での無害化を主防御とすることで、CSV 取込・共有DB 書き込みの両汚染経路を同時にカバーする（入力側検証だけでは共有DB 経路を塞げないため）。Issue #1267 の `FormulaInjectionSanitizer` と同じ「sink 側でユーザー入力を無害化」パターンを踏襲。

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 3,909件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 3,912件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **3,935件** | 全件パス（最終同期: Issue #1689 バックアップ健全性の見える化、`BackupHealthServiceTests` を19件・`DiskSpaceHelperTests` を13件・`WarningServiceBackupHealthTests` を10件・`BackupServiceHealthRecordingTests` を6件・`SystemManageDialogBackupHealthLayoutTests` を4件新設、`SystemManageViewModelTests` に17件・`MainViewModelTests` に4件追加（+73、UT-BACKUP-HEALTH-001〜004）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,909 + 26 = 3,935 と比較） |
+| **合計** | **3,938件** | 全件パス（最終同期: Issue #1697 トースト表示位置コメントの整合、`ToastPositionCommentConventionTests` を3件新設（+3、UT-TOAST-POSITION-001）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 3,912 + 26 = 3,938 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >
@@ -3838,6 +3838,42 @@ Issue #1548 マージ後の実機検証（Issue #1507）で、ページ送り操
 - `MainViewModel.OpenHelp` は `MessageBox.Show` を伴うため自動テスト対象外。手動検証で「インストールフォルダの `Docs` 削除時にダイアログが「ドキュメントフォルダが見つかりません」相当の文言で表示されること」を確認する。
 - 実 `Process.Start` 起動の検証は CI 上で GUI を立ち上げてしまうため、設計仕様書（`ICCardManager/docs/superpowers/specs/2026-05-22-issue-1465-safe-file-launcher-design.md` §8）の手動検証手順に委ねる。
 
+
+---
+
+### 2.52 トースト表示位置コメント規約（Issue #1697）
+
+#### UT-TOAST-POSITION-001: 「画面右上」断定コメントの禁止と配置ロジックの網羅性
+
+**テスト対象:** `ToastPositionCommentConventionTests`
+
+**目的:**
+
+トースト通知の表示位置は設定（`AppSettings.ToastPosition`: 右上/左上/右下/左下、既定は右上）で変更でき、`ToastNotificationWindow.PositionToast()` が 4 隅を分岐している。しかし位置設定の追加以前に書かれた「画面右上に表示」と断定するコメントがコード内に残っており、実装と乖離していた。このコメントを根拠に PR 本文へ「画面右上に表示される」という不正確な記述が伝播した実例（Issue #1683 / PR #1696）があるため、誤記述の伝播経路を静的テストで断つ。
+
+**検査範囲:**
+
+| 走査対象 | 判定単位 |
+|----------|----------|
+| `Services/IToastNotificationService.cs` / `Services/ToastNotificationService.cs` / `Views/ToastNotificationWindow.xaml.cs` / `Common/ToastLayoutCalculator.cs` | ファイル全体（トースト専用ファイル） |
+| `ViewModels/MainViewModel.cs` | 「トースト」「Toast」を含む行のみ（メイン画面の警告エリア「画面右下」等の正当な記述を誤検出しないため） |
+
+**テストケース:**
+
+| ID | 目的 | 期待結果 |
+|----|------|----------|
+| UT-TOAST-POSITION-001-1 | トースト関連ソースが「画面右上／左上／右下／左下」と特定の隅を断定していない | 違反なし |
+| UT-TOAST-POSITION-001-2 | `PositionToast` が `ToastPosition` の全メンバー（リフレクションで列挙）を `case` で分岐している | 違反なし |
+| UT-TOAST-POSITION-001-3 | `ToastNotificationWindow.CurrentPosition` の既定値が `ToastPosition.TopRight` である | 一致 |
+
+**実装上のポイント:**
+
+- 「既定」「デフォルト」を含む行は除外する。既定値の説明として「右上」に言及するのは正当なため（`AppSettings.cs` の enum コメント、設定画面の ToolTip 等と同じ扱い）
+- ソースルート探索は `UserFacingTextConventionTests` と同じ `ICCardManager.sln` 上方探索パターン（CI/ローカル/WSL2 互換）
+- 001-2 は「コメントの主張（設定に従う）が実装で裏付けられているか」を担保する。実際の配置座標の検証には WPF ウィンドウの実描画が必要なため、静的検証に留める
+- 001-3 が落ちた場合は既定値変更が意図的か確認し、意図的ならコメント・ユーザーマニュアル（§トースト通知の表示位置）の「既定は右上」記述を併せて更新する
+
+**カバー対象 Issue:** #1697（関連: #1683 / PR #1696）
 
 ---
 

--- a/ICCardManager/src/ICCardManager/Common/ToastLayoutCalculator.cs
+++ b/ICCardManager/src/ICCardManager/Common/ToastLayoutCalculator.cs
@@ -21,7 +21,8 @@ namespace ICCardManager.Common
     {
         /// <summary>
         /// トースト最大幅（フォントサイズに依存しない固定値）。
-        /// 画面右上にタイル配置される前提で、デスクトップに過度に張り出さない幅を設定。
+        /// 設定された画面隅（<see cref="ICCardManager.Models.ToastPosition"/>。既定は右上）に
+        /// 配置される前提で、デスクトップに過度に張り出さない幅を設定。
         /// </summary>
         public const double MaxWidth = 520;
 

--- a/ICCardManager/src/ICCardManager/Services/IToastNotificationService.cs
+++ b/ICCardManager/src/ICCardManager/Services/IToastNotificationService.cs
@@ -8,7 +8,8 @@ namespace ICCardManager.Services
     /// トースト通知サービスのインターフェース
     /// </summary>
     /// <remarks>
-    /// 画面右上に表示されるフォーカスを奪わない通知を管理するサービス。
+    /// 設定された画面隅（<see cref="ICCardManager.Models.ToastPosition"/>。既定は右上）に表示される、
+    /// フォーカスを奪わない通知を管理するサービス。
     /// 貸出・返却時の通知をメインウィンドウとは別ウィンドウで表示し、
     /// 職員の操作を妨げないようにする。
     /// </remarks>

--- a/ICCardManager/src/ICCardManager/Services/ToastNotificationService.cs
+++ b/ICCardManager/src/ICCardManager/Services/ToastNotificationService.cs
@@ -10,7 +10,8 @@ namespace ICCardManager.Services
     /// トースト通知サービスの実装
     /// </summary>
     /// <remarks>
-    /// ToastNotificationWindowを使用して画面右上に通知を表示する。
+    /// ToastNotificationWindowを使用して、設定された画面隅
+    /// （<see cref="ICCardManager.Models.ToastPosition"/>。既定は右上）に通知を表示する。
     /// フォーカスを奪わないため、職員の操作を妨げない。
     /// </remarks>
     public class ToastNotificationService : IToastNotificationService

--- a/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/MainViewModel.cs
@@ -1141,7 +1141,7 @@ public partial class MainViewModel : ViewModelBase
         {
             _soundPlayer.Play(SoundType.Lend);
 
-            // トースト通知を表示（画面右上、フォーカスを奪わない）
+            // トースト通知を表示（表示位置は設定に従う、フォーカスを奪わない）
             _toastNotificationService.ShowLendNotification(card.CardType, card.CardNumber);
 
             // メイン画面は変更しない（Issue #186: 職員の操作を妨げない）
@@ -1254,7 +1254,7 @@ public partial class MainViewModel : ViewModelBase
         // 残高はLendingServiceで設定済み（カードから直接読み取った値を優先）
         _soundPlayer.Play(SoundType.Return);
 
-        // トースト通知を表示（画面右上、フォーカスを奪わない）
+        // トースト通知を表示（表示位置は設定に従う、フォーカスを奪わない）
         _toastNotificationService.ShowReturnNotification(card.CardType, card.CardNumber, result.Balance, result.IsLowBalance, result.WarningBalance);
 
         // メイン画面は変更しない（Issue #186: 職員の操作を妨げない）

--- a/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
+++ b/ICCardManager/src/ICCardManager/Views/ToastNotificationWindow.xaml.cs
@@ -45,7 +45,8 @@ namespace ICCardManager.Views
     /// トースト通知ウィンドウ
     /// </summary>
     /// <remarks>
-    /// 画面右上に表示されるフォーカスを奪わない通知ウィンドウ。
+    /// 設定された画面隅（<see cref="ToastPosition"/>。既定は右上）に表示される、
+    /// フォーカスを奪わない通知ウィンドウ。
     /// 貸出・返却時の「いってらっしゃい！」「おかえりなさい！」メッセージを
     /// メインウィンドウとは別に表示し、職員の操作を妨げないようにする。
     /// </remarks>
@@ -71,7 +72,7 @@ namespace ICCardManager.Views
             };
             _autoCloseTimer.Tick += OnAutoCloseTimerTick;
 
-            // 画面右上に配置
+            // 設定された表示位置（CurrentPosition）に配置する（OnLoaded → PositionToast）
             Loaded += OnLoaded;
 
             // クリックで閉じる（エラー通知など自動消去されない場合用）

--- a/ICCardManager/tests/ICCardManager.Tests/Views/ToastPositionCommentConventionTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Views/ToastPositionCommentConventionTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using ICCardManager.Models;
+using Xunit;
+
+namespace ICCardManager.Tests.Views;
+
+/// <summary>
+/// Issue #1697: トースト通知の表示位置は設定（<see cref="ToastPosition"/>: 右上/左上/右下/左下、
+/// 既定は右上）で変更できるにもかかわらず、位置設定の追加以前に書かれた
+/// 「画面右上に表示」と断定するコメントがコード内に残り、実装と乖離していた。
+/// このコメントを根拠に PR 本文へ「画面右上に表示される」という不正確な記述が伝播した
+/// 実例（Issue #1683 / PR #1696）があるため、再発を静的に固定する。
+/// </summary>
+/// <remarks>
+/// 実際の配置座標の検証には WPF ウィンドウの実描画（UI オートメーション）が必要なため、
+/// ここでは (1) コメントが特定の画面隅を断定していないこと、(2) その根拠となる配置ロジックが
+/// <see cref="ToastPosition"/> の全メンバーを分岐していること、を軽量に検証する。
+/// </remarks>
+public class ToastPositionCommentConventionTests
+{
+    /// <summary>
+    /// 検査対象のトースト関連ソース（ソースルートからの相対パス → トースト専用ファイルか）。
+    /// トースト専用ファイルは全行を検査する。そうでないファイル（MainViewModel など）は
+    /// 「トースト」「Toast」を含む行のみを検査する。メイン画面の警告エリア（画面右下）のように
+    /// トースト以外の固定位置を正当に説明している記述を誤検出しないため。
+    /// </summary>
+    private static readonly Dictionary<string, bool> ToastRelatedSources = new Dictionary<string, bool>
+    {
+        [Path.Combine("Services", "IToastNotificationService.cs")] = true,
+        [Path.Combine("Services", "ToastNotificationService.cs")] = true,
+        [Path.Combine("Views", "ToastNotificationWindow.xaml.cs")] = true,
+        [Path.Combine("Common", "ToastLayoutCalculator.cs")] = true,
+        [Path.Combine("ViewModels", "MainViewModel.cs")] = false,
+    };
+
+    /// <summary>
+    /// トースト専用ではないファイルで「トーストについての記述」と判定するためのキーワード。
+    /// </summary>
+    private static readonly string[] ToastContextWords =
+    {
+        "トースト",
+        "Toast",
+    };
+
+    /// <summary>
+    /// 「画面◯◯」と特定の隅を断定する表現。設定で変更できるため誤り。
+    /// </summary>
+    private static readonly string[] FixedCornerClaims =
+    {
+        "画面右上",
+        "画面左上",
+        "画面右下",
+        "画面左下",
+    };
+
+    /// <summary>
+    /// 既定値の説明として隅の名称に言及するのは正当なため、これらの語を含む行は除外する。
+    /// </summary>
+    private static readonly string[] DefaultValueContextWords =
+    {
+        "既定",
+        "デフォルト",
+    };
+
+    [Fact]
+    public void Toast_related_sources_should_not_assert_a_fixed_screen_corner()
+    {
+        var sourceRoot = GetSourceRoot();
+        var violations = new List<string>();
+
+        foreach (var entry in ToastRelatedSources)
+        {
+            var relativePath = entry.Key;
+            var isToastDedicatedFile = entry.Value;
+            var fullPath = Path.Combine(sourceRoot, relativePath);
+            File.Exists(fullPath).Should().BeTrue($"検査対象ソースが存在する: {relativePath}");
+
+            var lines = File.ReadAllText(fullPath).Replace("\r\n", "\n").Split('\n');
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (DefaultValueContextWords.Any(w => line.Contains(w)))
+                {
+                    continue;
+                }
+
+                if (!isToastDedicatedFile && !ToastContextWords.Any(w => line.Contains(w)))
+                {
+                    continue;
+                }
+
+                var hit = FixedCornerClaims.FirstOrDefault(claim => line.Contains(claim));
+                if (hit != null)
+                {
+                    violations.Add($"  - {relativePath}:{i + 1}  「{hit}」  ({line.Trim()})");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "トーストの表示位置は設定（ToastPosition）で 4 隅から選べるため、特定の隅を断定するコメントは " +
+            "実装と乖離する。「設定された画面隅（既定は右上）」等の表現に修正すること。\n" +
+            string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void PositionToast_should_branch_on_every_ToastPosition_value()
+    {
+        var windowSource = File.ReadAllText(
+            Path.Combine(GetSourceRoot(), "Views", "ToastNotificationWindow.xaml.cs"));
+
+        var missing = Enum.GetNames(typeof(ToastPosition))
+            .Where(name => !windowSource.Contains($"case ToastPosition.{name}:"))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "ToastNotificationWindow.PositionToast が ToastPosition の全メンバーを分岐していなければ、" +
+            "「設定された画面隅に表示される」というコメント／マニュアルの記述が実装と乖離する。" +
+            $"分岐が無い値: {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void CurrentPosition_default_should_be_TopRight()
+    {
+        var windowSource = File.ReadAllText(
+            Path.Combine(GetSourceRoot(), "Views", "ToastNotificationWindow.xaml.cs"));
+
+        windowSource.Should().Contain("CurrentPosition { get; set; } = ToastPosition.TopRight;",
+            "コメント・マニュアルが「既定は右上」と説明しているため、既定値を変更する場合は " +
+            "それらの記述も併せて更新する必要がある（Issue #1697）。");
+    }
+
+    /// <summary>
+    /// テスト実行ディレクトリから親方向に `ICCardManager.sln` を探索し、
+    /// 見つかった階層から `src/ICCardManager/` を返す。
+    /// （<see cref="ICCardManager.Tests.UserFacingTextConventionTests"/> と同じ探索パターン）
+    /// </summary>
+    private static string GetSourceRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "ICCardManager.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        if (dir == null)
+        {
+            throw new InvalidOperationException(
+                $"ICCardManager.sln が AppContext.BaseDirectory ({AppContext.BaseDirectory}) から見つからない。" +
+                "テスト実行ディレクトリの構造を確認してください。");
+        }
+
+        return Path.Combine(dir.FullName, "src", "ICCardManager");
+    }
+}


### PR DESCRIPTION
## 概要

Issue #1697 の対応。トースト通知の表示位置は設定（`AppSettings.ToastPosition`: 右上/左上/右下/左下、既定は右上）で変更できるにもかかわらず、位置設定の追加以前に書かれた「画面右上に表示」と断定するコメントがコード内に残り、実装と乖離していた。

このコメントを根拠に PR 本文へ「画面右上に表示される」という不正確な記述が伝播した実例（Issue #1683 / PR #1696、ユーザー指摘で修正済み）があったため、**誤記述の伝播経路をコメント修正＋静的テストで断つ**。

## 実装確認の結果

Issue で「実装確認を伴う」とされた `ToastNotificationWindow.xaml.cs:74` を確認したところ、**配置ロジックは既に正しい**（`OnLoaded` → `PositionToast()` が `CurrentPosition` で 4 隅を分岐）。古いのはコメントのみだった。

あわせて `ToastLayoutCalculator` の「画面右上に**タイル配置**される前提」は二重に古いことが判明した。`ToastNotificationWindow.Show()` は毎回新規ウィンドウを同一座標に出すだけで、タイル（積み重ね）配置は実装されていない。「配置される前提」に修正した。

## 変更内容

**コメント修正（6 箇所）**

| ファイル | 修正後 |
|---------|--------|
| `Services/IToastNotificationService.cs` | 「設定された画面隅（`ToastPosition`。既定は右上）に表示される…」 |
| `Services/ToastNotificationService.cs` | 同上 |
| `Views/ToastNotificationWindow.xaml.cs`（クラス remarks） | 同上 |
| `Views/ToastNotificationWindow.xaml.cs`（コンストラクタ内） | 「設定された表示位置（CurrentPosition）に配置する（OnLoaded → PositionToast）」 |
| `Common/ToastLayoutCalculator.cs` | 「設定された画面隅（…既定は右上）に配置される前提で…」 |
| `ViewModels/MainViewModel.cs`（貸出／返却の 2 箇所） | 「トースト通知を表示（表示位置は設定に従う、フォーカスを奪わない）」 |

`<see cref>` は `GenerateDocumentationFile=true` のため解決可能な形（Models を using していないファイルは完全修飾名）で記述し、警告ゼロを維持している。

**対象外（Issue の記載どおり変更なし）**: `AppSettings.cs` の enum コメント「右上（デフォルト）」、`SettingsViewModel.cs`、設定画面 ToolTip、`03_画面設計書.md`、`ユーザーマニュアル.md` — いずれも既定値・設定項目の説明として正しい。

**再発防止テスト（新規 3 件）**

`tests/ICCardManager.Tests/Views/ToastPositionCommentConventionTests.cs`

| ID | 検証内容 |
|----|----------|
| 001-1 | トースト関連ソースが「画面右上／左上／右下／左下」と特定の隅を断定していない |
| 001-2 | `PositionToast` が `ToastPosition` の全メンバー（リフレクションで列挙）を `case` で分岐している |
| 001-3 | `CurrentPosition` の既定値が `ToastPosition.TopRight` である |

- 「既定」「デフォルト」を含む行は除外（既定値の説明として「右上」に言及するのは正当）
- `MainViewModel.cs` は「トースト」「Toast」を含む行のみ検査する。実装中に**実際に誤検出が発生した**ため（`メイン画面右下の警告エリア` という正当な記述が `画面右下` にマッチ）、この絞り込みを追加した
- 001-2 は「コメントの主張（設定に従う）が実装で裏付けられているか」を担保する。実配置座標の検証には WPF の実描画が必要なため静的検証に留める

## 検証

- ビルド: 成功（**0 警告 / 0 エラー**）
- 単体テスト: **3,965 件 全件パス**（Debug 構成）
- Red 確認: 旧コメントを一時的に戻して 001-1 が期待どおり失敗することを確認（`MainViewModel.cs:1144 「画面右上」`）
- テスト件数同期: Release 構成の実測 3,912 + UI 26 = 3,938 と §1.1a の記載値が一致（`tools/check-test-count-sync.py` のパーサで検証済み）

## ドキュメント同期

- `docs/design/07_テスト設計書.md` §1.1a（単体 3,909→3,912・合計 3,935→3,938 件）、§2.52 UT-TOAST-POSITION-001 を新設
- `CHANGELOG.md` Unreleased の **ドキュメント** に追記

## 手動テストのお願い

コメント修正のみで挙動は変わらないため、通常は不要です。念のため確認いただく場合は以下をお願いします。

1. 設定画面（F5）で「トースト通知の表示位置」を **左下**（既定以外）に変更し、アプリを再起動
2. 貸出／返却を行い、トーストが**左下**に表示されることを確認（本 PR 前後で挙動は同一のはずです）

Closes #1697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162BuNEuN3q9LCBku2CyuVr
