### PR TITLE
refactor: インポート2コマンドの約107行の複製を解消 (#1785)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -210,6 +210,15 @@
   - 検証: `DbContextCheckConnectionReachabilityTests`（22件）を新設（+22）。単体テストで SMB 切断は再現できないため、到達確認を `protected virtual` のテスト継ぎ目とし「クエリは通るがファイルへ届かない」状態を差し替えで作る。あわせて既定実装（`File.Exists` ベース）自体も実ファイルの有無で検証し、継ぎ目だけを検証して実装が空洞化することを防ぐ。ブロックの再現は `ManualResetEventSlim` と短縮した上限（100〜200ms）で決定的に行い、実時間の待機に依存しない。上限時間 < ヘルスチェック間隔（15秒）の関係も規約テストで固定した。既存の `DbContextCheckConnectionLoggingTests` / `DbContextCheckWritableTests` / `SharedModeMonitor*Tests` / `ConnectionDiagnosticsServiceTests` に影響がないことも確認済み。
   - 03_画面設計書 §3.22／04_機能設計書 §18.4・§19.2／05_クラス設計書 §3.3・§5.5／07_テスト設計書 §1.1a（単体 4,088→4,110・合計 4,114→4,136 件）・§2.55 UT-072 を同期更新（#1716）
 
+**リファクタリング**
+- Issue #1785 データ入出力ダイアログの**インポート2コマンドの複製を解消**した。「直接インポート(_R)」にバインドされた `DataExportImportViewModel.ImportAsync` は `ExecuteImportAsync` の全文複製で、**約115行中8行しか差が無かった**（インポート元が `dialog.FileName` か確定済みローカル変数かという点のみ。データ種別の switch・`LastImportedFile` 代入・`HasImported` 設定・成功/エラー/部分成功の3分岐・`TryLogImportAsync` 2箇所・catch まで同一）。結果処理・監査記録に関わる修正を毎回2箇所へ適用する必要があり、片方だけ直すと「一方の経路だけ壊れている」非対称が生じる。Issue #1741 では実際にこの非対称が発生しており、複製側が無傷であることを別途確認する作業が発生した。
+  - インポート本体を `RunImportAsync(string sourceFilePath, bool clearPreviewOnSuccess)`、結果の通知・監査記録を `HandleImportResultAsync(...)` として抽出し、両コマンドから呼ぶ構造にした。コマンド側に残るのは**インポート元の決定だけ**（`ExecuteImportAsync` はプレビューの検証と確定済みパス、`ImportAsync` は `OpenFileDialog` の選択結果）。`DataExportImportViewModel.cs` は 1,135 → 1,055 行。
+  - **唯一の挙動差は引数で表す**。プレビュー経由の経路は成功時に `ClearPreview()` を呼ぶが、直接インポートはプレビューを入力としないため呼ばない。一律クリアにするとプレビュー確認中の職員の作業状態を勝手に捨てることになるため、`clearPreviewOnSuccess` で明示的に切り替える。`ClearPreview()` の呼び出し位置（ステータス設定の後・監査記録の前）も元のままにし、完了ダイアログが出る時点でプレビューが消えている表示順を保存した。
+  - **挙動不変**。`#if DEBUG` のデバッグ出力ラベルのみ `[ExecuteImport Error]` / `[Import Error]` の2系統から `[Import Error]`（StackTrace 併記）へ統一した（Release ビルドには影響しない）。
+  - **これまでテスト不能だった経路を検証可能にした**。`ImportAsync` は `OpenFileDialog` をコマンド内で生成するため単体テストから起動できず、この経路の結果処理は一度もテストされていなかった。`RunImportAsync` を `internal` にしたことで複製側の設定（`clearPreviewOnSuccess: false`）を直接検証できる。
+  - 検証: `DataExportImportViewModelTests` に5件（直接インポート経路の成功／部分成功／失敗／監査ログ記録失敗／プレビュー非クリア）、`DataExportImportViewModelImportPathSharingTests` を新設して6件（+11、全4,644件パス）。**複製の復活は挙動テストでは表明できない**（複製された2つの実装が偶然どちらも正しい間は緑のまま通る）ため、レイアウト規約テストと同じくソーステキストを検査し、両コマンド本体がサービス呼び出し・監査記録・完了通知を持たないことと、インポートサービスの呼び分けがファイル全体で1箇所であることを固定した。リファクタ前のソースに対して同じ検査を行うと落ちること（禁止要素12行／出現回数2）を確認済み。
+  - 05_クラス設計書 §5.17／07_テスト設計書 §1.1a（単体 4,580→4,591・合計 4,606→4,617 件）・§2 UT-028 No.18〜22・UT-028a を同期更新（#1785）
+
 **ドキュメント**
 - Issue #1695 **交通系固有ロジックの境界を文書化し、規約テストで固定した**（2026-07-10 ユーザビリティ総合検討 Phase 3）。本システムのコア（タッチ認証→貸出/返却→出納簿）は「複数職員でシェアする物品の出納管理」として交通系ICカード以外（社用携帯・鍵・公用車両等）にも通用するが、どこまでが交通系固有かがどこにも書かれておらず、改修のたびに各自が判断していた。**今すぐの汎用化は行わず**、境界の可視化と保全のみを行う（YAGNI）。
   - **3リング境界モデル**を 05_クラス設計書 §2a に新設した。中心＝汎用コア（staff／貸出返却の状態遷移／30秒ルール／ledger の受入・払出・残額／繰越・月計・累計／操作ログ／バックアップ／帳票骨格）、中間＝交通系アダプタ（`ICardReader` 実装／`CardType`／`LedgerDetail` の乗車駅・降車駅・バス停）、外側＝交通系固有（駅名摘要／バス判別／往復・乗継・循環判定／`StationMasterService`／`FelicaHistoryBlockDecoder`）。ルールは「内側のリングに外側リングの知識を持ち込まない」の1点。**この境界はレイヤー構成（Presentation/Business/Data/Infrastructure）と直交する縦串**で、交通系固有性は3層すべてに分散しているため既存のレイヤー図では表現できない。

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -1560,12 +1560,12 @@ classDiagram
 
 **Issue #1741**: 一括操作ログの呼び出し・記録・表示について、次の3点を守ること。
 
-1. **`filePath` / `tableName` に画面の一時状態プロパティを直接渡さない。** 監査記録の入力（何を取り込んだか）とビュー状態（いま何を選んでいるか）は寿命が異なる。`ExecuteImportAsync` は成功分岐で `ClearPreview()` が `ImportPreviewFile` を空にした後に `LogImportAsync(..., ImportPreviewFile, ...)` を呼んでいたため、`TargetId` と `AfterData.FilePath` が空文字の監査行が残っていた。`Path.GetFileName("")` は例外を投げず空文字を返すので、**この欠落は無言で起きる**。`SelectedImportType` も同様に await 後に読まれており（データ種別コンボはアクセスキーを持ち `IsBusy` 中も操作できる）、実際とは異なる `TargetTable` を記録し得た。呼び出し元は**操作の開始時にパスと対象テーブルをローカル変数へ確定**させ、記録までその値を使い回すこと。
+1. **`filePath` / `tableName` に画面の一時状態プロパティを直接渡さない。** 監査記録の入力（何を取り込んだか）とビュー状態（いま何を選んでいるか）は寿命が異なる。`ExecuteImportAsync` は成功分岐で `ClearPreview()` が `ImportPreviewFile` を空にした後に `LogImportAsync(..., ImportPreviewFile, ...)` を呼んでいたため、`TargetId` と `AfterData.FilePath` が空文字の監査行が残っていた。`Path.GetFileName("")` は例外を投げず空文字を返すので、**この欠落は無言で起きる**。`SelectedImportType` も同様に await 後に読まれており（データ種別コンボはアクセスキーを持ち `IsBusy` 中も操作できる）、実際とは異なる `TargetTable` を記録し得た。呼び出し元は**操作の開始時にパスと対象テーブルをローカル変数へ確定**させ、記録までその値を使い回すこと。なお本欠陥の調査時、同じ結果処理が `ImportAsync`（直接インポート）に全文複製されており、複製側が無傷であることを別途確認する作業が発生した。**Issue #1785 で結果処理を `DataExportImportViewModel.RunImportAsync` / `HandleImportResultAsync` へ共通化済み**であり、インポート結果の扱いを変更するときはコマンド側へ複製せず共通メソッドへ書くこと（複製の復活は `DataExportImportViewModelImportPathSharingTests` が検出する）。
 2. **記録の失敗を業務処理の失敗として通知しない。** 本 API 群は `OperationLogRepository` まで含めて例外を握りつぶさないため、共有モードでは `SQLITE_BUSY` が実際に送出される。データの書き込みが確定した後に呼ぶ以上、例外を業務処理の `catch` へ流すと**確定済みの操作が「失敗」と通知され、再実行による二重登録**を招く（#1727「コミット確定後の後処理を、成否の判定に巻き込まない」）。呼び出し元は記録だけを個別に `try/catch` し（`DataExportImportViewModel.TryLogImportAsync` が参考実装）、失敗時は「処理は完了済み・再実行しない・管理者へ連絡」を案内する。**無言で握りつぶさない**（技術的詳細はログへ）。
 3. **payload に項目を足したら表示側2か所にも足す。** 一括操作の payload は**対象テーブルではなく Action で形が決まる**ため、テーブル別の仕組みからは漏れる。① `OperationLogExcelExportService.GetFieldNameMap` は全テーブルのマップへ一括操作項目（`BulkOperationFieldNames`）を併合する（マップに無いプロパティは読み飛ばされ、Excel の「変更前 / 変更後」列が空欄になる。#1726 と同型） ② `OperationLogSearchViewModel.GenerateTargetDisplayName` は payload に `FileName` があればそれを「対象詳細」列に表示する（テーブル別の生成メソッドはエンティティ項目しか見ないため必ず空になる）。`RESTORE` は DB 丸ごとリストアと `LogStaffRestoreAsync`（レコード単位復元）で共用されるため、**Action ではなく `FileName` の有無で振り分ける**。
 
 **呼び出し元**:
-- `DataExportImportViewModel.ExportAsync` / `ExecuteImportAsync` / `ImportAsync` — CSV 操作の成功時（部分成功時も `ImportedCount > 0` なら記録）
+- `DataExportImportViewModel.ExportAsync` / `HandleImportResultAsync`（`ExecuteImportAsync`・`ImportAsync` の両コマンドが `RunImportAsync` 経由で到達する共通の結果処理、Issue #1785） — CSV 操作の成功時（部分成功時も `ImportedCount > 0` なら記録）
 - `SystemManageViewModel.CreateBackupAsync` / `RestoreAsync` / `RestoreFromFileAsync` — バックアップ・リストアの成功時
 - リストア成功後の `operation_log` は**リストア後の新 DB** に記録される（既存 DB 接続が同一パスの新ファイルを参照するため）
 

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 4,580件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 4,591件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **4,606件** | 全件パス（最終同期: Issue #1741 インポート成功時の監査ログにファイルパスが空で記録される問題を修正。`DataExportImportViewModelTests` に6件・`OperationLogExcelExportServiceTests` に5件・`OperationLogSearchViewModelTests` に4件（+15）、UT-028 No.12〜17／UT-033 No.11〜14／UT-033b。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,580 + 26 = 4,606 と比較） |
+| **合計** | **4,617件** | 全件パス（最終同期: Issue #1785 `ImportAsync` と `ExecuteImportAsync` の複製解消。`DataExportImportViewModelTests` に5件・`DataExportImportViewModelImportPathSharingTests` を新設して6件（+11）、UT-028 No.18〜22／UT-028a。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,591 + 26 = 4,617 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >
@@ -2162,8 +2162,29 @@ Issue #1574 で「（貸出中）」状態の履歴行を削除可能にする�
 | 15 | **await 中にデータ種別が変わっても対象テーブルは実際の取込先**（Issue #1741） | カードインポート実行中に `SelectedImportType=Staff` へ切替（Callback で再現） | `target_table="ic_card"`、`after_data.FilePath` はインポート元のフルパス |
 | 16 | **監査ログ記録の失敗を取り込み失敗として通知しない**（Issue #1741） | `IOperationLogRepository.InsertAsync` が例外、インポートは成功（3件） | `IsStatusError=false`、`HasImported=true`、`ShowError` は呼ばれず、`ShowWarning` に「操作ログへの記録に失敗」「再度インポートしないでください」を含む |
 | 17 | **部分成功時も同様**（Issue #1741） | 同上で `ImportedCount=2, ErrorCount=1` | `IsStatusError=false`、`ShowError` は呼ばれず、`ShowWarning` に「一部エラー」＋「操作ログへの記録に失敗」を含む |
+| 18 | **直接インポートは成功してもプレビューを消さない**（Issue #1785） | プレビュー表示中に `RunImportAsync(別パス, clearPreviewOnSuccess: false)` が成功 | `HasPreview=true`、`ImportPreviewFile` 保持、`LastImportedFile` は引数のパス、`HasImported=true` |
+| 19 | **直接インポート成功時の監査ログ**（Issue #1785） | `RunImportAsync(C:\temp\staff_20260811.csv, false)` でカードインポート成功（4件） | インポートサービスが引数のパスで1回呼ばれる、`target_id="staff_20260811.csv"`、`after_data.FilePath` がフルパス、`ShowInformation("4件")` |
+| 20 | **直接インポートの部分成功**（Issue #1785） | 同上で `ImportedCount=2, ErrorCount=1`（行3: IDmが不正です） | `ImportErrors` が「行3: IDmが不正です」1件、`HasImported=true`、`ShowWarning("一部エラー")`、監査ログにフルパス |
+| 21 | **直接インポートの失敗**（Issue #1785） | `ErrorMessage="ヘッダー行が想定と異なります"`、`ImportedCount=0` | `IsStatusError=true`、`HasImported=false`、`ShowError` にエラー文言、`operation_log` に IMPORT 行を残さない |
+| 22 | **直接インポートでも監査ログ記録の失敗を取り込み失敗として通知しない**（Issue #1741 / #1785） | `IOperationLogRepository.InsertAsync` が例外、インポートは成功（3件） | `IsStatusError=false`、`HasImported=true`、`ShowError` は呼ばれず、`ShowWarning` に「操作ログへの記録に失敗」「再度インポートしないでください」を含む |
 
 **テストクラス:** `DataExportImportViewModelTests`
+
+**Issue #1785 の回帰意図（No.18〜22）:** 「直接インポート(_R)」ボタンにバインドされた `ImportAsync` は `ExecuteImportAsync` の全文複製（約115行中8行しか差が無い）で、`OpenFileDialog` をコマンド内で生成するため単体テストから起動できず、**この経路の結果処理は一度もテストされていなかった**。Issue #1741 では実際に一方の経路だけが壊れており、複製側が無傷であることを別途確認する作業が発生している。共通メソッド `RunImportAsync(sourceFilePath, clearPreviewOnSuccess)` へ括り出したことで、複製側の設定（`clearPreviewOnSuccess: false`）を直接検証できるようになった。No.18 は共通化にあたって**唯一の挙動差**（成功時に `ClearPreview()` を呼ぶか）が失われていないことを固定する。一律クリアにすると、プレビュー確認中の職員の作業状態を勝手に捨てることになる。
+
+#### UT-028a: インポート2コマンドの複製解消（Issue #1785）
+
+複製が復活したことは**挙動テストでは表明できない**。両経路が同じ結果を返すことを何件テストしても、複製された2つの実装が偶然どちらも正しい間は緑のまま通るためである。検出したいのは「同じ修正を2箇所へ適用する義務が復活したこと」なので、レイアウト規約テストと同じくソーステキストを検査する。
+
+| No | テストケース | 検査対象 | 期待結果 |
+|----|-------------|---------|---------|
+| 1 | 直接インポートコマンドの委譲 | `ImportAsync()` の本体 | `OpenFileDialog`（抽出の妥当性）と `RunImportAsync(` を含み、`_importService.` / `TryLogImportAsync` / `_dialogService.Show` を含まない |
+| 2 | プレビュー経由コマンドの委譲 | `ExecuteImportAsync()` の本体 | 「プレビューを実行してください」（抽出の妥当性）と `RunImportAsync(` を含み、同3要素を含まない |
+| 3〜6 | 呼び分けの単一化 | `DataExportImportViewModel.cs` 全体 | `_importService.ImportCardsAsync(` / `ImportStaffAsync(` / `ImportLedgersAsync(` / `ImportLedgerDetailsAsync(` の出現回数がそれぞれ **1**（複製復活時は 2 になる） |
+
+**テストクラス:** `DataExportImportViewModelImportPathSharingTests`
+
+**検出力の確認:** リファクタ前のソース（`origin/main`）に対して同じ検査を行うと、No.1 は禁止要素12行を含み、No.3〜6 は出現回数が 2 となって落ちる。「抽出の妥当性」を併せて表明しているのは、メソッド改名やシグネチャ変更で抽出範囲が空振りしたときに検査が無言で素通りするのを防ぐため（`.claude/rules/development-conventions.md`「禁止された配置の不在だけでなく正しい置き場所の存在も検査する」に従う）。
 
 **Issue #1741 の回帰意図（No.15〜17）:**
 

--- a/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
+++ b/ICCardManager/src/ICCardManager/ViewModels/DataExportImportViewModel.cs
@@ -613,6 +613,34 @@ public partial class DataExportImportViewModel : ViewModelBase
             return;
         }
 
+        // Issue #1741: インポート元パスをここで確定させて引数として渡す。
+        // ImportPreviewFile は画面の一時状態で、成功分岐の ClearPreview() が空にするため、
+        // 取り込み後に読み直すと監査ログへ空パスが記録される。
+        await RunImportAsync(ImportPreviewFile, clearPreviewOnSuccess: true);
+    }
+
+    /// <summary>
+    /// インポート本体。プレビュー経由（<see cref="ExecuteImportAsync"/>）と
+    /// 直接インポート（<see cref="ImportAsync"/>）の共通処理（Issue #1785）
+    /// </summary>
+    /// <param name="sourceFilePath">
+    /// 取り込む CSV のパス。呼び出し元で確定済みの値を渡すこと（Issue #1741）。
+    /// 画面状態のプロパティを本メソッド内で読み直してはならない。
+    /// </param>
+    /// <param name="clearPreviewOnSuccess">
+    /// 成功時にプレビュー表示を消すか。プレビュー経由の経路は取り込み済みのプレビューが
+    /// 画面に残らないよう <c>true</c>、直接インポートは無関係なプレビューを消さないよう <c>false</c>。
+    /// </param>
+    /// <remarks>
+    /// 2つのコマンドは差分8行の全文複製（約115行）で、結果処理・監査記録に関わる修正を
+    /// 毎回2箇所へ適用する必要があった。Issue #1741 では実際に一方の経路だけが壊れており、
+    /// 複製側が無傷であることを別途確認する作業が発生した。
+    /// インポートの分岐を増やすときは必ずここへ書き、コマンド側へ複製しないこと。
+    /// テストから直接呼べるよう internal にしている（<see cref="ImportAsync"/> は
+    /// <see cref="OpenFileDialog"/> をコマンド内で生成するため単体テストから起動できない）。
+    /// </remarks>
+    internal async Task RunImportAsync(string sourceFilePath, bool clearPreviewOnSuccess)
+    {
         ImportErrors.Clear();
 
         using (BeginBusy("インポート中..."))
@@ -623,31 +651,29 @@ public partial class DataExportImportViewModel : ViewModelBase
             {
                 CsvImportResult result;
 
-                // Issue #1741: インポート元パスと対象データ種別をここでローカル変数へ確定させる。
-                // どちらも画面の一時状態で、ImportPreviewFile は成功分岐の ClearPreview() が空にし、
-                // SelectedImportType は await 中のキー操作（データ種別コンボのアクセスキー）で変わり得る。
-                // 監査ログ記録時にプロパティを読み直すと、空パスや実際とは異なる対象テーブルが記録される。
-                var importSourceFilePath = ImportPreviewFile;
+                // Issue #1741: 対象データ種別をここでローカル変数へ確定させる。
+                // SelectedImportType は await 中のキー操作（データ種別コンボのアクセスキー）で変わり得るため、
+                // 監査ログ記録時にプロパティを読み直すと実際とは異なる対象テーブルが記録される。
                 var importDataType = SelectedImportType;
                 var importTargetTable = MapDataTypeToTableName(importDataType);
 
                 switch (importDataType)
                 {
                     case DataType.Cards:
-                        result = await _importService.ImportCardsAsync(importSourceFilePath, SkipExistingOnImport);
+                        result = await _importService.ImportCardsAsync(sourceFilePath, SkipExistingOnImport);
                         break;
 
                     case DataType.Staff:
-                        result = await _importService.ImportStaffAsync(importSourceFilePath, SkipExistingOnImport);
+                        result = await _importService.ImportStaffAsync(sourceFilePath, SkipExistingOnImport);
                         break;
 
                     case DataType.Ledgers:
                         // Issue #511: ターゲットカードIDmを渡す
-                        result = await _importService.ImportLedgersAsync(importSourceFilePath, SkipExistingOnImport, GetTargetCardIdm());
+                        result = await _importService.ImportLedgersAsync(sourceFilePath, SkipExistingOnImport, GetTargetCardIdm());
                         break;
 
                     case DataType.LedgerDetails:
-                        result = await _importService.ImportLedgerDetailsAsync(importSourceFilePath);
+                        result = await _importService.ImportLedgerDetailsAsync(sourceFilePath);
                         break;
 
                     default:
@@ -655,7 +681,7 @@ public partial class DataExportImportViewModel : ViewModelBase
                         return;
                 }
 
-                LastImportedFile = importSourceFilePath;
+                LastImportedFile = sourceFilePath;
 
                 // Issue #744: インポート実行済みフラグを設定（ダイアログ終了後のリフレッシュ用）
                 if (result.ImportedCount > 0)
@@ -663,77 +689,7 @@ public partial class DataExportImportViewModel : ViewModelBase
                     HasImported = true;
                 }
 
-                if (result.Success)
-                {
-                    var message = $"インポート完了: {result.ImportedCount}件を登録しました";
-                    if (result.SkippedCount > 0)
-                    {
-                        message += $"（{result.SkippedCount}件はスキップ）";
-                    }
-                    SetStatus(message, false);
-                    ClearPreview();
-
-                    // Issue #1302: 監査ログ記録
-                    // Issue #1741: 直前の ClearPreview() で空になる ImportPreviewFile ではなく
-                    // 確定済みのローカル変数を渡す（空パスだと後からファイルを追跡できない）
-                    var auditLogged = await TryLogImportAsync(importTargetTable, importSourceFilePath, result);
-
-                    var completionMessage =
-                        $"インポートが完了しました。\n\n登録件数: {result.ImportedCount}件"
-                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "");
-
-                    if (auditLogged)
-                    {
-                        _dialogService.ShowInformation(completionMessage, "インポート完了");
-                    }
-                    else
-                    {
-                        _dialogService.ShowWarning(
-                            completionMessage + AuditLogFailureNotice,
-                            "インポート完了（操作ログ記録の失敗あり）");
-                    }
-                }
-                else if (!string.IsNullOrEmpty(result.ErrorMessage))
-                {
-                    SetStatus($"インポートエラー: {result.ErrorMessage}", true);
-                    _dialogService.ShowError(
-                        $"インポートに失敗しました。\n\n{result.ErrorMessage}",
-                        "インポートエラー");
-                }
-                else
-                {
-                    var message = $"インポート完了（一部エラー）: {result.ImportedCount}件を登録、{result.ErrorCount}件がエラー";
-                    if (result.SkippedCount > 0)
-                    {
-                        message += $"、{result.SkippedCount}件はスキップ";
-                    }
-                    SetStatus(message, false);
-
-                    // エラー詳細を追加
-                    foreach (var error in result.Errors.Take(10))
-                    {
-                        ImportErrors.Add($"行{error.LineNumber}: {error.Message}");
-                    }
-
-                    if (result.Errors.Count > 10)
-                    {
-                        ImportErrors.Add($"... 他 {result.Errors.Count - 10}件のエラー");
-                    }
-
-                    // Issue #1302: 部分成功でもデータは書き込まれたため監査ログ記録
-                    var partialAuditLogged = true;
-                    if (result.ImportedCount > 0)
-                    {
-                        partialAuditLogged = await TryLogImportAsync(importTargetTable, importSourceFilePath, result);
-                    }
-
-                    _dialogService.ShowWarning(
-                        $"インポートが完了しましたが、一部エラーがあります。\n\n登録件数: {result.ImportedCount}件\nエラー: {result.ErrorCount}件"
-                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "")
-                        + "\n\n詳細はエラー一覧を確認してください。"
-                        + (partialAuditLogged ? "" : AuditLogFailureNotice),
-                        "インポート完了（一部エラー）");
-                }
+                await HandleImportResultAsync(result, sourceFilePath, importTargetTable, clearPreviewOnSuccess);
             }
             catch (Exception ex)
             {
@@ -743,9 +699,101 @@ public partial class DataExportImportViewModel : ViewModelBase
                 SetStatus(importErrorMessage, true);
                 _dialogService.ShowError(importErrorMessage, "インポートエラー");
 #if DEBUG
-                System.Diagnostics.Debug.WriteLine($"[ExecuteImport Error] {ex.GetType().Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[Import Error] {ex.GetType().Name}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"[Import Error] StackTrace: {ex.StackTrace}");
 #endif
             }
+        }
+    }
+
+    /// <summary>
+    /// インポート結果（成功／失敗／部分成功）の通知・監査ログ記録を行う（Issue #1785）
+    /// </summary>
+    /// <param name="result">インポートサービスの実行結果</param>
+    /// <param name="sourceFilePath">監査ログへ記録するインポート元パス（確定済みの値）</param>
+    /// <param name="targetTable">監査ログへ記録する対象テーブル（確定済みの値）</param>
+    /// <param name="clearPreviewOnSuccess">成功時にプレビュー表示を消すか</param>
+    private async Task HandleImportResultAsync(
+        CsvImportResult result,
+        string sourceFilePath,
+        string targetTable,
+        bool clearPreviewOnSuccess)
+    {
+        if (result.Success)
+        {
+            var message = $"インポート完了: {result.ImportedCount}件を登録しました";
+            if (result.SkippedCount > 0)
+            {
+                message += $"（{result.SkippedCount}件はスキップ）";
+            }
+            SetStatus(message, false);
+
+            if (clearPreviewOnSuccess)
+            {
+                ClearPreview();
+            }
+
+            // Issue #1302: 監査ログ記録
+            // Issue #1741: 直前の ClearPreview() で空になる ImportPreviewFile ではなく
+            // 呼び出し元が確定させた引数を使う（空パスだと後からファイルを追跡できない）。
+            // 記録の失敗を取り込みの失敗として通知しない（TryLogImportAsync の remarks 参照）
+            var auditLogged = await TryLogImportAsync(targetTable, sourceFilePath, result);
+
+            var completionMessage =
+                $"インポートが完了しました。\n\n登録件数: {result.ImportedCount}件"
+                + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "");
+
+            if (auditLogged)
+            {
+                _dialogService.ShowInformation(completionMessage, "インポート完了");
+            }
+            else
+            {
+                _dialogService.ShowWarning(
+                    completionMessage + AuditLogFailureNotice,
+                    "インポート完了（操作ログ記録の失敗あり）");
+            }
+        }
+        else if (!string.IsNullOrEmpty(result.ErrorMessage))
+        {
+            SetStatus($"インポートエラー: {result.ErrorMessage}", true);
+            _dialogService.ShowError(
+                $"インポートに失敗しました。\n\n{result.ErrorMessage}",
+                "インポートエラー");
+        }
+        else
+        {
+            var message = $"インポート完了（一部エラー）: {result.ImportedCount}件を登録、{result.ErrorCount}件がエラー";
+            if (result.SkippedCount > 0)
+            {
+                message += $"、{result.SkippedCount}件はスキップ";
+            }
+            SetStatus(message, false);
+
+            // エラー詳細を追加
+            foreach (var error in result.Errors.Take(10))
+            {
+                ImportErrors.Add($"行{error.LineNumber}: {error.Message}");
+            }
+
+            if (result.Errors.Count > 10)
+            {
+                ImportErrors.Add($"... 他 {result.Errors.Count - 10}件のエラー");
+            }
+
+            // Issue #1302: 部分成功でもデータは書き込まれたため監査ログ記録
+            var partialAuditLogged = true;
+            if (result.ImportedCount > 0)
+            {
+                partialAuditLogged = await TryLogImportAsync(targetTable, sourceFilePath, result);
+            }
+
+            _dialogService.ShowWarning(
+                $"インポートが完了しましたが、一部エラーがあります。\n\n登録件数: {result.ImportedCount}件\nエラー: {result.ErrorCount}件"
+                + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "")
+                + "\n\n詳細はエラー一覧を確認してください。"
+                + (partialAuditLogged ? "" : AuditLogFailureNotice),
+                "インポート完了（一部エラー）");
         }
     }
 
@@ -767,7 +815,7 @@ public partial class DataExportImportViewModel : ViewModelBase
     /// </summary>
     /// <remarks>
     /// 監査ログ記録は取り込みがコミットされた後の後処理であり、ここでの失敗を
-    /// <see cref="ExecuteImportAsync"/> の catch へ流すと、確定済みの取り込みが
+    /// <see cref="RunImportAsync"/> の catch へ流すと、確定済みの取り込みが
     /// 「インポートに失敗しました」と通知され、職員が再実行して二重登録を招く。
     /// CLAUDE.md（Issue #1727）の「コミット確定後の後処理を、成否の判定に巻き込まない」に従う。
     /// <see cref="OperationLogger.LogImportAsync"/> は内部で例外を握りつぶさないため、
@@ -824,137 +872,9 @@ public partial class DataExportImportViewModel : ViewModelBase
             return;
         }
 
-        ImportErrors.Clear();
-
-        using (BeginBusy("インポート中..."))
-        {
-            // Issue #1062: UIスレッドにプログレスバー描画の機会を与える
-            await Task.Yield();
-            try
-            {
-                CsvImportResult result;
-
-                // Issue #1741: 対象データ種別をローカル変数へ確定させる。
-                // await 中に画面のデータ種別が変わると、監査ログが実際とは異なる対象テーブルを記録する。
-                // （インポート元パスはこの経路では最初からローカルの dialog.FileName を使っている）
-                var importDataType = SelectedImportType;
-                var importTargetTable = MapDataTypeToTableName(importDataType);
-
-                switch (importDataType)
-                {
-                    case DataType.Cards:
-                        result = await _importService.ImportCardsAsync(dialog.FileName, SkipExistingOnImport);
-                        break;
-
-                    case DataType.Staff:
-                        result = await _importService.ImportStaffAsync(dialog.FileName, SkipExistingOnImport);
-                        break;
-
-                    case DataType.Ledgers:
-                        // Issue #511: ターゲットカードIDmを渡す
-                        result = await _importService.ImportLedgersAsync(dialog.FileName, SkipExistingOnImport, GetTargetCardIdm());
-                        break;
-
-                    case DataType.LedgerDetails:
-                        result = await _importService.ImportLedgerDetailsAsync(dialog.FileName);
-                        break;
-
-                    default:
-                        SetStatus("不正なデータタイプです", true);
-                        return;
-                }
-
-                LastImportedFile = dialog.FileName;
-
-                // Issue #744: インポート実行済みフラグを設定（ダイアログ終了後のリフレッシュ用）
-                if (result.ImportedCount > 0)
-                {
-                    HasImported = true;
-                }
-
-                if (result.Success)
-                {
-                    var message = $"インポート完了: {result.ImportedCount}件を登録しました";
-                    if (result.SkippedCount > 0)
-                    {
-                        message += $"（{result.SkippedCount}件はスキップ）";
-                    }
-                    SetStatus(message, false);
-
-                    // Issue #1302: 監査ログ記録
-                    // Issue #1741: 記録の失敗を取り込みの失敗として通知しない（TryLogImportAsync の remarks 参照）
-                    var auditLogged = await TryLogImportAsync(importTargetTable, dialog.FileName, result);
-
-                    var completionMessage =
-                        $"インポートが完了しました。\n\n登録件数: {result.ImportedCount}件"
-                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "");
-
-                    if (auditLogged)
-                    {
-                        _dialogService.ShowInformation(completionMessage, "インポート完了");
-                    }
-                    else
-                    {
-                        _dialogService.ShowWarning(
-                            completionMessage + AuditLogFailureNotice,
-                            "インポート完了（操作ログ記録の失敗あり）");
-                    }
-                }
-                else if (!string.IsNullOrEmpty(result.ErrorMessage))
-                {
-                    SetStatus($"インポートエラー: {result.ErrorMessage}", true);
-                    _dialogService.ShowError(
-                        $"インポートに失敗しました。\n\n{result.ErrorMessage}",
-                        "インポートエラー");
-                }
-                else
-                {
-                    var message = $"インポート完了（一部エラー）: {result.ImportedCount}件を登録、{result.ErrorCount}件がエラー";
-                    if (result.SkippedCount > 0)
-                    {
-                        message += $"、{result.SkippedCount}件はスキップ";
-                    }
-                    SetStatus(message, false);
-
-                    // エラー詳細を追加
-                    foreach (var error in result.Errors.Take(10))
-                    {
-                        ImportErrors.Add($"行{error.LineNumber}: {error.Message}");
-                    }
-
-                    if (result.Errors.Count > 10)
-                    {
-                        ImportErrors.Add($"... 他 {result.Errors.Count - 10}件のエラー");
-                    }
-
-                    // Issue #1302: 部分成功でもデータは書き込まれたため監査ログ記録
-                    var partialAuditLogged = true;
-                    if (result.ImportedCount > 0)
-                    {
-                        partialAuditLogged = await TryLogImportAsync(importTargetTable, dialog.FileName, result);
-                    }
-
-                    _dialogService.ShowWarning(
-                        $"インポートが完了しましたが、一部エラーがあります。\n\n登録件数: {result.ImportedCount}件\nエラー: {result.ErrorCount}件"
-                        + (result.SkippedCount > 0 ? $"\nスキップ: {result.SkippedCount}件" : "")
-                        + "\n\n詳細はエラー一覧を確認してください。"
-                        + (partialAuditLogged ? "" : AuditLogFailureNotice),
-                        "インポート完了（一部エラー）");
-                }
-            }
-            catch (Exception ex)
-            {
-                // 技術的詳細はログへ。UI には 3 要素のユーザー向け文言を表示（Issue #1614）。
-                ErrorDialogHelper.LogException(ex, "インポート");
-                var importErrorMessage = ExceptionMessageFormatter.ToUserMessage(ex, "インポート");
-                SetStatus(importErrorMessage, true);
-                _dialogService.ShowError(importErrorMessage, "インポートエラー");
-#if DEBUG
-                System.Diagnostics.Debug.WriteLine($"[Import Error] {ex.GetType().Name}: {ex.Message}");
-                System.Diagnostics.Debug.WriteLine($"[Import Error] StackTrace: {ex.StackTrace}");
-#endif
-            }
-        }
+        // この経路のインポート元はプレビューではなくファイルダイアログの選択結果のため、
+        // 成功してもプレビュー表示はクリアしない（従来どおりの挙動）。
+        await RunImportAsync(dialog.FileName, clearPreviewOnSuccess: false);
     }
 
     /// <summary>

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelImportPathSharingTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelImportPathSharingTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using ICCardManager.Tests.Views.Helpers;
+using Xunit;
+
+namespace ICCardManager.Tests.ViewModels;
+
+/// <summary>
+/// インポートの2コマンドが結果処理を共有し続けることを、ソーステキスト上で固定する（Issue #1785）
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ImportAsync</c>（直接インポート）は <c>ExecuteImportAsync</c>（プレビュー経由）の全文複製で、
+/// 約115行中8行しか差が無かった。結果処理・監査記録の修正を毎回2箇所へ適用する必要があり、
+/// Issue #1741 では実際に一方の経路だけが壊れていた。
+/// </para>
+/// <para>
+/// この回帰は挙動テストでは表明できない。両経路が同じ結果を返すことを何件テストしても、
+/// 「コードが複製されている」状態そのものは緑のまま通るためである
+/// （複製された2つの実装が偶然どちらも正しい間は落ちない）。
+/// 検出したいのは「同じ修正を2箇所へ適用する義務が復活したこと」なので、
+/// 本プロジェクトのレイアウト規約テストと同じくソーステキストを検査する。
+/// </para>
+/// <para>
+/// <c>ImportAsync</c> は <c>OpenFileDialog</c> をコマンド内で生成するため単体テストから起動できず、
+/// 挙動側の担保は共通メソッド <c>RunImportAsync</c> を直接呼ぶ
+/// <see cref="DataExportImportViewModelTests"/> の「直接インポート経路」リージョンが担う。
+/// </para>
+/// </remarks>
+public class DataExportImportViewModelImportPathSharingTests
+{
+    private const string ExecuteImportSignature = "public async Task ExecuteImportAsync()";
+    private const string ImportSignature = "public async Task ImportAsync()";
+
+    /// <summary>
+    /// 直接インポートコマンドが、インポート元の決定だけを行い共通メソッドへ委譲していること
+    /// </summary>
+    [Fact]
+    public void ImportAsync_は結果処理を複製せず共通メソッドへ委譲すること()
+    {
+        var body = ExtractMethodBody(ReadViewModelSource(), ImportSignature);
+
+        // 抽出の妥当性: この経路はファイルダイアログでインポート元を選ぶ
+        body.Should().Contain(
+            "OpenFileDialog",
+            "抽出範囲が想定どおり ImportAsync の本体であること");
+
+        AssertDelegatesToSharedImport(body, ImportSignature);
+    }
+
+    /// <summary>
+    /// プレビュー経由のインポートコマンドが、入力検証だけを行い共通メソッドへ委譲していること
+    /// </summary>
+    [Fact]
+    public void ExecuteImportAsync_は結果処理を複製せず共通メソッドへ委譲すること()
+    {
+        var body = ExtractMethodBody(ReadViewModelSource(), ExecuteImportSignature);
+
+        // 抽出の妥当性: この経路はプレビュー未実行・バリデーションエラーを門前で弾く
+        body.Should().Contain(
+            "プレビューを実行してください",
+            "抽出範囲が想定どおり ExecuteImportAsync の本体であること");
+
+        AssertDelegatesToSharedImport(body, ExecuteImportSignature);
+    }
+
+    /// <summary>
+    /// データ種別ごとのインポートサービス呼び分けが、ファイル全体で1箇所だけであること
+    /// </summary>
+    /// <remarks>
+    /// 複製が復活すると各呼び出しが2箇所になる。Issue #511（台帳の対象カードIDm）のように
+    /// 引数が増える修正は、この呼び分けの箇所数だけ適用漏れの機会が生まれる。
+    /// </remarks>
+    [Theory]
+    [InlineData("_importService.ImportCardsAsync(")]
+    [InlineData("_importService.ImportStaffAsync(")]
+    [InlineData("_importService.ImportLedgersAsync(")]
+    [InlineData("_importService.ImportLedgerDetailsAsync(")]
+    public void インポートサービスの呼び分けはソース全体で1箇所であること(string invocation)
+    {
+        var source = ReadViewModelSource();
+
+        CountOccurrences(source, invocation).Should().Be(
+            1,
+            $"{invocation} が複数箇所にあると、引数を増やす修正のたびに適用漏れが起こるため");
+    }
+
+    /// <summary>
+    /// コマンド本体が結果処理（サービス呼び出し・監査ログ・完了通知）を持たず、共通メソッドを呼ぶこと
+    /// </summary>
+    private static void AssertDelegatesToSharedImport(string body, string signature)
+    {
+        body.Should().Contain(
+            "RunImportAsync(",
+            $"{signature} はインポート本体を共通メソッドへ委譲すること");
+        body.Should().NotContain(
+            "_importService.",
+            $"{signature} がインポートサービスを直接呼ぶと、データ種別の呼び分けが再び複製される");
+        body.Should().NotContain(
+            "TryLogImportAsync",
+            $"{signature} が監査ログを記録すると、記録内容の修正が2箇所必要になる（Issue #1741 の再発）");
+        body.Should().NotContain(
+            "_dialogService.Show",
+            $"{signature} が完了・エラー通知を持つと、文言の修正が2箇所必要になる");
+    }
+
+    private static string ReadViewModelSource()
+        => File.ReadAllText(
+            ViewSourceLocator.Resolve(Path.Combine("ViewModels", "DataExportImportViewModel.cs")));
+
+    /// <summary>
+    /// メソッドシグネチャ直後の <c>{</c> から対応する <c>}</c> までを本体として取り出す
+    /// </summary>
+    private static string ExtractMethodBody(string source, string signature)
+    {
+        var signatureIndex = source.IndexOf(signature, StringComparison.Ordinal);
+        signatureIndex.Should().BeGreaterOrEqualTo(
+            0,
+            $"検査対象 {signature} がソース中に存在すること（改名したら本テストも追随すること）");
+
+        var openIndex = source.IndexOf('{', signatureIndex + signature.Length);
+        openIndex.Should().BeGreaterOrEqualTo(0, $"{signature} の本体開始位置が見つかること");
+
+        var depth = 0;
+        for (var i = openIndex; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(openIndex + 1, i - openIndex - 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"{signature} の本体終端が見つかりませんでした");
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = source.IndexOf(value, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = source.IndexOf(value, index + value.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/ViewModels/DataExportImportViewModelTests.cs
@@ -924,4 +924,198 @@ public class DataExportImportViewModelTests : IDisposable
     }
 
     #endregion
+
+    #region 直接インポート経路（旧API互換）の結果処理（Issue #1785）
+
+    // ImportAsync（「直接インポート(_R)」ボタン）は OpenFileDialog をコマンド内で生成するため
+    // 単体テストから起動できない。Issue #1785 で結果処理を RunImportAsync へ共通化したことにより、
+    // この経路の設定（clearPreviewOnSuccess: false）を直接検証できるようになった。
+    // 共通化前は ExecuteImportAsync 側にしかテストが無く、複製側は無検証だった。
+
+    private const string DirectImportFileName = "staff_20260811.csv";
+    private static readonly string DirectImportFilePath =
+        System.IO.Path.Combine(ImportSourceDirectory, DirectImportFileName);
+
+    /// <summary>
+    /// 直接インポートは成功してもプレビュー表示をクリアしないこと（Issue #1785 で挙動を保存）
+    /// </summary>
+    /// <remarks>
+    /// プレビューは ExecuteImportAsync 経路の入力であり、直接インポートとは無関係。
+    /// 共通化にあたって一律クリアにすると、プレビュー確認中の職員の作業状態を勝手に捨てることになる。
+    /// </remarks>
+    [Fact]
+    public async Task RunImportAsync_直接インポート_成功してもプレビューをクリアしないこと()
+    {
+        // Arrange: プレビューを表示したまま直接インポートを実行する状況
+        SetupValidPreview();
+        _viewModel.ImportPreviewFile = ImportSourceFilePath;
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 3
+            });
+
+        // Act
+        await _viewModel.RunImportAsync(DirectImportFilePath, clearPreviewOnSuccess: false);
+
+        // Assert
+        _viewModel.HasPreview.Should().BeTrue("直接インポートはプレビューを入力としないため消してはならない");
+        _viewModel.ImportPreviewFile.Should().Be(ImportSourceFilePath);
+        _viewModel.LastImportedFile.Should().Be(
+            DirectImportFilePath,
+            "取り込んだのはダイアログで選んだファイルであるため");
+        _viewModel.HasImported.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 直接インポートでも、渡されたパスでインポートサービスが呼ばれ監査ログへ記録されること（Issue #1785）
+    /// </summary>
+    [Fact]
+    public async Task RunImportAsync_直接インポート_成功時に監査ログへファイルパスが記録されること()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 4
+            });
+
+        // Act
+        await _viewModel.RunImportAsync(DirectImportFilePath, clearPreviewOnSuccess: false);
+
+        // Assert
+        _importServiceMock.Verify(
+            s => s.ImportCardsAsync(DirectImportFilePath, It.IsAny<bool>()),
+            Times.Once,
+            "プレビューのパスではなく引数で渡したパスを取り込むこと");
+
+        var log = await GetSingleImportLogAsync();
+        log.TargetTable.Should().Be(OperationLogger.Tables.IcCard);
+        log.TargetId.Should().Be(DirectImportFileName);
+        GetAfterDataString(log, "FilePath").Should().Be(
+            DirectImportFilePath,
+            "どのファイルを取り込んだかを後から追跡できる必要があるため");
+        _dialogServiceMock.Verify(
+            d => d.ShowInformation(It.Is<string>(m => m.Contains("4件")), "インポート完了"),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// 直接インポートの部分成功時、エラー一覧の表示と監査ログ記録の両方が行われること（Issue #1785）
+    /// </summary>
+    [Fact]
+    public async Task RunImportAsync_直接インポート_部分成功時もエラー一覧と監査ログが揃うこと()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = null,
+                ImportedCount = 2,
+                ErrorCount = 1,
+                Errors = new List<CsvImportError>
+                {
+                    new CsvImportError { LineNumber = 3, Message = "IDmが不正です" }
+                }
+            });
+
+        // Act
+        await _viewModel.RunImportAsync(DirectImportFilePath, clearPreviewOnSuccess: false);
+
+        // Assert
+        _viewModel.ImportErrors.Should().ContainSingle()
+            .Which.Should().Be("行3: IDmが不正です");
+        _viewModel.HasImported.Should().BeTrue("2件は書き込まれているため");
+        _dialogServiceMock.Verify(
+            d => d.ShowWarning(It.Is<string>(m => m.Contains("一部エラー")), It.IsAny<string>()),
+            Times.Once);
+
+        var log = await GetSingleImportLogAsync();
+        GetAfterDataString(log, "FilePath").Should().Be(DirectImportFilePath);
+    }
+
+    /// <summary>
+    /// 直接インポートでもインポート自体の失敗はエラーダイアログで通知し、監査ログは記録しないこと（Issue #1785）
+    /// </summary>
+    [Fact]
+    public async Task RunImportAsync_直接インポート_失敗時はエラー通知のみで監査ログを残さないこと()
+    {
+        // Arrange
+        SetupValidPreview();
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = false,
+                ErrorMessage = "ヘッダー行が想定と異なります",
+                ImportedCount = 0
+            });
+
+        // Act
+        await _viewModel.RunImportAsync(DirectImportFilePath, clearPreviewOnSuccess: false);
+
+        // Assert
+        _viewModel.IsStatusError.Should().BeTrue();
+        _viewModel.HasImported.Should().BeFalse("1件も書き込まれていないため");
+        _dialogServiceMock.Verify(
+            d => d.ShowError(It.Is<string>(m => m.Contains("ヘッダー行が想定と異なります")), "インポートエラー"),
+            Times.Once);
+
+        var logs = await _operationLogRepository.GetByDateRangeAsync(
+            DateTime.Today.AddDays(-1),
+            DateTime.Today.AddDays(1));
+        logs.Should().NotContain(
+            l => l.Action == OperationLogger.Actions.Import,
+            "書き込みが発生していない以上インポートとして記録してはならない");
+    }
+
+    /// <summary>
+    /// 直接インポートでも監査ログ記録の失敗を取り込み失敗として通知しないこと（Issue #1741 / #1785）
+    /// </summary>
+    /// <remarks>
+    /// Issue #1741 の是正は ExecuteImportAsync 側でのみテストされていた。
+    /// 共通化後は同じ経路を通ることを、複製側の設定（clearPreviewOnSuccess: false）でも表明する。
+    /// </remarks>
+    [Fact]
+    public async Task RunImportAsync_直接インポート_監査ログ記録の失敗を取り込み失敗として通知しないこと()
+    {
+        // Arrange: operation_log への INSERT だけが失敗する ViewModel
+        var dialogServiceMock = new Mock<IDialogService>();
+        var viewModel = CreateViewModelWithFailingAuditLog(dialogServiceMock);
+        SetupValidPreview(viewModel);
+        _importServiceMock
+            .Setup(s => s.ImportCardsAsync(It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync(new CsvImportResult
+            {
+                Success = true,
+                ImportedCount = 3
+            });
+
+        // Act
+        await viewModel.RunImportAsync(DirectImportFilePath, clearPreviewOnSuccess: false);
+
+        // Assert
+        viewModel.IsStatusError.Should().BeFalse();
+        viewModel.HasImported.Should().BeTrue();
+        dialogServiceMock.Verify(
+            d => d.ShowError(It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never,
+            "取り込みは確定しているためエラーとして通知してはならない");
+        dialogServiceMock.Verify(
+            d => d.ShowWarning(
+                It.Is<string>(m => m.Contains("操作ログへの記録に失敗")
+                                   && m.Contains("再度インポートしないでください")),
+                It.IsAny<string>()),
+            Times.Once);
+    }
+
+    #endregion
 }

--- a/ICCardManager/tests/ICCardManager.Tests/Views/Helpers/ViewSourceLocator.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Views/Helpers/ViewSourceLocator.cs
@@ -16,6 +16,10 @@ namespace ICCardManager.Tests.Views.Helpers;
 /// 集約しないと、テスト出力ディレクトリの構成やソースレイアウトが変わったときに全クラスを
 /// 個別に直すことになり、直し漏れたクラスだけが静かに検査対象を見失う。
 /// </para>
+/// <para>
+/// 解決処理自体は拡張子を問わないため、XAML 以外のソーステキスト検査からも利用してよい
+/// （Issue #1785 の <c>DataExportImportViewModelImportPathSharingTests</c> が ViewModel の .cs を検査する）。
+/// </para>
 /// </remarks>
 public static class ViewSourceLocator
 {


### PR DESCRIPTION
Closes #1785

## 背景

「直接インポート(_R)」ボタン（`DataExportImportDialog.xaml:382`、`ImportCommand`）にバインドされた `DataExportImportViewModel.ImportAsync` は `ExecuteImportAsync` の全文複製で、**約115行中8行しか差が無かった**。

差分はインポート元が `dialog.FileName` か確定済みローカル変数かという点だけで、データ種別の switch・`LastImportedFile` 代入・`HasImported` 設定・成功/エラー/部分成功の3分岐・`TryLogImportAsync` 2箇所・catch まで同一だった。

結果処理・監査記録に関わる修正を毎回2箇所へ適用する必要があり、**片方だけ直すと「一方の経路だけ壊れている」非対称が生じる**。Issue #1741 では実際にこの非対称が発生しており、複製側が無傷であること（`dialog.FileName` がローカル変数相当だったため偶然無傷だった）を別途確認する作業が発生した。

## 変更内容

インポート本体を `RunImportAsync(string sourceFilePath, bool clearPreviewOnSuccess)`、結果の通知・監査記録を `HandleImportResultAsync(...)` として抽出し、両コマンドから呼ぶ構造にした。コマンド側に残るのは**インポート元の決定だけ**。

| コマンド | 残る責務 |
|---------|---------|
| `ExecuteImportAsync`（プレビュー確認後） | プレビュー未実行・バリデーションエラーの門前チェック → `RunImportAsync(ImportPreviewFile, clearPreviewOnSuccess: true)` |
| `ImportAsync`（直接インポート） | `OpenFileDialog` でファイル選択 → `RunImportAsync(dialog.FileName, clearPreviewOnSuccess: false)` |

`DataExportImportViewModel.cs` は 1,135 → 1,055 行。

### 唯一の挙動差は引数で表す

プレビュー経由の経路は成功時に `ClearPreview()` を呼ぶが、直接インポートはプレビューを入力としないため呼ばない。**一律クリアにするとプレビュー確認中の職員の作業状態を勝手に捨てることになる**ため、`clearPreviewOnSuccess` で明示的に切り替えた。`ClearPreview()` の呼び出し位置（ステータス設定の後・監査記録の前）も元のままにし、完了ダイアログが出る時点でプレビューが消えている表示順も保存している。

### 挙動不変

唯一の差異は `#if DEBUG` のデバッグ出力ラベルで、`[ExecuteImport Error]` / `[Import Error]` の2系統を `[Import Error]`（StackTrace 併記＝両者の上位集合）へ統一した。**Release ビルドには影響しない**。

### これまでテスト不能だった経路を検証可能にした

`ImportAsync` は `OpenFileDialog` をコマンド内で生成するため単体テストから起動できず、**この経路の結果処理は一度もテストされていなかった**（既存の `DataExportImportViewModel` 関連テストはすべて `ExecuteImportAsync` 側を検証していた）。`RunImportAsync` を `internal` にしたことで、複製側の設定（`clearPreviewOnSuccess: false`）を直接検証できるようになった。

## テスト

`dotnet test` **全 4,644 件パス（失敗0）**。Release 構成のビルド警告 0。

### 追加（+11 件）

**`DataExportImportViewModelTests`（+5 件、UT-028 No.18〜22）** — 直接インポート経路の結果処理

| No | 内容 |
|----|------|
| 18 | 成功してもプレビューをクリアしない（`HasPreview=true`・`ImportPreviewFile` 保持・`LastImportedFile` は引数のパス） |
| 19 | 成功時に引数のパスでサービスが呼ばれ、監査ログへ `target_id` / `after_data.FilePath` が記録される |
| 20 | 部分成功時にエラー一覧（`行3: IDmが不正です`）と監査ログが揃う |
| 21 | 失敗時は `ShowError` のみで、`operation_log` に IMPORT 行を残さない |
| 22 | 監査ログ記録の失敗を取り込み失敗として通知しない（#1741 の是正が複製側でも効いていること） |

**`DataExportImportViewModelImportPathSharingTests`（新設 6 件、UT-028a）** — 再複製の回帰ガード

複製の復活は**挙動テストでは表明できない**。両経路が同じ結果を返すことを何件テストしても、複製された2つの実装が偶然どちらも正しい間は緑のまま通るためである。検出したいのは「同じ修正を2箇所へ適用する義務が復活したこと」なので、本プロジェクトのレイアウト規約テストと同じくソーステキストを検査する。

- 両コマンド本体が `RunImportAsync(` を含み、`_importService.` / `TryLogImportAsync` / `_dialogService.Show` を含まないこと
- `_importService.Import{Cards,Staff,Ledgers,LedgerDetails}Async(` の出現回数がそれぞれファイル全体で **1**（複製復活時は 2）

**検出力の確認**: リファクタ前のソース（`origin/main`）に対して同じ検査を行うと、委譲テストは禁止要素12行を含んで落ち、出現回数は 4 種すべて 2 になることを確認済み。また「抽出の妥当性」（`ImportAsync` 本体に `OpenFileDialog` が、`ExecuteImportAsync` 本体に「プレビューを実行してください」が含まれること）を併せて表明し、メソッド改名で抽出範囲が空振りしたときに検査が無言で素通りするのを防いでいる。

### 手動確認のお願い

自動テストで固定できない部分として、**実際のダイアログ操作での表示順**をご確認いただけると確実です（コード上は呼び出し順を保存していますが、実描画は自動検証していないため）。

1. データ入出力ダイアログ（メイン画面の「データ入出力」）を開く
2. インポート種別「カード」でファイルを選び **プレビュー** → **インポート実行** → 完了ダイアログが出る時点でプレビュー一覧が消えていること
3. 続けて **プレビュー** を実行した状態で **直接インポート(_R)** を押し、成功後も**プレビュー一覧が残っていること**（本 PR で保存した挙動差）
4. わざと不正な CSV（IDm 列が壊れた行を含む）で 2. と 3. を実行し、エラー一覧と警告ダイアログの内容が従来どおりであること

## ドキュメント

- `05_クラス設計書.md` §5.17 — Issue #1741 の規約に共通化済みである旨を追記し、「呼び出し元」の記述を実装（`HandleImportResultAsync`）に同期
- `07_テスト設計書.md` §1.1a（単体 4,580→4,591・合計 4,606→4,617 件）、§2 UT-028 No.18〜22、UT-028a を追加
- `CHANGELOG.md` — `### Unreleased` の **リファクタリング** に追記

## 補足

Issue 本文に挙がっていた他の分離済み指摘（部分成功時のプレビュー未クリア、`LastImportedFile` の代入位置、`BeginBusy` スコープ内のモーダル表示）は**本 PR のスコープ外**です。挙動変更を伴うため、挙動不変のリファクタと混ぜるとレビューで切り分けられなくなります。本 PR のマージ後は、いずれも 1 箇所の修正で済みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDSy5UdSqtmSYLQaKgpM1E
