### PR TITLE
fix: 未観測Task例外ハンドラのモーダル表示によるファイナライザスレッド停止を解消 (#1742)

### DIFF
--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -50,12 +50,14 @@
 
 **バグ修正**
 - Issue #1742 **未観測 Task 例外ハンドラがファイナライザスレッドでモーダルダイアログを開く**問題を修正した。`TaskScheduler.UnobservedTaskException` は Task のファイナライズ時（＝ファイナライザスレッド）に発火するが、旧実装はそこから同期 `Dispatcher.Invoke` で `ErrorDialogHelper.ShowError`（モーダルの `MessageBox.Show`）を開いていたため、ユーザーが [OK] を押すまでファイナライザスレッドがブロックされ、プロセス全体のファイナライザ（SQLite 接続等の後始末）が停止していた。無人の共用端末では「バックグラウンド処理エラー」ダイアログが長時間放置され得る。
-  - **ハンドラ本体を `Common/UnobservedTaskExceptionHandler` へ抽出**し、①`e.SetObserved()` を最初に呼ぶ ②ログ記録（集約例外＋全内部例外） ③シャットダウンガード（`Dispatcher.HasShutdownStarted` / `HasShutdownFinished`）④`Dispatcher.BeginInvoke`（非同期）で**非モーダルのトースト通知**（`IToastNotificationService.ShowError`）、の形へ改めた。いかなる内部エラー（ロガー未初期化・ディスパッチ失敗・通知失敗）も外へ漏らさない — ファイナライザから例外が漏れるとプロセスが異常終了するため。
-  - **ロガー・トーストは発火時に遅延解決する**。`SetupGlobalExceptionHandlers` は DI コンテナ構築前（`OnStartup` 冒頭）に呼ばれるため、生成時に解決すると常に null を掴む。
-  - **トースト文言は簡潔表現とし、例外の詳細はログのみに残す**（`error-messages.md` のトースト例外規定。生の `ex.Message` を UI へ出さない #1614 の方針を踏襲）。エラートーストは自動消去されないため見逃しは防げる。
-  - **`App` は WPF `Application` のため単体テストから駆動できない**。挙動はデリゲート注入の `UnobservedTaskExceptionHandler` で検証し、`App.xaml.cs` 側の配線（同期 Invoke 禁止・モーダル禁止・ガード必須・SetObserved が先）はソーステキストの静的検証で固定する二段構えとした（`WpfDispatcherService.ObserveTask` と同じ判断）。静的検証はコメント除去後のコードのみを対象とし、「同期 Invoke を使わない」という戒めのコメントが禁止語検査に引っかかる極性反転を避けた。
-  - 検証: `UnobservedTaskExceptionHandlerTests`（8件）・`AppUnobservedTaskExceptionConventionTests`（4件）を新設（+12）。Release / Debug 双方のソリューションビルドが 0 警告であることも実測した。
-  - 05_クラス設計書 §9.5・§10.1a／07_テスト設計書 §1.1a（単体 4,622→4,634・合計 4,648→4,660 件）・§2 UT-080 を同期更新（#1742）
+  - **ハンドラ本体を `Common/UnobservedTaskExceptionHandler` へ抽出**し、①`e.SetObserved()` を最初に呼ぶ ②ログ記録（集約例外＋全内部例外） ③シャットダウンガード（`Dispatcher.HasShutdownStarted` / `HasShutdownFinished`）④`Dispatcher.BeginInvoke`（非同期）で**非モーダルのトースト通知**（`IToastNotificationService.ShowError`）、の形へ改めた。いかなる内部エラー（ログ記録失敗・ディスパッチ失敗・通知失敗）も外へ漏らさない — ファイナライザから例外が漏れるとプロセスが異常終了するため。
+  - **通知はクールダウン（5分）で間引く（ログは毎回記録）**。エラートーストは自動消去されない（クリックで閉じる）ため、共有モードのヘルスチェック失敗のような繰り返し発生する障害で発火のたびに通知すると、無人の共用端末にトーストが際限なく積み上がる（コードレビューで検出）。
+  - **ログ記録は ILogger が使えない時期も無痕跡にしない**。`SetupGlobalExceptionHandlers` は DI コンテナ構築前（`OnStartup` 冒頭）に呼ばれるため `_logger` はその時点で null。旧実装は `ErrorDialogHelper` が DI 非依存でファイルログも書いていたため、単純に ILogger へ寄せると構築前・構築失敗時の発火がどこにも残らなくなる（コードレビューで検出）。配線側で「`_logger` があれば ILogger／なければ `ErrorDialogHelper.LogException`（DI 非依存・ダイアログ非表示）」とフォールバックする。トーストの解決も同様に発火時の遅延解決とする。
+  - **トースト文言は `ExceptionMessageFormatter.ToUserMessage` で例外種別に応じて組み立てる**（生の `ex.Message` を UI へ出さない #1614 の方針。固定文言だと「管理者に連絡」と案内された管理者へ原因が伝わらない — コードレビューで検出。トースト本文は `TextWrapping="Wrap"` のため折り返して表示される）。
+  - **`App` は WPF `Application` のため単体テストから駆動できない**。挙動はデリゲート注入の `UnobservedTaskExceptionHandler` で検証し、`App.xaml.cs` 側の配線（同期 Invoke 禁止・モーダル禁止・ガード必須・SetObserved が先・フォールバックログ必須）はソーステキストの静的検証で固定する二段構えとした（`WpfDispatcherService.ObserveTask` と同じ判断）。
+  - **静的検証は「コードのみ」テキストを対象とする**（新設 `TestSourceInspection`）。コメント除去により「同期 Invoke を使わない」という戒めのコメントが禁止語検査に引っかかる極性反転を避けるのに加え、①生ソースへの波括弧対応はコメント・文字列内の `}` で抽出が黙って短縮される ②正規表現ベースの除去は文字列リテラル内の `//` を誤処理する、の 2 つの迂回経路を 1 パスの状態機械で塞いだ。禁止トークンも固定部分文字列ではなく正規表現（`\.Invoke\s*\(`）で照合し、空白挿入・中間変数による迂回を検出する（いずれもコードレビューで検出。検査ロジック自体を既知のサンプルで固定）。
+  - 検証: `UnobservedTaskExceptionHandlerTests`（10件）・`AppUnobservedTaskExceptionConventionTests`（5件）を新設（+15）。Release / Debug 双方のソリューションビルドが 0 警告であることも実測した。
+  - 05_クラス設計書 §9.5・§10.1a／07_テスト設計書 §1.1a（単体 4,622→4,637・合計 4,648→4,663 件）・§2 UT-080 を同期更新（#1742）
 - Issue #1786 **ビルド警告 CS8618**（`SettingsRepositorySetConcurrencyTests`）を解消した。Release / Debug いずれのビルドでも 1 件出ていた唯一の警告で、コミット 564b9be0（Issue #1737 / PR #1776）で追加したテストヘルパー `CleanupSimulator` の `_worker` フィールドが未初期化だったことによる。
   - **是正は宣言側で行い、`NoWarn` による抑制も `= null!` も使わない**。`_worker` は `StartAndWaitUntilTransactionOpenAsync` を呼ぶまで実際に null であり、`RollbackAndCompleteAsync` も `if (_worker != null)` で分岐している。`= null!` は「必ず非 null」とコンパイラに宣言することになり、この null チェックと矛盾する。正しい注釈は `Task?`。
   - **警告の「発生」を CI で止める**。`ci.yml` の code-quality ジョブに**ビルド警告ゼロ検証**を追加した（`: warning ` を含む行を数え、1 件でもあれば警告内容を出力して fail）。従来 CI に警告のゲートは無く、警告ゼロは「気付いた人が Issue を起票する」運用でしか担保されていなかった。`-warnaserror` は NuGet / MSBuild 警告まで昇格させて CI を不安定にするため使わない。

--- a/ICCardManager/CHANGELOG.md
+++ b/ICCardManager/CHANGELOG.md
@@ -49,6 +49,13 @@
   - 03_画面設計書 §1・§2・§3.15・§3.22／04_機能設計書 §19／05_クラス設計書 §3.2・§3.3・§10.3／07_テスト設計書 §1.1a（単体 3,912→4,024・合計 3,938→4,050 件）・§2.47a・§2.53 UT-DIAG-001〜004／管理者マニュアル §10.0・§10.2・§10.4・クイックガイド／`.claude/rules/error-messages.md` を同期更新（#1690）
 
 **バグ修正**
+- Issue #1742 **未観測 Task 例外ハンドラがファイナライザスレッドでモーダルダイアログを開く**問題を修正した。`TaskScheduler.UnobservedTaskException` は Task のファイナライズ時（＝ファイナライザスレッド）に発火するが、旧実装はそこから同期 `Dispatcher.Invoke` で `ErrorDialogHelper.ShowError`（モーダルの `MessageBox.Show`）を開いていたため、ユーザーが [OK] を押すまでファイナライザスレッドがブロックされ、プロセス全体のファイナライザ（SQLite 接続等の後始末）が停止していた。無人の共用端末では「バックグラウンド処理エラー」ダイアログが長時間放置され得る。
+  - **ハンドラ本体を `Common/UnobservedTaskExceptionHandler` へ抽出**し、①`e.SetObserved()` を最初に呼ぶ ②ログ記録（集約例外＋全内部例外） ③シャットダウンガード（`Dispatcher.HasShutdownStarted` / `HasShutdownFinished`）④`Dispatcher.BeginInvoke`（非同期）で**非モーダルのトースト通知**（`IToastNotificationService.ShowError`）、の形へ改めた。いかなる内部エラー（ロガー未初期化・ディスパッチ失敗・通知失敗）も外へ漏らさない — ファイナライザから例外が漏れるとプロセスが異常終了するため。
+  - **ロガー・トーストは発火時に遅延解決する**。`SetupGlobalExceptionHandlers` は DI コンテナ構築前（`OnStartup` 冒頭）に呼ばれるため、生成時に解決すると常に null を掴む。
+  - **トースト文言は簡潔表現とし、例外の詳細はログのみに残す**（`error-messages.md` のトースト例外規定。生の `ex.Message` を UI へ出さない #1614 の方針を踏襲）。エラートーストは自動消去されないため見逃しは防げる。
+  - **`App` は WPF `Application` のため単体テストから駆動できない**。挙動はデリゲート注入の `UnobservedTaskExceptionHandler` で検証し、`App.xaml.cs` 側の配線（同期 Invoke 禁止・モーダル禁止・ガード必須・SetObserved が先）はソーステキストの静的検証で固定する二段構えとした（`WpfDispatcherService.ObserveTask` と同じ判断）。静的検証はコメント除去後のコードのみを対象とし、「同期 Invoke を使わない」という戒めのコメントが禁止語検査に引っかかる極性反転を避けた。
+  - 検証: `UnobservedTaskExceptionHandlerTests`（8件）・`AppUnobservedTaskExceptionConventionTests`（4件）を新設（+12）。Release / Debug 双方のソリューションビルドが 0 警告であることも実測した。
+  - 05_クラス設計書 §9.5・§10.1a／07_テスト設計書 §1.1a（単体 4,622→4,634・合計 4,648→4,660 件）・§2 UT-080 を同期更新（#1742）
 - Issue #1786 **ビルド警告 CS8618**（`SettingsRepositorySetConcurrencyTests`）を解消した。Release / Debug いずれのビルドでも 1 件出ていた唯一の警告で、コミット 564b9be0（Issue #1737 / PR #1776）で追加したテストヘルパー `CleanupSimulator` の `_worker` フィールドが未初期化だったことによる。
   - **是正は宣言側で行い、`NoWarn` による抑制も `= null!` も使わない**。`_worker` は `StartAndWaitUntilTransactionOpenAsync` を呼ぶまで実際に null であり、`RollbackAndCompleteAsync` も `if (_worker != null)` で分岐している。`= null!` は「必ず非 null」とコンパイラに宣言することになり、この null チェックと矛盾する。正しい注釈は `Task?`。
   - **警告の「発生」を CI で止める**。`ci.yml` の code-quality ジョブに**ビルド警告ゼロ検証**を追加した（`: warning ` を含む行を数え、1 件でもあれば警告内容を出力して fail）。従来 CI に警告のゲートは無く、警告ゼロは「気付いた人が Issue を起票する」運用でしか担保されていなかった。`-warnaserror` は NuGet / MSBuild 警告まで昇格させて CI を不安定にするため使わない。

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -2139,7 +2139,7 @@ classDiagram
 | 1. `DispatcherOperation` | `Dispatcher.InvokeAsync` は例外を戻り値の `DispatcherOperation.Task` に格納する。`Invoke`（同期版）と違い `Application.DispatcherUnhandledException` は**発火しない** |
 | 2. 内側の `Task` | `InvokeAsync(Func<Task>)` は `InvokeAsync<TResult>` として解決され `DispatcherOperation<Task>` を返す。`.Task` は `Task<Task>` であり、**外側だけ観測しても async lambda 本体の例外は取りこぼす** |
 
-どちらも観測しないと `TaskScheduler.UnobservedTaskException`（`App.xaml.cs`）が **GC ファイナライズ時に遅れて発火するだけ**で、操作と無関係なタイミングで「バックグラウンド処理エラー」ダイアログが出る一方、障害調査に使えるログは残らない。Issue #1725 で `MainViewModel` の `Processing` 固着が無言のまま起きた原因の半分がこれ。
+どちらも観測しないと `TaskScheduler.UnobservedTaskException`（`App.xaml.cs`）が **GC ファイナライズ時に遅れて発火するだけ**で、操作と無関係なタイミングで「バックグラウンド処理エラー」トースト（Issue #1742 以前はモーダルダイアログ。§10.1a 参照）が出る一方、障害調査に使えるログは残らない。Issue #1725 で `MainViewModel` の `Processing` 固着が無言のまま起きた原因の半分がこれ。
 
 #### 実装
 
@@ -2186,6 +2186,35 @@ classDiagram
         -LogError(exception, errorCode, isFatal?)$ void
     }
 ```
+
+### 10.1a UnobservedTaskExceptionHandler（Issue #1742）
+
+```mermaid
+classDiagram
+    class UnobservedTaskExceptionHandler {
+        -Func~ILogger~ _getLogger
+        -Func~bool~ _isUiAvailable
+        -Action~Action~ _postToUi
+        -Action~Exception~ _notifyError
+        +Handle(AggregateException) void
+        -TryLog(Action~ILogger~) void
+    }
+
+    App ..> UnobservedTaskExceptionHandler : OnUnobservedTaskException から委譲
+```
+
+`TaskScheduler.UnobservedTaskException` のハンドラ本体。このイベントは Task のファイナライズ時（＝**ファイナライザスレッド**）に発火するため、ハンドラの振る舞いには通常のエラー提示と異なる制約がある。
+
+| 制約 | 理由 |
+|------|------|
+| 同期ディスパッチ（`Dispatcher.Invoke`）禁止 | UI 処理が完了するまでファイナライザスレッドがブロックされ、プロセス全体のファイナライザキュー（SQLite 接続等の後始末）が停止する |
+| モーダル表示（`ErrorDialogHelper` → `MessageBox.Show`）禁止 | 無人の共用端末では [OK] が押されるまで長時間放置され、上記ブロックが継続する |
+| 例外を一切外へ漏らさない | ファイナライザから例外が漏れるとプロセスが異常終了する |
+| シャットダウンガード（`HasShutdownStarted` / `HasShutdownFinished`）必須 | Dispatcher 停止後のポストは実行されず、例外の温床になるだけ |
+
+- **通知は `Dispatcher.BeginInvoke`（非同期）＋トースト（`IToastNotificationService.ShowError`、非モーダル）**。例外の詳細はログへ記録済みのため、トースト文言は簡潔表現とする（`error-messages.md` のトースト例外規定）
+- WPF 非依存のデリゲート注入とし、単体テストから駆動できるようにする（`WpfDispatcherService` が `Application.Current` 依存の本体から `ObserveTask` を切り出したのと同じ判断）。ロガー・トーストは**発火時に遅延解決**する（`SetupGlobalExceptionHandlers` は DI コンテナ構築前に呼ばれるため）
+- `App.OnUnobservedTaskException` は `e.SetObserved()` を**最初に**呼んでから本クラスへ委譲する。配線の制約は `AppUnobservedTaskExceptionConventionTests` がソーステキストの静的検証で固定し、本体の挙動は `UnobservedTaskExceptionHandlerTests` が検証する
 
 ### 10.2 PathValidator
 

--- a/ICCardManager/docs/design/05_クラス設計書.md
+++ b/ICCardManager/docs/design/05_クラス設計書.md
@@ -2192,12 +2192,15 @@ classDiagram
 ```mermaid
 classDiagram
     class UnobservedTaskExceptionHandler {
-        -Func~ILogger~ _getLogger
+        +NotificationCooldown$ TimeSpan
+        -Action~Exception,string~ _logError
         -Func~bool~ _isUiAvailable
         -Action~Action~ _postToUi
         -Action~Exception~ _notifyError
+        -Func~DateTime~ _utcNow
+        -DateTime _lastNotifiedUtc
         +Handle(AggregateException) void
-        -TryLog(Action~ILogger~) void
+        -TryLog(Exception, string) void
     }
 
     App ..> UnobservedTaskExceptionHandler : OnUnobservedTaskException から委譲
@@ -2208,13 +2211,15 @@ classDiagram
 | 制約 | 理由 |
 |------|------|
 | 同期ディスパッチ（`Dispatcher.Invoke`）禁止 | UI 処理が完了するまでファイナライザスレッドがブロックされ、プロセス全体のファイナライザキュー（SQLite 接続等の後始末）が停止する |
-| モーダル表示（`ErrorDialogHelper` → `MessageBox.Show`）禁止 | 無人の共用端末では [OK] が押されるまで長時間放置され、上記ブロックが継続する |
+| モーダル表示（`ErrorDialogHelper` の Show 系 → `MessageBox.Show`）禁止 | 無人の共用端末では [OK] が押されるまで長時間放置され、上記ブロックが継続する |
 | 例外を一切外へ漏らさない | ファイナライザから例外が漏れるとプロセスが異常終了する |
 | シャットダウンガード（`HasShutdownStarted` / `HasShutdownFinished`）必須 | Dispatcher 停止後のポストは実行されず、例外の温床になるだけ |
+| 通知はクールダウン（`NotificationCooldown` = 5分）で間引く | エラートーストは自動消去されない（クリックで閉じる）ため、共有モードのヘルスチェック失敗のような繰り返し発生する障害で発火のたびに通知すると、無人の共用端末にトーストが際限なく積み上がる。**ログは間引かず毎回記録する** |
 
-- **通知は `Dispatcher.BeginInvoke`（非同期）＋トースト（`IToastNotificationService.ShowError`、非モーダル）**。例外の詳細はログへ記録済みのため、トースト文言は簡潔表現とする（`error-messages.md` のトースト例外規定）
-- WPF 非依存のデリゲート注入とし、単体テストから駆動できるようにする（`WpfDispatcherService` が `Application.Current` 依存の本体から `ObserveTask` を切り出したのと同じ判断）。ロガー・トーストは**発火時に遅延解決**する（`SetupGlobalExceptionHandlers` は DI コンテナ構築前に呼ばれるため）
-- `App.OnUnobservedTaskException` は `e.SetObserved()` を**最初に**呼んでから本クラスへ委譲する。配線の制約は `AppUnobservedTaskExceptionConventionTests` がソーステキストの静的検証で固定し、本体の挙動は `UnobservedTaskExceptionHandlerTests` が検証する
+- **通知は `Dispatcher.BeginInvoke`（非同期）＋トースト（`IToastNotificationService.ShowError`、非モーダル）**。文言は `ExceptionMessageFormatter.ToUserMessage(ex, "バックグラウンド処理")` で**例外種別に応じて**組み立てる（固定文言だと「管理者に連絡」と案内された管理者へ原因が伝わらない。トースト本文は `TextWrapping="Wrap"` のため長めでも切れない）
+- **ログ記録は `Action<Exception, string>` デリゲートで受け、App 側の配線が経路を選ぶ**: `_logger`（ILogger）が使えればそちら、DI コンテナ構築前・構築失敗時は `ErrorDialogHelper.LogException`（DI 非依存のファイルログ `error_YYYYMMDD.log`、ダイアログ非表示）へフォールバックする。旧実装は `ErrorDialogHelper.ShowError` が DI 非依存でログも書いていたため、単純に ILogger へ寄せると**ロガー未初期化の時期の発火が無痕跡になる**（本 Issue のコードレビューで検出）
+- WPF 非依存のデリゲート注入とし、単体テストから駆動できるようにする（`WpfDispatcherService` が `Application.Current` 依存の本体から `ObserveTask` を切り出したのと同じ判断）。時刻も `Func<DateTime>` で注入し、クールダウンを決定論的にテストする
+- `App.OnUnobservedTaskException` は `e.SetObserved()` を**最初に**呼んでから本クラスへ委譲する。委譲の `?.` は意図的な fail-safe（配線順の退行でハンドラ未生成のまま発火しても、ファイナライザスレッドで NullReferenceException を投げるよりログ喪失の方が被害が小さい。SetObserved 済みのためプロセスは守られる）。配線の制約は `AppUnobservedTaskExceptionConventionTests` がソーステキストの静的検証で固定し、本体の挙動は `UnobservedTaskExceptionHandlerTests` が検証する（07_テスト設計書 UT-080）
 
 ### 10.2 PathValidator
 

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 4,622件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 4,634件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **4,648件** | 全件パス（最終同期: Issue #1786 ビルド警告 CS8618 の解消。`BuildWarningSuppressionConventionTests` に5件（UT-079-1〜5）追加（+5）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,622 + 26 = 4,648 と比較） |
+| **合計** | **4,660件** | 全件パス（最終同期: Issue #1742 未観測 Task 例外ハンドラの修正。`UnobservedTaskExceptionHandlerTests` 8件＋`AppUnobservedTaskExceptionConventionTests` 4件（UT-080-1〜12）追加（+12）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,634 + 26 = 4,660 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >
@@ -4799,6 +4799,43 @@ INSERT の失敗を実 SQLite 上で決定論的に起こすため、テスト�
 **テストが失敗したときの対処:** 新しい警告を抑制する必要が生じた場合は、csproj のコメントに ID と理由を追記する（テストは抑制の禁止ではなく、理由を残させる装置）。CS8618 については抑制せず宣言側を修正すること。
 
 **カバー対象 Issue:** #1786（関連: #1737）
+
+#### UT-080: 未観測 Task 例外ハンドラのファイナライザスレッド保護（Issue #1742）
+
+**対象:** `UnobservedTaskExceptionHandler`（`UnobservedTaskExceptionHandlerTests`、8件）／`App.xaml.cs` の配線（`AppUnobservedTaskExceptionConventionTests`、4件）
+
+`TaskScheduler.UnobservedTaskException` は Task のファイナライズ時（＝ファイナライザスレッド）に発火する。旧実装はそこから同期 `Dispatcher.Invoke` でモーダルダイアログ（`ErrorDialogHelper` → `MessageBox.Show`）を開いていたため、無人の共用端末でユーザーが [OK] を押すまでプロセス全体のファイナライザ（SQLite 接続等の後始末）が停止した。
+
+**挙動テスト（UnobservedTaskExceptionHandlerTests）:**
+
+| No | 条件 | 期待結果 |
+|----|------|---------|
+| UT-080-1 | 内部例外 2 件の AggregateException | 通知は**ポストされたアクションを実行するまで行われず**（＝呼び出しスレッドで同期実行しない）、実行すると最初の内部例外が通知される |
+| UT-080-2 | UI 利用不可（シャットダウン中相当） | 通知をポストしない（ログ記録のみ） |
+| UT-080-3 | 内部例外 2 件の AggregateException | 集約例外と全内部例外がログへ記録される |
+| UT-080-4 | 通知処理（トースト）が例外 | ポストしたアクションの外へ漏れず、ログへ記録される |
+| UT-080-5 | UI ディスパッチが例外 | `Handle` の外へ漏れず、ログへ記録される |
+| UT-080-6 | UI 可用性判定が例外 | `Handle` の外へ漏れず、ログへ記録される |
+| UT-080-7 | ロガー取得が例外 | `Handle` の外へ漏れず、**通知は行われる**（ログ経路の障害が通知経路を道連れにしない） |
+| UT-080-8 | 例外が null | 通知もポストも行わず、例外を漏らさない |
+
+**静的検証（AppUnobservedTaskExceptionConventionTests）:**
+
+| No | 検査対象 | 期待結果 |
+|----|---------|---------|
+| UT-080-9 | メソッド本体抽出器 | 既知のサンプルソースから対象メソッド本体を正しく取り出し、コメントを除去できること（検査ロジック自体の固定） |
+| UT-080-10 | `OnUnobservedTaskException` 本体 | `Dispatcher.Invoke(`・`ErrorDialogHelper`・`MessageBox` を含まないこと |
+| UT-080-11 | `OnUnobservedTaskException` 本体 | `SetObserved()` を**最初に**呼んでから `_unobservedTaskExceptionHandler` へ委譲していること（出現位置の前後関係まで検査） |
+| UT-080-12 | `CreateUnobservedTaskExceptionHandler` 本体 | `HasShutdownStarted` / `HasShutdownFinished` ガード・`BeginInvoke`（非同期）・`IToastNotificationService`（非モーダル）を持ち、同期 Invoke・モーダル経路を含まないこと |
+
+**設計上の注意:**
+
+- **`App` は WPF `Application` のため単体テストから駆動できない。** ハンドラ本体をデリゲート注入の `UnobservedTaskExceptionHandler` へ抽出して挙動を検証し、`App.xaml.cs` 側の配線はソーステキストの静的検証で固定する（`WpfDispatcherService.ObserveTask` / `CardManageDialogStatusAreaLayoutTests` と同じ二段構え）
+- **UT-080-1 は「非同期であること」をスレッドではなく実行順序で表明する。** ポスト用デリゲートがアクションを蓄積するだけの実装に差し替え、「`Handle` 直後は未通知・アクション実行後に通知済み」を検査する。同期 `Invoke` へ退行すると `Handle` 内で通知が完了してしまい fail する
+- **静的検証はコメント除去後のコードのみを対象とする。**「同期 Invoke を使わない」という戒めのコメント自体が禁止語検査に引っかかる極性反転（UT-079-2 と同型）を避ける
+- **UT-080-2/8 のような「何もしないこと」の表明は空実装でも通る**（RED で失敗できない）。防ぎたいリグレッションは UT-080-1/3〜7 の側が担い、これらはガードの撤去・順序の入れ替わりを検出する
+
+**カバー対象 Issue:** #1742（関連: #1725、#1737）
 
 ---
 

--- a/ICCardManager/docs/design/07_テスト設計書.md
+++ b/ICCardManager/docs/design/07_テスト設計書.md
@@ -24,9 +24,9 @@
 
 | 種別 | テスト数 | 備考 |
 |------|---------|------|
-| 単体テスト（ICCardManager.Tests） | 4,634件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
+| 単体テスト（ICCardManager.Tests） | 4,637件 | xUnit + FluentAssertions + Moq（Release 構成での実測、CI `test-count-sync` と整合） |
 | UIテスト（ICCardManager.UITests） | 26件 | Issue #1263 でダイアログ追加6件（その後アクセシビリティ・新機能対応で増加） |
-| **合計** | **4,660件** | 全件パス（最終同期: Issue #1742 未観測 Task 例外ハンドラの修正。`UnobservedTaskExceptionHandlerTests` 8件＋`AppUnobservedTaskExceptionConventionTests` 4件（UT-080-1〜12）追加（+12）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,634 + 26 = 4,660 と比較） |
+| **合計** | **4,663件** | 全件パス（最終同期: Issue #1742 未観測 Task 例外ハンドラの修正。`UnobservedTaskExceptionHandlerTests` 10件＋`AppUnobservedTaskExceptionConventionTests` 5件（UT-080-1〜15）追加（+15）。CI `test-count-sync` は Release 構成 `dotnet test --list-tests` の実測値 4,637 + 26 = 4,663 と比較） |
 
 > **件数の同期手順（Issue #1475）**
 >
@@ -4802,7 +4802,7 @@ INSERT の失敗を実 SQLite 上で決定論的に起こすため、テスト�
 
 #### UT-080: 未観測 Task 例外ハンドラのファイナライザスレッド保護（Issue #1742）
 
-**対象:** `UnobservedTaskExceptionHandler`（`UnobservedTaskExceptionHandlerTests`、8件）／`App.xaml.cs` の配線（`AppUnobservedTaskExceptionConventionTests`、4件）
+**対象:** `UnobservedTaskExceptionHandler`（`UnobservedTaskExceptionHandlerTests`、10件）／`App.xaml.cs` の配線（`AppUnobservedTaskExceptionConventionTests`、5件）
 
 `TaskScheduler.UnobservedTaskException` は Task のファイナライズ時（＝ファイナライザスレッド）に発火する。旧実装はそこから同期 `Dispatcher.Invoke` でモーダルダイアログ（`ErrorDialogHelper` → `MessageBox.Show`）を開いていたため、無人の共用端末でユーザーが [OK] を押すまでプロセス全体のファイナライザ（SQLite 接続等の後始末）が停止した。
 
@@ -4816,24 +4816,28 @@ INSERT の失敗を実 SQLite 上で決定論的に起こすため、テスト�
 | UT-080-4 | 通知処理（トースト）が例外 | ポストしたアクションの外へ漏れず、ログへ記録される |
 | UT-080-5 | UI ディスパッチが例外 | `Handle` の外へ漏れず、ログへ記録される |
 | UT-080-6 | UI 可用性判定が例外 | `Handle` の外へ漏れず、ログへ記録される |
-| UT-080-7 | ロガー取得が例外 | `Handle` の外へ漏れず、**通知は行われる**（ログ経路の障害が通知経路を道連れにしない） |
+| UT-080-7 | ログ記録（`logError` デリゲート）が例外 | `Handle` の外へ漏れず、**通知は行われる**（ログ経路の障害が通知経路を道連れにしない） |
 | UT-080-8 | 例外が null | 通知もポストも行わず、例外を漏らさない |
+| UT-080-9 | クールダウン（5分）内の連続発火 | 通知を再ポストしない。**ログは毎回記録する**（エラートーストは自動消去されないため、繰り返し発生する障害で無人端末にトーストが際限なく積み上がるのを防ぐ） |
+| UT-080-10 | クールダウン経過後の発火 | 再び通知をポストする（抑止は恒久ではない。新たな障害の発生をユーザーが知れなくなるため） |
 
 **静的検証（AppUnobservedTaskExceptionConventionTests）:**
 
 | No | 検査対象 | 期待結果 |
 |----|---------|---------|
-| UT-080-9 | メソッド本体抽出器 | 既知のサンプルソースから対象メソッド本体を正しく取り出し、コメントを除去できること（検査ロジック自体の固定） |
-| UT-080-10 | `OnUnobservedTaskException` 本体 | `Dispatcher.Invoke(`・`ErrorDialogHelper`・`MessageBox` を含まないこと |
-| UT-080-11 | `OnUnobservedTaskException` 本体 | `SetObserved()` を**最初に**呼んでから `_unobservedTaskExceptionHandler` へ委譲していること（出現位置の前後関係まで検査） |
-| UT-080-12 | `CreateUnobservedTaskExceptionHandler` 本体 | `HasShutdownStarted` / `HasShutdownFinished` ガード・`BeginInvoke`（非同期）・`IToastNotificationService`（非モーダル）を持ち、同期 Invoke・モーダル経路を含まないこと |
+| UT-080-11 | ソース検査ヘルパー（`TestSourceInspection`） | コメント・文字列リテラル内の波括弧や禁止トークンを含む既知のサンプルから、対象メソッド本体を正しく取り出せること（検査ロジック自体の固定） |
+| UT-080-12 | 同期 Invoke 検出パターン | `Dispatcher.Invoke (` の空白挿入・`d.Invoke(` の中間変数による迂回を検出し、`BeginInvoke` / `InvokeAsync` は許容すること（検出パターン自体の固定） |
+| UT-080-13 | `OnUnobservedTaskException` 本体 | 同期 Invoke（`\.Invoke\s*\(`）・`ErrorDialogHelper`・`MessageBox` を含まないこと |
+| UT-080-14 | `OnUnobservedTaskException` 本体 | `SetObserved()` を**最初に**呼んでから `_unobservedTaskExceptionHandler` へ委譲していること（出現位置の前後関係まで検査） |
+| UT-080-15 | `CreateUnobservedTaskExceptionHandler` 本体 | `HasShutdownStarted` / `HasShutdownFinished` ガード・`BeginInvoke`（非同期）・`IToastNotificationService`（非モーダル）・`ToUserMessage`（例外種別に応じた文言）・`ErrorDialogHelper.LogException`（DI 非依存のフォールバックログ）を持ち、同期 Invoke・モーダル経路（`ErrorDialogHelper.Show*` / `MessageBox`）を含まないこと |
 
 **設計上の注意:**
 
 - **`App` は WPF `Application` のため単体テストから駆動できない。** ハンドラ本体をデリゲート注入の `UnobservedTaskExceptionHandler` へ抽出して挙動を検証し、`App.xaml.cs` 側の配線はソーステキストの静的検証で固定する（`WpfDispatcherService.ObserveTask` / `CardManageDialogStatusAreaLayoutTests` と同じ二段構え）
 - **UT-080-1 は「非同期であること」をスレッドではなく実行順序で表明する。** ポスト用デリゲートがアクションを蓄積するだけの実装に差し替え、「`Handle` 直後は未通知・アクション実行後に通知済み」を検査する。同期 `Invoke` へ退行すると `Handle` 内で通知が完了してしまい fail する
-- **静的検証はコメント除去後のコードのみを対象とする。**「同期 Invoke を使わない」という戒めのコメント自体が禁止語検査に引っかかる極性反転（UT-079-2 と同型）を避ける
-- **UT-080-2/8 のような「何もしないこと」の表明は空実装でも通る**（RED で失敗できない）。防ぎたいリグレッションは UT-080-1/3〜7 の側が担い、これらはガードの撤去・順序の入れ替わりを検出する
+- **静的検証は「コードのみ」テキスト（`TestSourceInspection.ToCodeOnly`）を対象とする。** コメント除去により「同期 Invoke を使わない」という戒めのコメントが禁止語検査に引っかかる極性反転（UT-079-2 と同型）を避ける。加えて①**生ソースへの波括弧対応はコメント・文字列内の `}` で抽出が黙って短縮され検査が空振りする**、②**正規表現によるコメント除去は文字列リテラル内の `//` を誤処理して同一行の後続コードを消す**、の 2 つの迂回経路があるため、1 パスの状態機械で文字列リテラルの中身ごと除去してから波括弧対応を取る（いずれも本 Issue のコードレビューで検出）
+- **禁止トークンは固定の部分文字列で照合しない。** `"Dispatcher.Invoke("` のリテラル一致は空白挿入や中間変数で迂回できる。「メンバー呼び出しとしての `.Invoke(`」を正規表現（`\.Invoke\s*\(`）で照合し、パターン自体の検出力を UT-080-12 で固定する
+- **UT-080-2/8 のような「何もしないこと」の表明は空実装でも通る**（RED で失敗できない）。防ぎたいリグレッションは UT-080-1/3〜7/9〜10 の側が担い、これらはガードの撤去・順序の入れ替わり・抑止の恒久化を検出する
 
 **カバー対象 Issue:** #1742（関連: #1725、#1737）
 

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -889,7 +889,21 @@ namespace ICCardManager
         private UnobservedTaskExceptionHandler CreateUnobservedTaskExceptionHandler()
         {
             return new UnobservedTaskExceptionHandler(
-                getLogger: () => _logger,
+                logError: (exception, message) =>
+                {
+                    var logger = _logger;
+                    if (logger != null)
+                    {
+                        logger.LogError(exception, message);
+                    }
+                    else
+                    {
+                        // DI コンテナ構築前（OnStartup 冒頭〜構築失敗時）の発火でも痕跡を残す。
+                        // ErrorDialogHelper.LogException は DI 非依存のファイルログ
+                        // （error_YYYYMMDD.log）で、ダイアログは表示しない
+                        ErrorDialogHelper.LogException(exception, message);
+                    }
+                },
                 isUiAvailable: () =>
                 {
                     var app = Application.Current;
@@ -906,12 +920,12 @@ namespace ICCardManager
                     // OnExit で ServiceProvider が Dispose された後の発火では GetService が
                     // ObjectDisposedException を投げ得るが、UnobservedTaskExceptionHandler 側の
                     // try/catch が握りつぶすため通知がスキップされるだけで済む。
-                    // 文言: トーストは文字数制約があるため 3 要素のフル文言ではなく簡潔表現を優先
-                    // （error-messages.md）。例外の詳細は Handle がログへ記録済み
+                    // 文言: 例外種別に応じた「何が/なぜ/どうすれば」を ToUserMessage で組み立てる
+                    // （生の ex.Message を UI へ出さない #1614。トーストの本文は
+                    // TextWrapping="Wrap" のため長めの文言でも切れずに折り返される）
                     ServiceProvider?.GetService<IToastNotificationService>()?.ShowError(
                         "バックグラウンド処理エラー",
-                        "画面更新などのバックグラウンド処理が失敗しました。操作はそのまま続けられます。" +
-                        "繰り返し表示される場合は管理者に連絡してください。");
+                        ExceptionMessageFormatter.ToUserMessage(exception, "バックグラウンド処理"));
                 });
         }
 
@@ -975,6 +989,9 @@ namespace ICCardManager
             // 以降の処理で何が起きてもプロセスを守れるよう、最初に呼ぶ
             e.SetObserved();
 
+            // ?. は意図的な fail-safe: ハンドラ未生成（配線順の退行時のみ到達）で
+            // NullReferenceException を投げるとファイナライザからプロセスが異常終了する。
+            // SetObserved 済みのため、黙って捨ててもプロセスは守られる
             _unobservedTaskExceptionHandler?.Handle(e.Exception);
         }
 

--- a/ICCardManager/src/ICCardManager/App.xaml.cs
+++ b/ICCardManager/src/ICCardManager/App.xaml.cs
@@ -859,6 +859,8 @@ namespace ICCardManager
         /// </summary>
         private void SetupGlobalExceptionHandlers()
         {
+            _unobservedTaskExceptionHandler = CreateUnobservedTaskExceptionHandler();
+
             // UIスレッド上の未処理例外
             DispatcherUnhandledException += OnDispatcherUnhandledException;
 
@@ -867,6 +869,50 @@ namespace ICCardManager
 
             // Task内の未観測例外
             TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+        }
+
+        /// <summary>
+        /// 未観測 Task 例外のハンドラ本体（Issue #1742）。
+        /// SetupGlobalExceptionHandlers で生成し、OnUnobservedTaskException から委譲する。
+        /// </summary>
+        private UnobservedTaskExceptionHandler _unobservedTaskExceptionHandler;
+
+        /// <summary>
+        /// <see cref="UnobservedTaskExceptionHandler"/> を App の実行環境へ配線して生成
+        /// </summary>
+        /// <remarks>
+        /// 本メソッドは DI コンテナ構築前（OnStartup 冒頭）に呼ばれるため、
+        /// ロガー・トースト通知サービスはクロージャで発火時に遅延解決する。
+        /// 配線の制約（同期 Invoke 禁止・モーダル表示禁止・シャットダウンガード必須）は
+        /// AppUnobservedTaskExceptionConventionTests が静的検証で固定している。
+        /// </remarks>
+        private UnobservedTaskExceptionHandler CreateUnobservedTaskExceptionHandler()
+        {
+            return new UnobservedTaskExceptionHandler(
+                getLogger: () => _logger,
+                isUiAvailable: () =>
+                {
+                    var app = Application.Current;
+
+                    // Dispatcher シャットダウン後はポストしたアクションが実行されないため、
+                    // UI 通知をスキップしてログ記録のみとする
+                    return app != null
+                        && !app.Dispatcher.HasShutdownStarted
+                        && !app.Dispatcher.HasShutdownFinished;
+                },
+                postToUi: action => Application.Current?.Dispatcher.BeginInvoke(action),
+                notifyError: exception =>
+                {
+                    // OnExit で ServiceProvider が Dispose された後の発火では GetService が
+                    // ObjectDisposedException を投げ得るが、UnobservedTaskExceptionHandler 側の
+                    // try/catch が握りつぶすため通知がスキップされるだけで済む。
+                    // 文言: トーストは文字数制約があるため 3 要素のフル文言ではなく簡潔表現を優先
+                    // （error-messages.md）。例外の詳細は Handle がログへ記録済み
+                    ServiceProvider?.GetService<IToastNotificationService>()?.ShowError(
+                        "バックグラウンド処理エラー",
+                        "画面更新などのバックグラウンド処理が失敗しました。操作はそのまま続けられます。" +
+                        "繰り返し表示される場合は管理者に連絡してください。");
+                });
         }
 
         /// <summary>
@@ -914,28 +960,22 @@ namespace ICCardManager
         }
 
         /// <summary>
-        /// Task内の未観測例外ハンドラー
+        /// Task内の未観測例外ハンドラー（Issue #1742）
         /// </summary>
+        /// <remarks>
+        /// 本ハンドラは Task のファイナライズ時（＝ファイナライザスレッド）に呼ばれる。
+        /// 同期ディスパッチ（Dispatcher.Invoke）＋モーダル表示（ErrorDialogHelper →
+        /// MessageBox.Show）を行うと、ユーザーが [OK] を押すまでプロセス全体の
+        /// ファイナライザが停止するため、ログ記録と非同期・非モーダル通知だけを行う
+        /// UnobservedTaskExceptionHandler へ委譲する。
+        /// </remarks>
         private void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
         {
-            _logger?.LogError(e.Exception, "Task未観測例外 (InnerCount={InnerCount})", e.Exception.InnerExceptions.Count);
-
-            // 例外を観測済みとしてマーク（アプリケーションのクラッシュを防止）
+            // 例外を観測済みとしてマーク（アプリケーションのクラッシュを防止）。
+            // 以降の処理で何が起きてもプロセスを守れるよう、最初に呼ぶ
             e.SetObserved();
 
-            // 内部例外もログに記録
-            foreach (var innerException in e.Exception.InnerExceptions)
-            {
-                _logger?.LogError(innerException, "Task未観測例外の内部例外");
-            }
-
-            // UIスレッドでエラーダイアログを表示
-            Dispatcher.Invoke(() =>
-            {
-                // 複数の例外がある場合は最初のものを表示
-                var displayException = e.Exception.InnerExceptions.FirstOrDefault() ?? e.Exception;
-                ErrorDialogHelper.ShowError(displayException, "バックグラウンド処理エラー");
-            });
+            _unobservedTaskExceptionHandler?.Handle(e.Exception);
         }
 
         #endregion

--- a/ICCardManager/src/ICCardManager/Common/UnobservedTaskExceptionHandler.cs
+++ b/ICCardManager/src/ICCardManager/Common/UnobservedTaskExceptionHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 
 namespace ICCardManager.Common
 {
@@ -26,17 +25,37 @@ namespace ICCardManager.Common
     /// </remarks>
     public class UnobservedTaskExceptionHandler
     {
-        private readonly Func<ILogger> _getLogger;
+        /// <summary>
+        /// ユーザー通知（トースト）の最小間隔。
+        /// </summary>
+        /// <remarks>
+        /// エラートーストは自動消去されない（クリックで閉じる）ため、共有モードの
+        /// ヘルスチェック失敗のような繰り返し発生する障害で発火のたびに通知すると、
+        /// 無人の共用端末にトーストが際限なく積み上がる。ログは間引かず毎回記録し、
+        /// 通知だけを抑制する。
+        /// </remarks>
+        internal static readonly TimeSpan NotificationCooldown = TimeSpan.FromMinutes(5);
+
+        private readonly Action<Exception, string> _logError;
         private readonly Func<bool> _isUiAvailable;
         private readonly Action<Action> _postToUi;
         private readonly Action<Exception> _notifyError;
+        private readonly Func<DateTime> _utcNow;
+
+        /// <summary>
+        /// 最後にユーザー通知をポストした時刻（UTC）。
+        /// UnobservedTaskException は単一のファイナライザスレッドから逐次発火するため、
+        /// ロックは不要。
+        /// </summary>
+        private DateTime _lastNotifiedUtc = DateTime.MinValue;
 
         /// <summary>
         /// <see cref="UnobservedTaskExceptionHandler"/> を生成します。
         /// </summary>
-        /// <param name="getLogger">
-        /// ロガーの遅延取得。ハンドラ登録（SetupGlobalExceptionHandlers）は DI コンテナ構築前に
-        /// 行われるため、生成時ではなく発火時に解決する。null を返してもよい。
+        /// <param name="logError">
+        /// 例外とメッセージの記録。ハンドラ登録（SetupGlobalExceptionHandlers）は DI コンテナ
+        /// 構築前に行われるため、呼び出し側は ILogger が未初期化でも記録が残る実装
+        /// （ErrorDialogHelper.LogException 等の DI 非依存経路へのフォールバック）を渡すこと。
         /// </param>
         /// <param name="isUiAvailable">
         /// UI へ通知できる状態かの判定（Dispatcher がシャットダウンを開始していないか等）。
@@ -49,16 +68,22 @@ namespace ICCardManager.Common
         /// ユーザーへの非モーダル通知（トースト等）。<paramref name="postToUi"/> でポストした
         /// アクションの中から呼ばれる。モーダルダイアログを渡してはいけない。
         /// </param>
+        /// <param name="utcNow">
+        /// 現在時刻（UTC）の取得。通知クールダウンの判定に使う。
+        /// 省略時は DateTime.UtcNow（テストから決定論的に駆動するための注入点）。
+        /// </param>
         public UnobservedTaskExceptionHandler(
-            Func<ILogger> getLogger,
+            Action<Exception, string> logError,
             Func<bool> isUiAvailable,
             Action<Action> postToUi,
-            Action<Exception> notifyError)
+            Action<Exception> notifyError,
+            Func<DateTime> utcNow = null)
         {
-            _getLogger = getLogger ?? throw new ArgumentNullException(nameof(getLogger));
+            _logError = logError ?? throw new ArgumentNullException(nameof(logError));
             _isUiAvailable = isUiAvailable ?? throw new ArgumentNullException(nameof(isUiAvailable));
             _postToUi = postToUi ?? throw new ArgumentNullException(nameof(postToUi));
             _notifyError = notifyError ?? throw new ArgumentNullException(nameof(notifyError));
+            _utcNow = utcNow ?? (() => DateTime.UtcNow);
         }
 
         /// <summary>
@@ -77,15 +102,12 @@ namespace ICCardManager.Common
                 return;
             }
 
-            TryLog(logger =>
-            {
-                logger.LogError(exception, "Task未観測例外 (InnerCount={InnerCount})", exception.InnerExceptions.Count);
+            TryLog(exception, $"Task未観測例外 (InnerCount={exception.InnerExceptions.Count})");
 
-                foreach (var innerException in exception.InnerExceptions)
-                {
-                    logger.LogError(innerException, "Task未観測例外の内部例外");
-                }
-            });
+            foreach (var innerException in exception.InnerExceptions)
+            {
+                TryLog(innerException, "Task未観測例外の内部例外");
+            }
 
             try
             {
@@ -94,6 +116,15 @@ namespace ICCardManager.Common
                     // Dispatcher シャットダウン後のポストは実行されないため、ログ記録のみで終える
                     return;
                 }
+
+                var now = _utcNow();
+                if (now - _lastNotifiedUtc < NotificationCooldown)
+                {
+                    // 繰り返し発生する障害での通知の積み上がりを抑止（ログは上で記録済み）
+                    return;
+                }
+
+                _lastNotifiedUtc = now;
 
                 // 複数の例外がある場合は最初のものを通知対象とする（従来実装の踏襲）
                 var displayException = exception.InnerExceptions.FirstOrDefault() ?? (Exception)exception;
@@ -108,37 +139,32 @@ namespace ICCardManager.Common
                     {
                         // Dispatcher 上で実行されるアクションから漏れた例外は
                         // DispatcherUnhandledException へ波及し二次エラーダイアログを生むため、ここで止める
-                        TryLog(logger => logger.LogError(notifyException, "Task未観測例外のユーザー通知に失敗"));
+                        TryLog(notifyException, "Task未観測例外のユーザー通知に失敗");
                     }
                 });
             }
             catch (Exception dispatchException)
             {
                 // ファイナライザスレッドへ例外が漏れるとプロセスが異常終了するため、ここで止める
-                TryLog(logger => logger.LogError(dispatchException, "Task未観測例外のUIスレッドへのディスパッチに失敗"));
+                TryLog(dispatchException, "Task未観測例外のUIスレッドへのディスパッチに失敗");
             }
         }
 
         /// <summary>
-        /// ログ記録を試みます。ロガーの取得・記録自体の失敗は握りつぶします。
+        /// ログ記録を試みます。記録自体の失敗は握りつぶします。
         /// </summary>
         /// <remarks>
-        /// ログ経路の障害（DI コンテナ構築前でロガー未初期化等）が
-        /// 通知経路やファイナライザスレッドを道連れにしないための隔離。
+        /// ログ経路の障害が通知経路やファイナライザスレッドを道連れにしないための隔離。
         /// </remarks>
-        private void TryLog(Action<ILogger> log)
+        private void TryLog(Exception exception, string message)
         {
             try
             {
-                var logger = _getLogger();
-                if (logger != null)
-                {
-                    log(logger);
-                }
+                _logError(exception, message);
             }
             catch
             {
-                // ロガー自体の障害はここでは救えない。例外を漏らさないことを優先する
+                // ログ記録の障害はここでは救えない。例外を漏らさないことを優先する
             }
         }
     }

--- a/ICCardManager/src/ICCardManager/Common/UnobservedTaskExceptionHandler.cs
+++ b/ICCardManager/src/ICCardManager/Common/UnobservedTaskExceptionHandler.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace ICCardManager.Common
+{
+    /// <summary>
+    /// TaskScheduler.UnobservedTaskException のハンドラ本体（Issue #1742）。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 未観測 Task 例外は GC のファイナライズ時（＝ファイナライザスレッド）に発火する。
+    /// このスレッドで同期ディスパッチ（Dispatcher.Invoke）やモーダル表示を行うと、
+    /// ユーザーがダイアログを閉じるまでプロセス全体のファイナライザが停止する。
+    /// また、ハンドラから例外が漏れるとファイナライザ経由でプロセスが異常終了する。
+    /// このため本クラスは「UI スレッドへの非同期ポスト＋非モーダル通知」だけを行い、
+    /// いかなる内部エラーも外へ伝播させない。
+    /// </para>
+    /// <para>
+    /// WPF（Dispatcher / Application）へ直接依存せずデリゲート注入とするのは、
+    /// 単体テストから駆動できるようにするため（WpfDispatcherService が
+    /// Application.Current 依存の本体から観測ロジックだけを切り出したのと同じ判断）。
+    /// App.xaml.cs 側の配線（シャットダウンガード・BeginInvoke・トースト通知）は
+    /// AppUnobservedTaskExceptionConventionTests が静的検証で固定する。
+    /// </para>
+    /// </remarks>
+    public class UnobservedTaskExceptionHandler
+    {
+        private readonly Func<ILogger> _getLogger;
+        private readonly Func<bool> _isUiAvailable;
+        private readonly Action<Action> _postToUi;
+        private readonly Action<Exception> _notifyError;
+
+        /// <summary>
+        /// <see cref="UnobservedTaskExceptionHandler"/> を生成します。
+        /// </summary>
+        /// <param name="getLogger">
+        /// ロガーの遅延取得。ハンドラ登録（SetupGlobalExceptionHandlers）は DI コンテナ構築前に
+        /// 行われるため、生成時ではなく発火時に解決する。null を返してもよい。
+        /// </param>
+        /// <param name="isUiAvailable">
+        /// UI へ通知できる状態かの判定（Dispatcher がシャットダウンを開始していないか等）。
+        /// </param>
+        /// <param name="postToUi">
+        /// UI スレッドへの非同期ポスト（Dispatcher.BeginInvoke 相当）。
+        /// 同期ディスパッチを渡してはいけない（ファイナライザスレッドがブロックされる）。
+        /// </param>
+        /// <param name="notifyError">
+        /// ユーザーへの非モーダル通知（トースト等）。<paramref name="postToUi"/> でポストした
+        /// アクションの中から呼ばれる。モーダルダイアログを渡してはいけない。
+        /// </param>
+        public UnobservedTaskExceptionHandler(
+            Func<ILogger> getLogger,
+            Func<bool> isUiAvailable,
+            Action<Action> postToUi,
+            Action<Exception> notifyError)
+        {
+            _getLogger = getLogger ?? throw new ArgumentNullException(nameof(getLogger));
+            _isUiAvailable = isUiAvailable ?? throw new ArgumentNullException(nameof(isUiAvailable));
+            _postToUi = postToUi ?? throw new ArgumentNullException(nameof(postToUi));
+            _notifyError = notifyError ?? throw new ArgumentNullException(nameof(notifyError));
+        }
+
+        /// <summary>
+        /// 未観測 Task 例外を処理します（ログ記録＋UI スレッドへの非同期通知）。
+        /// </summary>
+        /// <param name="exception">未観測の集約例外。null の場合は何もしません。</param>
+        /// <remarks>
+        /// 呼び出し元（App.OnUnobservedTaskException）は本メソッドを呼ぶ前に
+        /// UnobservedTaskExceptionEventArgs.SetObserved() を済ませておくこと。
+        /// 本メソッドはいかなる例外も外へ伝播させない。
+        /// </remarks>
+        public void Handle(AggregateException exception)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            TryLog(logger =>
+            {
+                logger.LogError(exception, "Task未観測例外 (InnerCount={InnerCount})", exception.InnerExceptions.Count);
+
+                foreach (var innerException in exception.InnerExceptions)
+                {
+                    logger.LogError(innerException, "Task未観測例外の内部例外");
+                }
+            });
+
+            try
+            {
+                if (!_isUiAvailable())
+                {
+                    // Dispatcher シャットダウン後のポストは実行されないため、ログ記録のみで終える
+                    return;
+                }
+
+                // 複数の例外がある場合は最初のものを通知対象とする（従来実装の踏襲）
+                var displayException = exception.InnerExceptions.FirstOrDefault() ?? (Exception)exception;
+
+                _postToUi(() =>
+                {
+                    try
+                    {
+                        _notifyError(displayException);
+                    }
+                    catch (Exception notifyException)
+                    {
+                        // Dispatcher 上で実行されるアクションから漏れた例外は
+                        // DispatcherUnhandledException へ波及し二次エラーダイアログを生むため、ここで止める
+                        TryLog(logger => logger.LogError(notifyException, "Task未観測例外のユーザー通知に失敗"));
+                    }
+                });
+            }
+            catch (Exception dispatchException)
+            {
+                // ファイナライザスレッドへ例外が漏れるとプロセスが異常終了するため、ここで止める
+                TryLog(logger => logger.LogError(dispatchException, "Task未観測例外のUIスレッドへのディスパッチに失敗"));
+            }
+        }
+
+        /// <summary>
+        /// ログ記録を試みます。ロガーの取得・記録自体の失敗は握りつぶします。
+        /// </summary>
+        /// <remarks>
+        /// ログ経路の障害（DI コンテナ構築前でロガー未初期化等）が
+        /// 通知経路やファイナライザスレッドを道連れにしないための隔離。
+        /// </remarks>
+        private void TryLog(Action<ILogger> log)
+        {
+            try
+            {
+                var logger = _getLogger();
+                if (logger != null)
+                {
+                    log(logger);
+                }
+            }
+            catch
+            {
+                // ロガー自体の障害はここでは救えない。例外を漏らさないことを優先する
+            }
+        }
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/AppUnobservedTaskExceptionConventionTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/AppUnobservedTaskExceptionConventionTests.cs
@@ -14,7 +14,7 @@ namespace ICCardManager.Tests;
 /// <para>
 /// <c>TaskScheduler.UnobservedTaskException</c> はファイナライザスレッドで発火するため、
 /// ハンドラ内の同期ディスパッチ（<c>Dispatcher.Invoke</c>）＋モーダル表示
-/// （<c>ErrorDialogHelper</c> → <c>MessageBox.Show</c>）は、ユーザーが [OK] を押すまで
+/// （<c>ErrorDialogHelper</c> の Show 系 → <c>MessageBox.Show</c>）は、ユーザーが [OK] を押すまで
 /// プロセス全体のファイナライザを停止させる。
 /// </para>
 /// <para>
@@ -23,7 +23,9 @@ namespace ICCardManager.Tests;
 /// <c>App</c> は WPF <c>Application</c> のため単体テストから駆動できず、
 /// 配線側の回帰はソーステキストの静的検証で固定する
 /// （<c>CardManageDialogStatusAreaLayoutTests</c> 等と同じ流儀）。
-/// 検査はコメントを除去したコードのみを対象とし、規約の理由をコメントに書けるようにする。
+/// 検査は <see cref="TestSourceInspection.ToCodeOnly"/> でコメントと文字列リテラルの中身を
+/// 除去した「コードのみ」を対象とし、規約の理由をコメントに書けるようにしつつ、
+/// コメント・文字列内の波括弧が抽出を狂わせないようにする。
 /// </para>
 /// </remarks>
 public class AppUnobservedTaskExceptionConventionTests
@@ -31,95 +33,84 @@ public class AppUnobservedTaskExceptionConventionTests
     private const string HandlerSignature = "private void OnUnobservedTaskException";
     private const string WiringSignature = "private UnobservedTaskExceptionHandler CreateUnobservedTaskExceptionHandler";
 
-    private static string ReadAppSource()
-        => File.ReadAllText(Path.Combine(TestPaths.GetProductionSourceRoot(), "App.xaml.cs"));
-
     /// <summary>
-    /// コメント（<c>//</c> 行コメント・<c>/* */</c> ブロックコメント）を除去する。
-    /// 「禁止された要素の不在」検査がコメント中の正当な言及
-    /// （例: 「同期 Invoke を使わない」という戒め）を誤検出しないようにするため。
+    /// 同期ディスパッチの検出パターン。固定の部分文字列
+    /// （<c>"Dispatcher.Invoke("</c>）では空白の挿入や中間変数
+    /// （<c>var d = app.Dispatcher; d.Invoke(...)</c>）で迂回できるため、
+    /// 「メンバー呼び出しとしての <c>.Invoke(</c>」を語形ゆれ込みで照合する。
+    /// <c>BeginInvoke(</c> / <c>InvokeAsync(</c> は直前が <c>.</c> でない・直後が <c>(</c> でないため一致しない。
     /// </summary>
-    private static string StripComments(string source)
-    {
-        var withoutBlock = Regex.Replace(source, @"/\*.*?\*/", "", RegexOptions.Singleline);
-        return Regex.Replace(withoutBlock, @"//[^\r\n]*", "");
-    }
+    private static readonly Regex SyncInvokePattern = new(@"\.Invoke\s*\(", RegexOptions.Compiled);
 
-    /// <summary>
-    /// シグネチャ文字列から始まるメソッドの本体（<c>{ }</c> 含む）を波括弧の対応で取り出す。
-    /// </summary>
-    private static string ExtractMethodBody(string source, string signatureMarker)
-    {
-        var start = source.IndexOf(signatureMarker, StringComparison.Ordinal);
-        start.Should().BeGreaterThanOrEqualTo(0,
-            $"App.xaml.cs に「{signatureMarker}」が存在するはず。リネームした場合は本テストの定数も更新すること");
-
-        var braceStart = source.IndexOf('{', start);
-        braceStart.Should().BeGreaterThan(start, "メソッド本体の開始波括弧が見つかるはず");
-
-        var depth = 0;
-        for (var i = braceStart; i < source.Length; i++)
-        {
-            if (source[i] == '{')
-            {
-                depth++;
-            }
-            else if (source[i] == '}')
-            {
-                depth--;
-                if (depth == 0)
-                {
-                    return source.Substring(braceStart, i - braceStart + 1);
-                }
-            }
-        }
-
-        throw new InvalidOperationException($"「{signatureMarker}」の本体の波括弧が閉じていない。");
-    }
+    private static string ReadAppCodeOnly()
+        => TestSourceInspection.ToCodeOnly(
+            File.ReadAllText(Path.Combine(TestPaths.GetProductionSourceRoot(), "App.xaml.cs")));
 
     [Fact]
-    public void メソッド本体抽出_既知のサンプルから正しく取り出せること()
+    public void メソッド本体抽出_コメントや文字列に波括弧や禁止トークンがあっても正しく取り出せること()
     {
         // 検査ロジック自体を既知のサンプル入力で固定する（development-conventions.md）。
-        // 実ソース側の抽出が空振りしても、この検証が抽出器の劣化と実ソースの変化を切り分ける
+        // 実ソース側の抽出が空振りしても、この検証が抽出器の劣化と実ソースの変化を切り分ける。
+        // サンプルには迂回経路になり得る要素を仕込む:
+        //   ①コメント内の閉じ波括弧（生ソースへの波括弧対応だと本体が途中で切れる）
+        //   ②文字列リテラル内の "//"（正規表現ベースの除去だと同一行の後続コードが消える）
+        //   ③文字列リテラル内の閉じ波括弧
+        //   ④コメント内の禁止トークン（コード扱いすると戒めのコメントが書けなくなる）
         const string sample = @"
             class C
             {
-                // Dispatcher.Invoke( をコメントで言及しても検出対象にしない
                 private void Target()
                 {
+                    // } このコメントの閉じ波括弧で抽出が切れてはいけない
+                    /* Dispatcher.Invoke( をコメントで言及しても検出対象にしない */
+                    var s = ""literal with } and // not a comment""; Marker();
                     if (true) { Inner(); }
                 }
                 private void Other() { Forbidden(); }
             }";
 
-        var body = ExtractMethodBody(sample, "private void Target");
-        var stripped = StripComments(body);
+        var body = TestSourceInspection.ExtractMethodBody(TestSourceInspection.ToCodeOnly(sample), "private void Target");
 
-        stripped.Should().Contain("Inner();", "対象メソッドの本体を取り出せていること");
-        stripped.Should().NotContain("Forbidden", "次のメソッドまで巻き込んでいないこと");
-        stripped.Should().NotContain("Dispatcher.Invoke(", "コメントが除去されていること");
+        body.Should().Contain("Inner();", "対象メソッドの本体を取り出せていること");
+        body.Should().Contain("Marker();", "文字列リテラル内の // を行コメント扱いして同一行の後続コードを消してはいけない");
+        body.Should().NotContain("Forbidden", "次のメソッドまで巻き込んでいないこと");
+        body.Should().NotContain("literal with", "文字列リテラルの中身は検査対象から除外されていること");
+        SyncInvokePattern.IsMatch(body).Should().BeFalse("コメント内の言及は検出対象にしないこと");
+    }
+
+    [Fact]
+    public void 同期Invoke検出パターン_語形ゆれや中間変数による迂回を検出できること()
+    {
+        // 検出パターン自体の有効性を固定する。固定の部分文字列照合へ退化させると
+        // 空白の挿入や中間変数で静かに迂回できるようになる
+        SyncInvokePattern.IsMatch("Dispatcher.Invoke(() => { })").Should().BeTrue();
+        SyncInvokePattern.IsMatch("Dispatcher.Invoke (action)").Should().BeTrue("空白の挿入で迂回できてはいけない");
+        SyncInvokePattern.IsMatch("var d = app.Dispatcher; d.Invoke(action);").Should().BeTrue("中間変数で迂回できてはいけない");
+
+        SyncInvokePattern.IsMatch("Dispatcher.BeginInvoke(action)").Should().BeFalse("非同期の BeginInvoke は許容される");
+        SyncInvokePattern.IsMatch("Dispatcher.InvokeAsync(action)").Should().BeFalse("非同期の InvokeAsync は許容される");
     }
 
     [Fact]
     public void OnUnobservedTaskException_同期ディスパッチとモーダル表示を含まないこと()
     {
-        var body = StripComments(ExtractMethodBody(ReadAppSource(), HandlerSignature));
+        var body = TestSourceInspection.ExtractMethodBody(ReadAppCodeOnly(), HandlerSignature);
 
         // 同期 Invoke はファイナライザスレッドを UI 処理の完了までブロックする
-        body.Should().NotContain("Dispatcher.Invoke(",
+        SyncInvokePattern.IsMatch(body).Should().BeFalse(
             "ファイナライザスレッドからの同期ディスパッチは、モーダル表示が閉じられるまで" +
             "プロセス全体のファイナライザを停止させる（Issue #1742）");
 
-        // ErrorDialogHelper.ShowError は内部で Dispatcher.Invoke（同期）＋ MessageBox.Show（モーダル）を行う
-        body.Should().NotContain("ErrorDialogHelper", "モーダルダイアログ経路を使わない");
+        // ErrorDialogHelper の Show 系は内部で Dispatcher.Invoke（同期）＋ MessageBox.Show（モーダル）を行う。
+        // ハンドラ本体は SetObserved と委譲だけを行うべきなので、ここでは LogException も含め全面禁止
+        body.Should().NotContain("ErrorDialogHelper", "ハンドラ本体は SetObserved と委譲だけを行う");
         body.Should().NotContain("MessageBox", "モーダルダイアログ経路を使わない");
     }
 
     [Fact]
     public void OnUnobservedTaskException_最初に観測済みにしてからハンドラへ委譲すること()
     {
-        var body = StripComments(ExtractMethodBody(ReadAppSource(), HandlerSignature));
+        var body = TestSourceInspection.ExtractMethodBody(ReadAppCodeOnly(), HandlerSignature);
 
         body.Should().Contain("SetObserved()",
             "観測済みにしないと未観測例外がプロセスを異常終了させる（.NET Framework の既定挙動）");
@@ -135,7 +126,7 @@ public class AppUnobservedTaskExceptionConventionTests
     [Fact]
     public void ハンドラ配線_シャットダウンガード付きの非同期ディスパッチと非モーダル通知を用いること()
     {
-        var body = StripComments(ExtractMethodBody(ReadAppSource(), WiringSignature));
+        var body = TestSourceInspection.ExtractMethodBody(ReadAppCodeOnly(), WiringSignature);
 
         // シャットダウンガード: Dispatcher 停止後のディスパッチは実行されず、例外の温床になるだけ
         body.Should().Contain("HasShutdownStarted", "アプリ終了中の発火に備えたガードを持つこと");
@@ -143,11 +134,18 @@ public class AppUnobservedTaskExceptionConventionTests
 
         // 非同期ディスパッチ: BeginInvoke はファイナライザスレッドをブロックしない
         body.Should().Contain("BeginInvoke", "UI スレッドへは非同期でポストすること");
-        body.Should().NotContain("Dispatcher.Invoke(", "同期ディスパッチへ退行させない");
+        SyncInvokePattern.IsMatch(body).Should().BeFalse("同期ディスパッチへ退行させない");
 
-        // 非モーダル通知: トーストはユーザーの操作を要求せず、ファイナライザ停止の原因にならない
+        // 非モーダル通知: トーストはユーザーの操作を要求せず、ファイナライザ停止の原因にならない。
+        // 文言は例外種別に応じて ToUserMessage で組み立てる（固定文言だと管理者へ原因が伝わらない）
         body.Should().Contain("IToastNotificationService", "非モーダルなトースト通知を使うこと");
-        body.Should().NotContain("ErrorDialogHelper", "モーダルダイアログ経路へ退行させない");
+        body.Should().Contain("ToUserMessage", "例外種別に応じた文言を通知に載せること（固定文言へ退行させない）");
+        body.Should().NotContain("ErrorDialogHelper.Show", "モーダルダイアログ経路へ退行させない");
         body.Should().NotContain("MessageBox", "モーダルダイアログ経路へ退行させない");
+
+        // DI 非依存のフォールバックログ: ロガー未初期化の時期（DI コンテナ構築前）の発火でも
+        // error_YYYYMMDD.log へ痕跡が残ること（LogException はダイアログ非表示のログ専用経路）
+        body.Should().Contain("ErrorDialogHelper.LogException",
+            "ILogger が使えない時期の発火を無痕跡にしない（旧実装は ErrorDialogHelper が DI 非依存でログしていた）");
     }
 }

--- a/ICCardManager/tests/ICCardManager.Tests/AppUnobservedTaskExceptionConventionTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/AppUnobservedTaskExceptionConventionTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace ICCardManager.Tests;
+
+/// <summary>
+/// Issue #1742: <c>App.xaml.cs</c> の未観測 Task 例外ハンドラが
+/// 「ファイナライザスレッドをブロックしない」形で配線されていることを固定する規約テスト。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>TaskScheduler.UnobservedTaskException</c> はファイナライザスレッドで発火するため、
+/// ハンドラ内の同期ディスパッチ（<c>Dispatcher.Invoke</c>）＋モーダル表示
+/// （<c>ErrorDialogHelper</c> → <c>MessageBox.Show</c>）は、ユーザーが [OK] を押すまで
+/// プロセス全体のファイナライザを停止させる。
+/// </para>
+/// <para>
+/// ハンドラ本体（<c>UnobservedTaskExceptionHandler</c>）の挙動は
+/// <see cref="Common.UnobservedTaskExceptionHandlerTests"/> が検証する。
+/// <c>App</c> は WPF <c>Application</c> のため単体テストから駆動できず、
+/// 配線側の回帰はソーステキストの静的検証で固定する
+/// （<c>CardManageDialogStatusAreaLayoutTests</c> 等と同じ流儀）。
+/// 検査はコメントを除去したコードのみを対象とし、規約の理由をコメントに書けるようにする。
+/// </para>
+/// </remarks>
+public class AppUnobservedTaskExceptionConventionTests
+{
+    private const string HandlerSignature = "private void OnUnobservedTaskException";
+    private const string WiringSignature = "private UnobservedTaskExceptionHandler CreateUnobservedTaskExceptionHandler";
+
+    private static string ReadAppSource()
+        => File.ReadAllText(Path.Combine(TestPaths.GetProductionSourceRoot(), "App.xaml.cs"));
+
+    /// <summary>
+    /// コメント（<c>//</c> 行コメント・<c>/* */</c> ブロックコメント）を除去する。
+    /// 「禁止された要素の不在」検査がコメント中の正当な言及
+    /// （例: 「同期 Invoke を使わない」という戒め）を誤検出しないようにするため。
+    /// </summary>
+    private static string StripComments(string source)
+    {
+        var withoutBlock = Regex.Replace(source, @"/\*.*?\*/", "", RegexOptions.Singleline);
+        return Regex.Replace(withoutBlock, @"//[^\r\n]*", "");
+    }
+
+    /// <summary>
+    /// シグネチャ文字列から始まるメソッドの本体（<c>{ }</c> 含む）を波括弧の対応で取り出す。
+    /// </summary>
+    private static string ExtractMethodBody(string source, string signatureMarker)
+    {
+        var start = source.IndexOf(signatureMarker, StringComparison.Ordinal);
+        start.Should().BeGreaterThanOrEqualTo(0,
+            $"App.xaml.cs に「{signatureMarker}」が存在するはず。リネームした場合は本テストの定数も更新すること");
+
+        var braceStart = source.IndexOf('{', start);
+        braceStart.Should().BeGreaterThan(start, "メソッド本体の開始波括弧が見つかるはず");
+
+        var depth = 0;
+        for (var i = braceStart; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(braceStart, i - braceStart + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"「{signatureMarker}」の本体の波括弧が閉じていない。");
+    }
+
+    [Fact]
+    public void メソッド本体抽出_既知のサンプルから正しく取り出せること()
+    {
+        // 検査ロジック自体を既知のサンプル入力で固定する（development-conventions.md）。
+        // 実ソース側の抽出が空振りしても、この検証が抽出器の劣化と実ソースの変化を切り分ける
+        const string sample = @"
+            class C
+            {
+                // Dispatcher.Invoke( をコメントで言及しても検出対象にしない
+                private void Target()
+                {
+                    if (true) { Inner(); }
+                }
+                private void Other() { Forbidden(); }
+            }";
+
+        var body = ExtractMethodBody(sample, "private void Target");
+        var stripped = StripComments(body);
+
+        stripped.Should().Contain("Inner();", "対象メソッドの本体を取り出せていること");
+        stripped.Should().NotContain("Forbidden", "次のメソッドまで巻き込んでいないこと");
+        stripped.Should().NotContain("Dispatcher.Invoke(", "コメントが除去されていること");
+    }
+
+    [Fact]
+    public void OnUnobservedTaskException_同期ディスパッチとモーダル表示を含まないこと()
+    {
+        var body = StripComments(ExtractMethodBody(ReadAppSource(), HandlerSignature));
+
+        // 同期 Invoke はファイナライザスレッドを UI 処理の完了までブロックする
+        body.Should().NotContain("Dispatcher.Invoke(",
+            "ファイナライザスレッドからの同期ディスパッチは、モーダル表示が閉じられるまで" +
+            "プロセス全体のファイナライザを停止させる（Issue #1742）");
+
+        // ErrorDialogHelper.ShowError は内部で Dispatcher.Invoke（同期）＋ MessageBox.Show（モーダル）を行う
+        body.Should().NotContain("ErrorDialogHelper", "モーダルダイアログ経路を使わない");
+        body.Should().NotContain("MessageBox", "モーダルダイアログ経路を使わない");
+    }
+
+    [Fact]
+    public void OnUnobservedTaskException_最初に観測済みにしてからハンドラへ委譲すること()
+    {
+        var body = StripComments(ExtractMethodBody(ReadAppSource(), HandlerSignature));
+
+        body.Should().Contain("SetObserved()",
+            "観測済みにしないと未観測例外がプロセスを異常終了させる（.NET Framework の既定挙動）");
+        body.Should().Contain("_unobservedTaskExceptionHandler",
+            "テスト可能な UnobservedTaskExceptionHandler へ委譲する（Common.UnobservedTaskExceptionHandlerTests が挙動を検証）");
+
+        var setObservedIndex = body.IndexOf("SetObserved()", StringComparison.Ordinal);
+        var delegateIndex = body.IndexOf("_unobservedTaskExceptionHandler", StringComparison.Ordinal);
+        setObservedIndex.Should().BeLessThan(delegateIndex,
+            "以降の処理で何が起きてもプロセスを守れるよう、SetObserved を最初に呼ぶ");
+    }
+
+    [Fact]
+    public void ハンドラ配線_シャットダウンガード付きの非同期ディスパッチと非モーダル通知を用いること()
+    {
+        var body = StripComments(ExtractMethodBody(ReadAppSource(), WiringSignature));
+
+        // シャットダウンガード: Dispatcher 停止後のディスパッチは実行されず、例外の温床になるだけ
+        body.Should().Contain("HasShutdownStarted", "アプリ終了中の発火に備えたガードを持つこと");
+        body.Should().Contain("HasShutdownFinished", "アプリ終了後の発火に備えたガードを持つこと");
+
+        // 非同期ディスパッチ: BeginInvoke はファイナライザスレッドをブロックしない
+        body.Should().Contain("BeginInvoke", "UI スレッドへは非同期でポストすること");
+        body.Should().NotContain("Dispatcher.Invoke(", "同期ディスパッチへ退行させない");
+
+        // 非モーダル通知: トーストはユーザーの操作を要求せず、ファイナライザ停止の原因にならない
+        body.Should().Contain("IToastNotificationService", "非モーダルなトースト通知を使うこと");
+        body.Should().NotContain("ErrorDialogHelper", "モーダルダイアログ経路へ退行させない");
+        body.Should().NotContain("MessageBox", "モーダルダイアログ経路へ退行させない");
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Common/UnobservedTaskExceptionHandlerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/UnobservedTaskExceptionHandlerTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using ICCardManager.Common;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ICCardManager.Tests.Common;
+
+/// <summary>
+/// Issue #1742: <see cref="UnobservedTaskExceptionHandler"/> の挙動テスト。
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>TaskScheduler.UnobservedTaskException</c> はファイナライザスレッドで発火する。
+/// ハンドラが同期ディスパッチ（<c>Dispatcher.Invoke</c>）でモーダルダイアログを開くと、
+/// ユーザーが [OK] を押すまでプロセス全体のファイナライザが停止し、
+/// ハンドラから例外が漏れるとプロセスが異常終了する。
+/// </para>
+/// <para>
+/// 本テストは抽出したハンドラ本体の 2 つの性質を固定する:
+/// ①通知は「UI スレッドへの非同期ポスト」経由でのみ実行される（呼び出しスレッドをブロックしない）、
+/// ②ハンドラおよびポストしたアクションから例外が一切漏れない。
+/// <c>App.xaml.cs</c> 側の配線（シャットダウンガード・BeginInvoke・トースト通知）は
+/// <see cref="AppUnobservedTaskExceptionConventionTests"/> が静的検証で固定する。
+/// </para>
+/// </remarks>
+public class UnobservedTaskExceptionHandlerTests
+{
+    private readonly Mock<ILogger> _loggerMock = new();
+    private readonly List<Action> _postedActions = new();
+    private readonly List<Exception> _notifiedExceptions = new();
+
+    private UnobservedTaskExceptionHandler CreateHandler(
+        Func<ILogger?>? getLogger = null,
+        Func<bool>? isUiAvailable = null,
+        Action<Action>? postToUi = null,
+        Action<Exception>? notifyError = null)
+    {
+        return new UnobservedTaskExceptionHandler(
+            getLogger ?? (() => _loggerMock.Object),
+            isUiAvailable ?? (() => true),
+            postToUi ?? _postedActions.Add,
+            notifyError ?? _notifiedExceptions.Add);
+    }
+
+    private void VerifyErrorLogged(Exception expected, string because)
+    {
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.Is<Exception>(e => ReferenceEquals(e, expected)),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Once,
+            because);
+    }
+
+    [Fact]
+    public void Handle_通知はUIスレッドへの非同期ポスト経由でのみ実行され最初の内部例外が渡されること()
+    {
+        var inner1 = new InvalidOperationException("1件目");
+        var inner2 = new InvalidOperationException("2件目");
+        var handler = CreateHandler();
+
+        handler.Handle(new AggregateException(inner1, inner2));
+
+        // ポストしたアクションを実行するまで通知は行われない
+        // （＝呼び出しスレッド上で同期的に通知していないことの表明）
+        _notifiedExceptions.Should().BeEmpty(
+            "通知はポストされたアクションの中でのみ実行されるべき（呼び出しスレッドをブロックしない）");
+        _postedActions.Should().ContainSingle();
+
+        _postedActions[0]();
+
+        _notifiedExceptions.Should().ContainSingle()
+            .Which.Should().BeSameAs(inner1, "従来実装と同じく最初の内部例外を表示対象とする");
+    }
+
+    [Fact]
+    public void Handle_UIが利用できない場合は通知をポストしないこと()
+    {
+        var handler = CreateHandler(isUiAvailable: () => false);
+
+        handler.Handle(new AggregateException(new InvalidOperationException()));
+
+        _postedActions.Should().BeEmpty(
+            "Dispatcher がシャットダウン済みの場合にポストしても実行されず、例外の温床になるだけ");
+    }
+
+    [Fact]
+    public void Handle_集約例外と全ての内部例外をログへ記録すること()
+    {
+        var inner1 = new InvalidOperationException("1件目");
+        var inner2 = new TimeoutException("2件目");
+        var aggregate = new AggregateException(inner1, inner2);
+        var handler = CreateHandler();
+
+        handler.Handle(aggregate);
+
+        VerifyErrorLogged(aggregate, "集約例外そのものを記録しないと未観測例外の発生自体を追跡できない");
+        VerifyErrorLogged(inner1, "内部例外を記録しないと障害の原因を特定できない");
+        VerifyErrorLogged(inner2, "2件目以降の内部例外も等しく記録する");
+    }
+
+    [Fact]
+    public void Handle_通知処理の例外はポストしたアクションの外へ漏れずログへ記録されること()
+    {
+        var notifyException = new InvalidOperationException("トースト表示失敗");
+        var handler = CreateHandler(notifyError: _ => throw notifyException);
+
+        handler.Handle(new AggregateException(new TimeoutException()));
+
+        _postedActions.Should().ContainSingle();
+        var act = () => _postedActions[0]();
+
+        // Dispatcher 上で実行されるアクションから例外が漏れると
+        // DispatcherUnhandledException へ波及し、二次エラーダイアログが出る
+        act.Should().NotThrow();
+        VerifyErrorLogged(notifyException, "通知の失敗も無言で握りつぶさない");
+    }
+
+    [Fact]
+    public void Handle_UIディスパッチの例外はHandleの外へ漏れずログへ記録されること()
+    {
+        var postException = new InvalidOperationException("ディスパッチ失敗");
+        var handler = CreateHandler(postToUi: _ => throw postException);
+
+        var act = () => handler.Handle(new AggregateException(new TimeoutException()));
+
+        // ファイナライザスレッドへ例外が漏れるとプロセスが異常終了する
+        act.Should().NotThrow();
+        VerifyErrorLogged(postException, "ディスパッチの失敗も無言で握りつぶさない");
+    }
+
+    [Fact]
+    public void Handle_UI可用性判定の例外はHandleの外へ漏れずログへ記録されること()
+    {
+        var guardException = new InvalidOperationException("判定失敗");
+        var handler = CreateHandler(isUiAvailable: () => throw guardException);
+
+        var act = () => handler.Handle(new AggregateException(new TimeoutException()));
+
+        act.Should().NotThrow();
+        VerifyErrorLogged(guardException, "ガード判定の失敗も無言で握りつぶさない");
+    }
+
+    [Fact]
+    public void Handle_ロガー取得が失敗しても通知は行われること()
+    {
+        var handler = CreateHandler(getLogger: () => throw new InvalidOperationException("ロガー未初期化"));
+
+        var act = () => handler.Handle(new AggregateException(new TimeoutException()));
+
+        // SetupGlobalExceptionHandlers は DI コンテナ構築前に呼ばれるため、
+        // ロガーが取得できない時期にも発火し得る。ログ経路の障害が通知経路を道連れにしない
+        act.Should().NotThrow();
+        _postedActions.Should().ContainSingle("ログに残せなくてもユーザーへの通知は行うべき");
+    }
+
+    [Fact]
+    public void Handle_例外がnullの場合は通知もポストも行わず例外を漏らさないこと()
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.Handle(null!);
+
+        act.Should().NotThrow();
+        _postedActions.Should().BeEmpty();
+        _notifiedExceptions.Should().BeEmpty();
+    }
+}

--- a/ICCardManager/tests/ICCardManager.Tests/Common/UnobservedTaskExceptionHandlerTests.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/Common/UnobservedTaskExceptionHandlerTests.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using ICCardManager.Common;
-using Microsoft.Extensions.Logging;
-using Moq;
 using Xunit;
 
 namespace ICCardManager.Tests.Common;
@@ -19,42 +17,43 @@ namespace ICCardManager.Tests.Common;
 /// ハンドラから例外が漏れるとプロセスが異常終了する。
 /// </para>
 /// <para>
-/// 本テストは抽出したハンドラ本体の 2 つの性質を固定する:
+/// 本テストは抽出したハンドラ本体の 3 つの性質を固定する:
 /// ①通知は「UI スレッドへの非同期ポスト」経由でのみ実行される（呼び出しスレッドをブロックしない）、
-/// ②ハンドラおよびポストしたアクションから例外が一切漏れない。
-/// <c>App.xaml.cs</c> 側の配線（シャットダウンガード・BeginInvoke・トースト通知）は
-/// <see cref="AppUnobservedTaskExceptionConventionTests"/> が静的検証で固定する。
+/// ②ハンドラおよびポストしたアクションから例外が一切漏れない、
+/// ③通知はクールダウンで間引かれる（エラートーストは自動消去されないため、
+/// 繰り返し発生する障害で無人端末に積み上がるのを防ぐ。ログは間引かない）。
+/// <c>App.xaml.cs</c> 側の配線（シャットダウンガード・BeginInvoke・トースト通知・
+/// DI 非依存のフォールバックログ）は <see cref="AppUnobservedTaskExceptionConventionTests"/>
+/// が静的検証で固定する。
 /// </para>
 /// </remarks>
 public class UnobservedTaskExceptionHandlerTests
 {
-    private readonly Mock<ILogger> _loggerMock = new();
+    private readonly List<(Exception Exception, string Message)> _loggedErrors = new();
     private readonly List<Action> _postedActions = new();
     private readonly List<Exception> _notifiedExceptions = new();
 
+    /// <summary>テストから進められる決定論的な時計（既定はクールダウンの影響を受けない固定時刻）。</summary>
+    private DateTime _utcNow = new(2026, 8, 12, 9, 0, 0, DateTimeKind.Utc);
+
     private UnobservedTaskExceptionHandler CreateHandler(
-        Func<ILogger?>? getLogger = null,
+        Action<Exception, string>? logError = null,
         Func<bool>? isUiAvailable = null,
         Action<Action>? postToUi = null,
         Action<Exception>? notifyError = null)
     {
         return new UnobservedTaskExceptionHandler(
-            getLogger ?? (() => _loggerMock.Object),
+            logError ?? ((exception, message) => _loggedErrors.Add((exception, message))),
             isUiAvailable ?? (() => true),
             postToUi ?? _postedActions.Add,
-            notifyError ?? _notifiedExceptions.Add);
+            notifyError ?? _notifiedExceptions.Add,
+            () => _utcNow);
     }
 
-    private void VerifyErrorLogged(Exception expected, string because)
+    private void AssertErrorLogged(Exception expected, string because)
     {
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => true),
-                It.Is<Exception>(e => ReferenceEquals(e, expected)),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-            Times.Once,
+        _loggedErrors.Should().Contain(
+            entry => ReferenceEquals(entry.Exception, expected),
             because);
     }
 
@@ -100,9 +99,9 @@ public class UnobservedTaskExceptionHandlerTests
 
         handler.Handle(aggregate);
 
-        VerifyErrorLogged(aggregate, "集約例外そのものを記録しないと未観測例外の発生自体を追跡できない");
-        VerifyErrorLogged(inner1, "内部例外を記録しないと障害の原因を特定できない");
-        VerifyErrorLogged(inner2, "2件目以降の内部例外も等しく記録する");
+        AssertErrorLogged(aggregate, "集約例外そのものを記録しないと未観測例外の発生自体を追跡できない");
+        AssertErrorLogged(inner1, "内部例外を記録しないと障害の原因を特定できない");
+        AssertErrorLogged(inner2, "2件目以降の内部例外も等しく記録する");
     }
 
     [Fact]
@@ -119,7 +118,7 @@ public class UnobservedTaskExceptionHandlerTests
         // Dispatcher 上で実行されるアクションから例外が漏れると
         // DispatcherUnhandledException へ波及し、二次エラーダイアログが出る
         act.Should().NotThrow();
-        VerifyErrorLogged(notifyException, "通知の失敗も無言で握りつぶさない");
+        AssertErrorLogged(notifyException, "通知の失敗も無言で握りつぶさない");
     }
 
     [Fact]
@@ -132,7 +131,7 @@ public class UnobservedTaskExceptionHandlerTests
 
         // ファイナライザスレッドへ例外が漏れるとプロセスが異常終了する
         act.Should().NotThrow();
-        VerifyErrorLogged(postException, "ディスパッチの失敗も無言で握りつぶさない");
+        AssertErrorLogged(postException, "ディスパッチの失敗も無言で握りつぶさない");
     }
 
     [Fact]
@@ -144,18 +143,18 @@ public class UnobservedTaskExceptionHandlerTests
         var act = () => handler.Handle(new AggregateException(new TimeoutException()));
 
         act.Should().NotThrow();
-        VerifyErrorLogged(guardException, "ガード判定の失敗も無言で握りつぶさない");
+        AssertErrorLogged(guardException, "ガード判定の失敗も無言で握りつぶさない");
     }
 
     [Fact]
-    public void Handle_ロガー取得が失敗しても通知は行われること()
+    public void Handle_ログ記録が失敗しても通知は行われること()
     {
-        var handler = CreateHandler(getLogger: () => throw new InvalidOperationException("ロガー未初期化"));
+        var handler = CreateHandler(logError: (_, _) => throw new InvalidOperationException("ログ記録失敗"));
 
         var act = () => handler.Handle(new AggregateException(new TimeoutException()));
 
         // SetupGlobalExceptionHandlers は DI コンテナ構築前に呼ばれるため、
-        // ロガーが取得できない時期にも発火し得る。ログ経路の障害が通知経路を道連れにしない
+        // ログ経路が機能しない時期にも発火し得る。ログ経路の障害が通知経路を道連れにしない
         act.Should().NotThrow();
         _postedActions.Should().ContainSingle("ログに残せなくてもユーザーへの通知は行うべき");
     }
@@ -170,5 +169,35 @@ public class UnobservedTaskExceptionHandlerTests
         act.Should().NotThrow();
         _postedActions.Should().BeEmpty();
         _notifiedExceptions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Handle_クールダウン内の連続発火では通知を再ポストせずログは毎回記録すること()
+    {
+        var first = new AggregateException(new TimeoutException("1回目"));
+        var second = new AggregateException(new TimeoutException("2回目"));
+        var handler = CreateHandler();
+
+        handler.Handle(first);
+        _utcNow += UnobservedTaskExceptionHandler.NotificationCooldown - TimeSpan.FromSeconds(1);
+        handler.Handle(second);
+
+        // エラートーストは自動消去されない（クリックで閉じる）ため、繰り返し発生する障害で
+        // 発火のたびに通知すると無人の共用端末にトーストが際限なく積み上がる
+        _postedActions.Should().ContainSingle("クールダウン内の再発火はトーストを積み増さない");
+        AssertErrorLogged(second, "通知を間引いてもログは間引かない（障害調査の痕跡を欠かさない）");
+    }
+
+    [Fact]
+    public void Handle_クールダウン経過後の発火では再び通知をポストすること()
+    {
+        var handler = CreateHandler();
+
+        handler.Handle(new AggregateException(new TimeoutException("1回目")));
+        _utcNow += UnobservedTaskExceptionHandler.NotificationCooldown;
+        handler.Handle(new AggregateException(new TimeoutException("2回目")));
+
+        _postedActions.Should().HaveCount(2,
+            "抑止は恒久ではなくクールダウンに限る（新たな障害の発生をユーザーが知れなくなるため）");
     }
 }

--- a/ICCardManager/tests/ICCardManager.Tests/TestSourceInspection.cs
+++ b/ICCardManager/tests/ICCardManager.Tests/TestSourceInspection.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Text;
+
+namespace ICCardManager.Tests;
+
+/// <summary>
+/// ソーステキストの静的検証（規約テスト）用のヘルパー。
+/// </summary>
+/// <remarks>
+/// <para>
+/// 検査は「コード部分のみ」を対象にするため、<see cref="ToCodeOnly"/> でコメントと
+/// 文字列リテラルの中身を除去してから <see cref="ExtractMethodBody"/> で
+/// メソッド本体を波括弧対応で取り出す。生のソースへ波括弧対応を適用すると、
+/// コメントや文字列の中の <c>}</c> が抽出を黙って短縮させ、禁止トークン検査が
+/// 空振りする（Issue #1742 のコードレビュー指摘）。
+/// </para>
+/// <para>
+/// 同種の波括弧抽出は <c>DataExportImportViewModelImportPathSharingTests</c> /
+/// <c>DialogAutomationPropertiesCoverageTests</c> にも私的コピーが存在する。
+/// 新規の規約テストは本ヘルパーを使い、複製をこれ以上増やさないこと
+/// （既存コピーの集約は別途行う。<see cref="TestPaths"/> と同じ方針）。
+/// </para>
+/// </remarks>
+internal static class TestSourceInspection
+{
+    /// <summary>
+    /// コメント（<c>//</c>・<c>/* */</c>）を除去し、文字列・文字リテラルの中身を
+    /// 空にした「コードのみ」のテキストを返す。リテラルの引用符自体は残す。
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 正規表現ではなく 1 パスの状態機械で処理する。正規表現による除去は
+    /// 文字列リテラル内の <c>//</c> や <c>/*</c> を誤ってコメント扱いし、
+    /// 同一行の後続コードや複数行のコードを巻き添えに消してしまう。
+    /// </para>
+    /// <para>
+    /// 対応する構文: <c>//</c> 行コメント、<c>/* */</c> ブロックコメント、
+    /// <c>"..."</c>（<c>\</c> エスケープ付き）、<c>@"..."</c>（<c>""</c> エスケープ付き）、
+    /// <c>'...'</c>（<c>\</c> エスケープ付き）。補間文字列 <c>$"..."</c> は中身ごと
+    /// 除去されるため、補間式の中のコードは検査できない — 検査対象メソッドでは
+    /// 補間文字列を使わないこと。
+    /// </para>
+    /// </remarks>
+    public static string ToCodeOnly(string source)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        var result = new StringBuilder(source.Length);
+        var i = 0;
+
+        while (i < source.Length)
+        {
+            var c = source[i];
+            var next = i + 1 < source.Length ? source[i + 1] : '\0';
+
+            if (c == '/' && next == '/')
+            {
+                // 行コメント: 改行の手前まで読み飛ばす（改行自体は次の周回で出力される）
+                while (i < source.Length && source[i] != '\n')
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (c == '/' && next == '*')
+            {
+                // ブロックコメント: */ まで読み飛ばし、トークンの結合を防ぐため空白を1つ出力
+                i += 2;
+                while (i + 1 < source.Length && !(source[i] == '*' && source[i + 1] == '/'))
+                {
+                    i++;
+                }
+
+                i = Math.Min(i + 2, source.Length);
+                result.Append(' ');
+                continue;
+            }
+
+            if (c == '@' && next == '"')
+            {
+                // 逐語的文字列: "" が引用符のエスケープ
+                result.Append("@\"");
+                i += 2;
+                while (i < source.Length)
+                {
+                    if (source[i] == '"')
+                    {
+                        if (i + 1 < source.Length && source[i + 1] == '"')
+                        {
+                            i += 2;
+                            continue;
+                        }
+
+                        break;
+                    }
+
+                    i++;
+                }
+
+                result.Append('"');
+                i++;
+                continue;
+            }
+
+            if ((c == '"') || (c == '$' && next == '"'))
+            {
+                // 通常の文字列・補間文字列: \ がエスケープ。中身（補間式の波括弧を含む）は捨てる
+                if (c == '$')
+                {
+                    result.Append('$');
+                    i++;
+                }
+
+                result.Append('"');
+                i++;
+                while (i < source.Length && source[i] != '"')
+                {
+                    if (source[i] == '\\')
+                    {
+                        i++;
+                    }
+
+                    i++;
+                }
+
+                result.Append('"');
+                i++;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                // 文字リテラル: \ がエスケープ
+                result.Append('\'');
+                i++;
+                while (i < source.Length && source[i] != '\'')
+                {
+                    if (source[i] == '\\')
+                    {
+                        i++;
+                    }
+
+                    i++;
+                }
+
+                result.Append('\'');
+                i++;
+                continue;
+            }
+
+            result.Append(c);
+            i++;
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// シグネチャ文字列から始まるメソッドの本体（<c>{ }</c> 含む）を波括弧の対応で取り出す。
+    /// </summary>
+    /// <param name="codeOnlySource">
+    /// <see cref="ToCodeOnly"/> を通したソース。生のソースを渡すとコメント・文字列内の
+    /// 波括弧が対応を狂わせるため、必ずサニタイズ後のテキストを渡すこと。
+    /// </param>
+    /// <param name="signatureMarker">メソッドシグネチャの先頭部分（例: <c>"private void Target"</c>）。</param>
+    /// <exception cref="InvalidOperationException">
+    /// シグネチャが見つからない、または波括弧が閉じないとき。
+    /// </exception>
+    public static string ExtractMethodBody(string codeOnlySource, string signatureMarker)
+    {
+        if (codeOnlySource == null)
+        {
+            throw new ArgumentNullException(nameof(codeOnlySource));
+        }
+
+        var start = codeOnlySource.IndexOf(signatureMarker, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            throw new InvalidOperationException(
+                $"「{signatureMarker}」が見つからない。対象をリネームした場合は呼び出し側の定数も更新すること。");
+        }
+
+        var braceStart = codeOnlySource.IndexOf('{', start);
+        if (braceStart < 0)
+        {
+            throw new InvalidOperationException($"「{signatureMarker}」の本体の開始波括弧が見つからない。");
+        }
+
+        var depth = 0;
+        for (var i = braceStart; i < codeOnlySource.Length; i++)
+        {
+            if (codeOnlySource[i] == '{')
+            {
+                depth++;
+            }
+            else if (codeOnlySource[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return codeOnlySource.Substring(braceStart, i - braceStart + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"「{signatureMarker}」の本体の波括弧が閉じていない。");
+    }
+}


### PR DESCRIPTION
Closes #1742

## 概要

`TaskScheduler.UnobservedTaskException` は Task のファイナライズ時（＝**ファイナライザスレッド**）に発火するが、旧実装の `App.OnUnobservedTaskException` はそこから同期 `Dispatcher.Invoke` で `ErrorDialogHelper.ShowError`（モーダルの `MessageBox.Show`）を開いていた。このためユーザーが [OK] を押すまでファイナライザスレッドがブロックされ、プロセス全体のファイナライザ（SQLite 接続等の後始末）が停止していた。無人の共用端末では「バックグラウンド処理エラー」ダイアログが長時間放置され得る。

## 修正内容

Issue の修正方針（案）どおり、「try/catch で包む＋シャットダウンガード付き非同期ディスパッチ＋非モーダル通知」へ改めた。

- **ハンドラ本体を `Common/UnobservedTaskExceptionHandler` へ抽出**
  - `e.SetObserved()` を**最初に**呼ぶ（以降で何が起きてもプロセスを守る）
  - ログ記録（集約例外＋全内部例外。従来と同等）
  - シャットダウンガード: `Dispatcher.HasShutdownStarted` / `HasShutdownFinished` が立っていれば UI 通知をスキップしログ記録のみ
  - `Dispatcher.BeginInvoke`（非同期）で **トースト通知**（`IToastNotificationService.ShowError`、非モーダル・自動消去なし）
  - いかなる内部エラー（ロガー未初期化・ディスパッチ失敗・通知失敗）も外へ漏らさない — ファイナライザから例外が漏れるとプロセスが異常終了するため
- **ロガー・トーストは発火時に遅延解決**。`SetupGlobalExceptionHandlers` は DI コンテナ構築前（`OnStartup` 冒頭）に呼ばれるため、生成時解決では常に null を掴む
- **トースト文言は簡潔表現とし、例外の詳細はログのみに残す**（`error-messages.md` のトースト例外規定。生の `ex.Message` を UI へ出さない #1614 の方針を踏襲）

## コードレビュー（/code-review high）の反映

ワークフローレビューで 8 件の指摘（CONFIRMED 6・PLAUSIBLE 2）を受け、7 件を修正・1 件を意図明示で対応した。

1. **通知クールダウン（5分）を追加** — エラートーストは自動消去されないため、繰り返し発生する障害（共有モードのヘルスチェック失敗等）で無人端末にトーストが際限なく積み上がる。ログは間引かず毎回記録
2. **DI 非依存のフォールバックログ** — 旧実装は `ErrorDialogHelper` が DI 非依存でファイルログも書いていた。ILogger 未初期化（DI コンテナ構築前・構築失敗時）の発火を無痕跡にしないよう、`ErrorDialogHelper.LogException` へフォールバック
3. **トースト文言を例外種別に応じて組み立て** — 固定文言だと「管理者に連絡」と案内された管理者へ原因が伝わらない。`ExceptionMessageFormatter.ToUserMessage` を使用（トースト本文は `TextWrapping="Wrap"` で折り返し表示を確認済み）
4. **規約テストの迂回経路を封じ** — ①波括弧抽出を「コメント・文字列リテラルの中身を 1 パス状態機械で除去したコードのみ」に対して行う（コメント内 `}` による抽出の黙った短縮、文字列内 `//` の誤処理を排除） ②禁止トークンを正規表現 `\.Invoke\s*\(` で照合（空白挿入・中間変数による迂回を検出）。検査ロジック自体を既知のサンプルで固定
5. **抽出器の共有ヘルパー化** — `TestSourceInspection` を新設（`TestPaths` と同じ「新規はこれを使う」方針。既存 2 クラスの私的コピーの集約は別途）
6. **`?.Handle` の意図明示** — 到達不能ガードだが、ファイナライザスレッドで NullReferenceException を投げるとプロセスが異常終了するため fail-safe として意図的に維持（コメントで明文化）

## テスト設計（二段構え）

`App` は WPF `Application` のため単体テストから駆動できない。`WpfDispatcherService.ObserveTask`（#1725）と同じ判断で分割した。

| テスト | 対象 | 件数 |
|--------|------|------|
| `UnobservedTaskExceptionHandlerTests` | 抽出したハンドラ本体の挙動（デリゲート注入で駆動） | 10件 |
| `AppUnobservedTaskExceptionConventionTests` | `App.xaml.cs` 配線の静的検証（同期 Invoke 禁止・モーダル禁止・ガード必須・SetObserved が先・フォールバックログ必須） | 5件 |

- 「非同期であること」は実行順序で表明する（`Handle` 直後は未通知・ポストしたアクション実行後に通知済み。同期 `Invoke` へ退行すると fail）
- クールダウンは注入した時計（`Func<DateTime>`）で決定論的に検証（間引き中もログは記録されることまで表明）
- TDD（RED→GREEN）: 空スタブに対し 9 件が期待どおり失敗することを確認してから実装

## Issue の指摘のうち対応を限定した点

Issue の検証根拠に記載のとおり、「終了中の発火 → `TaskCanceledException` がファイナライザから漏れてプロセス異常終了」の経路は CLR 側のガードにより成立余地が極めて狭い。本修正はシャットダウンガード＋例外封じ込めでその狭い窓も塞いでいるが、主眼は「ファイナライザスレッドの長時間停止」の解消にある。

## 検証

- [x] 新規 15 件を含む単体テスト全 4,690 件（Debug 構成）合格
- [x] Release / Debug 双方のソリューションビルドで 0 警告・0 エラーを実測
- [x] Release 構成 `--list-tests` 実測 4,637 件 = §1.1a 記載値（CI `test-count-sync` 整合）

## ドキュメント同期

- 05_クラス設計書: §10.1a（`UnobservedTaskExceptionHandler` 新設）、§9.5（「ダイアログが出る」→トーストへの記述追随）
- 07_テスト設計書: §1.1a（単体 4,622→4,637・合計 4,648→4,663 件）、§2 UT-080
- CHANGELOG: Unreleased に追記

## 手動確認のお願い

未観測 Task 例外は GC のタイミング依存で人為的に起こしにくいため、以下は実機での再現確認ではなく**通常操作のスモーク確認**で足ります。

1. アプリを起動し、貸出・返却・履歴表示など通常操作が従来どおり動くこと
2. アプリを閉じたとき、エラーなく終了すること（本修正はアプリ終了中の例外経路にも触れているため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDSy5UdSqtmSYLQaKgpM1E
